### PR TITLE
chore: update MCP server schema to 2025-12-11

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/mcp-local-rag",
   "description": "Easy-to-setup local RAG server with minimal configuration",
   "vendor": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
Update server.json schema reference to the latest supported version for MCP registry publishing.

## Changes
- Update `$schema` from `2025-10-17` to `2025-12-11`

## Notes
- This is a metadata-only change, no runtime impact
- Required for MCP registry publishing with mcp-publisher 1.4.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)