### PR TITLE
docs: clarify tagline to avoid code-search misinterpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Code-aware local RAG for developers using MCP.
-Hybrid search (BM25 + semantic) — fully private, zero setup.
+Local RAG for developers using MCP.
+Hybrid search (BM25 + semantic) for exact technical terms — fully private, zero setup.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Remove "Code-aware" from tagline to prevent confusion with code search tools
- Add "for exact technical terms" to better explain hybrid search benefits

## Reason
The term "Code-aware" could mislead users into thinking this is a code search tool, when it's actually a RAG system that handles technical terminology well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)