### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to MCP Local RAG
+
+Contributions welcome! This guide covers what you need to get started.
+
+## Prerequisites
+
+- Node.js >= 20
+- [pnpm](https://pnpm.io/)
+
+## Setup
+
+```bash
+git clone https://github.com/shinpr/mcp-local-rag.git
+cd mcp-local-rag
+pnpm install
+```
+
+The embedding model (~90MB) downloads on first test/run.
+
+## Quality Checks
+
+All PRs must pass the full quality check, which mirrors CI:
+
+```bash
+pnpm run check:all
+```
+
+This runs the following in order:
+
+| Step | Command | What it checks |
+|------|---------|----------------|
+| Biome check | `pnpm run check` | Lint + format combined |
+| Lint | `pnpm run lint` | Code quality rules |
+| Format | `pnpm run format:check` | Code formatting |
+| Unused exports | `pnpm run check:unused` | No dead exports |
+| Circular deps | `pnpm run check:deps` | No circular dependencies |
+| Build | `pnpm run build` | TypeScript compilation |
+| Test | `pnpm run test` | All tests pass |
+
+Fix lint/format issues automatically:
+
+```bash
+pnpm run check:fix
+```
+
+## PR Requirements
+
+Before submitting a pull request:
+
+1. **Add tests** for new features and bug fixes
+2. **Run `pnpm run check:all`** and ensure everything passes
+3. **Update documentation** if behavior changes
+4. **Keep commits focused** — one logical change per PR
+
+## What We Look For
+
+This project's development standards — testing strategy, error handling, code organization, etc. — are documented in [claude-code-workflows/skills](https://github.com/shinpr/claude-code-workflows/tree/main/skills).
+
+We share this upfront so you know what to expect in review, not after. You don't need to memorize it, but if review feedback feels unexpected, that's where it comes from.
+
+## Project Structure
+
+```
+src/
+  index.ts        # Entry point
+  server/         # MCP tool handlers
+  parser/         # Document parsing (PDF, DOCX, TXT, Markdown, HTML)
+  chunker/        # Semantic text chunking
+  embedder/       # Transformers.js embeddings
+  vectordb/       # LanceDB operations
+  __tests__/      # Test suites
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -417,12 +417,7 @@ src/
 
 ## Contributing
 
-Contributions welcome. Before submitting a PR:
-
-1. Run tests: `pnpm test`
-2. Check quality: `pnpm run check:all`
-3. Add tests for new features
-4. Update docs if behavior changes
+Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with prerequisites, setup, quality checks, PR requirements, review standards reference, and project structure
- Simplify README contributing section to link to `CONTRIBUTING.md` instead of duplicating content

## Context

Project quality standards exist in claude-code-workflows skills but contributors had no pointer to them. This guide makes review criteria transparent upfront — contributors know what to expect before submitting, not after.

## Test plan

- [ ] CONTRIBUTING.md renders correctly on GitHub
- [ ] Links resolve (`claude-code-workflows/skills`, `CONTRIBUTING.md` from README)
- [ ] `pnpm run check:all` passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)