### PR TITLE
feat: add ingest_directory tool for recursive directory ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Dependencies
+lancedb/
+models/
 node_modules/
 npm-debug.log*
 yarn-debug.log*
@@ -45,3 +47,4 @@ tmp/
 CLAUDE.md
 .claude/
 docs/
+/models/Xenova/all-MiniLM-L6-v2/*.json

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ You want AI to search your documents—technical specs, research papers, interna
 
 ## Usage
 
-The server provides 6 MCP tools: ingest file, ingest data, search, list, delete, status
-(`ingest_file`, `ingest_data`, `query_documents`, `list_files`, `delete_file`, `status`).
+The server provides 7 MCP tools: ingest file, ingest directory, ingest data, search, list, delete, status
+(`ingest_file`, `ingest_directory`, `ingest_data`, `query_documents`, `list_files`, `delete_file`, `status`).
 
 ### Ingesting Documents
 
@@ -101,6 +101,14 @@ The server provides 6 MCP tools: ingest file, ingest data, search, list, delete,
 Supports PDF, DOCX, TXT, and Markdown. The server extracts text, splits it into chunks, generates embeddings locally, and stores everything in a local vector database.
 
 Re-ingesting the same file replaces the old version automatically.
+
+### Ingesting a Directory
+
+```
+"Ingest all documents from /Users/me/docs/project"
+```
+
+Recursively scans the directory for supported files (PDF, DOCX, TXT, MD) and ingests them all. Returns per-file results with success/failure counts. Use `recursive: false` to scan only the top-level directory.
 
 ### Ingesting HTML Content
 

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -10,6 +10,7 @@ description: Provides score interpretation (< 0.3 good, > 0.5 skip), query optim
 | Tool | Use When |
 |------|----------|
 | `ingest_file` | Local files (PDF, DOCX, TXT, MD) |
+| `ingest_directory` | Recursively ingest all files in a directory |
 | `ingest_data` | Raw content (HTML, text) with source URL |
 | `query_documents` | Semantic + keyword hybrid search |
 | `delete_file` / `list_files` / `status` | Management |
@@ -76,6 +77,13 @@ When to include vs skip—based on answer quality, not just score.
 ```
 ingest_file({ filePath: "/absolute/path/to/document.pdf" })
 ```
+
+### ingest_directory
+```
+ingest_directory({ directoryPath: "/absolute/path/to/docs" })
+ingest_directory({ directoryPath: "/absolute/path/to/docs", recursive: false })
+```
+Recursively scans for PDF, DOCX, TXT, MD files. Set `recursive: false` to skip subdirectories. Returns per-file results with success/failure counts.
 
 ### ingest_data
 ```


### PR DESCRIPTION
## Summary

Adds a new \ingest_directory\ MCP tool that allows users to recursively ingest all supported documents from a directory in a single operation.

## Changes

- **New \ingest_directory\ tool** — recursively scans a directory for supported file types (PDF, DOCX, TXT, MD) and ingests them into the vector database
- **Parameters**:
  - \directoryPath\ (required) — absolute path to the directory
  - \ecursive\ (optional, default: \	rue\) — whether to recurse into subdirectories
- **Returns** per-file results with success/failure counts, chunk counts, and timestamps
- **Validation**: absolute path check, directory readability, non-empty file list
- **Error handling**: graceful per-file error collection (one failing file doesn't stop the rest)

## Updated files

| File | Changes |
|------|---------|
| \src/server/index.ts\ | New tool implementation: interfaces, schema registration, handler, file collector |
| \README.md\ | Added documentation for the new tool |
| \skills/mcp-local-rag/SKILL.md\ | Added tool reference and usage examples |
| \.gitignore\ | Added \lancedb/\ and \models/\ directories |

## Tool count

The server now provides **7 MCP tools** (previously 6): \ingest_file\, \ingest_directory\, \ingest_data\, \query_documents\, \list_files\, \delete_file\, \status\.