### PR TITLE
chore: bump version to 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "main": "dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.5.4",
+  "version": "0.5.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bump version from 0.5.4 to 0.5.5 in package.json and server.json
- Prepare for npm publish and MCP registry update

## Test plan
- [ ] Verify version numbers are correctly updated
- [ ] npm publish after merge
- [ ] Update MCP registry with `mcp-publisher publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)