### PR TITLE
chore: add GitHub stars badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # MCP Local RAG
 
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
 [![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)


### PR DESCRIPTION
## Summary
- Add a dynamic GitHub stars badge (shields.io, `style=social`) to the top of README
- Badge auto-updates as the star count grows — no manual maintenance needed

## Test plan
- [ ] Verify the badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)