### PR TITLE
feat: async ingestion with progress monitoring via list_files

### DIFF
--- a/src/__tests__/e2e/html-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/html-workflow.e2e.test.ts
@@ -105,7 +105,8 @@ describe('HTML Workflow E2E', () => {
       })
 
       const ingestParsed = JSON.parse(ingestResult.content[0].text)
-      expect(ingestParsed.chunkCount).toBeGreaterThan(0)
+      expect(ingestParsed.status).toBe('started')
+      await server.waitForIngestion(ingestParsed.filePath)
 
       // Act: Search for content
       const queryResult = await server.handleQueryDocuments({
@@ -144,13 +145,14 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const mlIngestResult = await server.handleIngestData({
         content: html,
         metadata: {
           source: 'https://example.com/ml-fundamentals',
           format: 'html',
         },
       })
+      await server.waitForIngestion(JSON.parse(mlIngestResult.content[0].text).filePath)
 
       // Search for navigation-specific terms
       const navQuery = await server.handleQueryDocuments({
@@ -212,13 +214,14 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const tsIngestResult = await server.handleIngestData({
         content: typescriptHtml,
         metadata: {
           source: 'https://docs.example.com/typescript-best-practices',
           format: 'html',
         },
       })
+      await server.waitForIngestion(JSON.parse(tsIngestResult.content[0].text).filePath)
 
       // Ingest second page about Python
       const pythonHtml = `
@@ -234,13 +237,14 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const pyIngestResult = await server.handleIngestData({
         content: pythonHtml,
         metadata: {
           source: 'https://docs.example.com/python-data-science',
           format: 'html',
         },
       })
+      await server.waitForIngestion(JSON.parse(pyIngestResult.content[0].text).filePath)
 
       // Search for TypeScript content
       const tsQuery = await server.handleQueryDocuments({
@@ -284,10 +288,11 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const initialIngestResult = await server.handleIngestData({
         content: initialHtml,
         metadata: { source, format: 'html' },
       })
+      await server.waitForIngestion(JSON.parse(initialIngestResult.content[0].text).filePath)
 
       // Verify initial content is searchable
       const initialQuery = await server.handleQueryDocuments({
@@ -311,10 +316,11 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const updatedIngestResult = await server.handleIngestData({
         content: updatedHtml,
         metadata: { source, format: 'html' },
       })
+      await server.waitForIngestion(JSON.parse(updatedIngestResult.content[0].text).filePath)
 
       // Verify updated content is searchable
       const updatedQuery = await server.handleQueryDocuments({
@@ -358,13 +364,14 @@ describe('HTML Workflow E2E', () => {
         </html>
       `
 
-      await server.handleIngestData({
+      const jaIngestResult = await server.handleIngestData({
         content: japaneseHtml,
         metadata: {
           source: 'https://example.jp/vector-db-intro',
           format: 'html',
         },
       })
+      await server.waitForIngestion(JSON.parse(jaIngestResult.content[0].text).filePath)
 
       const query = await server.handleQueryDocuments({
         query: 'ベクトルデータベース 類似度検索',

--- a/src/__tests__/e2e/rag-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/rag-workflow.e2e.test.ts
@@ -48,12 +48,15 @@ describe('RAG MCP Server E2E Test', () => {
             'TypeScript is a strongly typed programming language.'
         )
 
+        // 2b. Wait for background ingestion to complete
         const ingestResult = await ragServer.handleIngestFile({ filePath: txtFile })
         expect(ingestResult.content[0].text).toBeDefined()
 
         const ingestData = JSON.parse(ingestResult.content[0].text)
-        expect(ingestData.chunkCount).toBeGreaterThan(0)
+        expect(ingestData.status).toBe('started')
         expect(ingestData.filePath).toBe(txtFile)
+
+        await ragServer.waitForIngestion(txtFile)
 
         // 3. Search with natural language query
         const queryResult = await ragServer.handleQueryDocuments({
@@ -114,7 +117,8 @@ describe('RAG MCP Server E2E Test', () => {
         expect(ingestResult.content[0].text).toBeDefined()
 
         const ingestData = JSON.parse(ingestResult.content[0].text)
-        expect(ingestData.chunkCount).toBeGreaterThan(0)
+        expect(ingestData.status).toBe('started')
+        await ragServer.waitForIngestion(docxFile)
 
         // 3. Search with natural language query
         const queryResult = await ragServer.handleQueryDocuments({
@@ -161,6 +165,7 @@ describe('RAG MCP Server E2E Test', () => {
           'TypeScript is a strongly typed programming language that builds on JavaScript. It provides better tooling at any scale.'
         )
         await ragServer.handleIngestFile({ filePath: v1File })
+        await ragServer.waitForIngestion(v1File)
 
         // 3. Verify search with old content
         const queryResult1 = await ragServer.handleQueryDocuments({
@@ -178,6 +183,7 @@ describe('RAG MCP Server E2E Test', () => {
 
         // 5. Re-ingest file
         await ragServer.handleIngestFile({ filePath: v1File })
+        await ragServer.waitForIngestion(v1File)
 
         // 6. Verify search with new content
         const queryResult2 = await ragServer.handleQueryDocuments({

--- a/src/__tests__/helpers/type-guards.ts
+++ b/src/__tests__/helpers/type-guards.ts
@@ -1,0 +1,30 @@
+// Type guard helpers for test assertions on FileEntry and SourceEntry unions
+
+import type { FileEntry, SourceEntry } from '../../server/types.js'
+
+/** Narrows a FileEntry to one with `failed: true` */
+export function isFailedFileEntry(
+  entry: FileEntry
+): entry is { filePath: string; ingested: false; failed: true; error: string } {
+  return 'failed' in entry && (entry as { failed?: boolean }).failed === true
+}
+
+/** Narrows a FileEntry to one with `ingesting: true` (not yet ingested) */
+export function isIngestingFileEntry(
+  entry: FileEntry
+): entry is { filePath: string; ingested: false; ingesting: true; startedAt: string } {
+  return (
+    'ingesting' in entry &&
+    (entry as { ingesting?: boolean }).ingesting === true &&
+    (entry as { ingested: boolean }).ingested === false
+  )
+}
+
+/** Narrows a SourceEntry to one with `failed: true` and no existing DB data */
+export function isFailedSourceEntry(
+  entry: SourceEntry
+): entry is { source: string; failed: true; error: string } {
+  return (
+    'failed' in entry && (entry as { failed?: boolean }).failed === true && !('chunkCount' in entry)
+  )
+}

--- a/src/__tests__/security/security.test.ts
+++ b/src/__tests__/security/security.test.ts
@@ -102,9 +102,10 @@ This approach provides accurate search results for natural language queries.`
       const monitor = createNetworkMonitor()
 
       try {
-        // Ingest file
+        // Ingest file and wait for background ingestion to complete
         const sampleFile = resolve(fixturesDir, 'sample.txt')
         await server.handleIngestFile({ filePath: sampleFile })
+        await server.waitForIngestion(sampleFile)
 
         // Execute search
         await server.handleQueryDocuments({ query: 'TypeScript', limit: 5 })
@@ -143,6 +144,7 @@ This approach provides accurate search results for natural language queries.`
         // Execute LanceDB operations
         const sampleFile = resolve(fixturesDir, 'sample.txt')
         await server.handleIngestFile({ filePath: sampleFile })
+        await server.waitForIngestion(sampleFile)
         await server.handleQueryDocuments({ query: 'TypeScript', limit: 5 })
 
         // Verify no external communication occurred
@@ -275,9 +277,10 @@ The chunker requires sufficient text length to generate meaningful chunks.`
       }
 
       try {
-        // Ingest sample file
+        // Ingest sample file and wait for background ingestion to complete
         const sampleFile = resolve(fixturesDir, 'sample.txt')
         await server.handleIngestFile({ filePath: sampleFile })
+        await server.waitForIngestion(sampleFile)
 
         // Search with confidential query
         const secretQuery = 'secret query with confidential information PASSWORD123'
@@ -334,10 +337,11 @@ The chunker requires sufficient text length to generate meaningful chunks.`
       const originalEnv = process.env['NODE_ENV']
       process.env['NODE_ENV'] = undefined
 
-      const nonExistentFile = resolve('./tmp/nonexistent.txt')
+      // Use a path outside BASE_DIR so validateFilePath throws synchronously
+      const outsidePath = '/nonexistent/outside-base-dir-file.txt'
 
       try {
-        await server.handleIngestFile({ filePath: nonExistentFile })
+        await server.handleIngestFile({ filePath: outsidePath })
         expect.fail('Expected error to be thrown')
       } catch (error) {
         const errorMessage = (error as Error).message
@@ -357,10 +361,11 @@ The chunker requires sufficient text length to generate meaningful chunks.`
       const originalEnv = process.env['NODE_ENV']
       process.env['NODE_ENV'] = 'development'
 
-      const nonExistentFile = resolve('./tmp/nonexistent.txt')
+      // Use a path outside BASE_DIR so validateFilePath throws synchronously
+      const outsidePath = '/nonexistent/outside-base-dir-file.txt'
 
       try {
-        await server.handleIngestFile({ filePath: nonExistentFile })
+        await server.handleIngestFile({ filePath: outsidePath })
         expect.fail('Expected error to be thrown')
       } catch (error) {
         const errorMessage = (error as Error).message

--- a/src/__tests__/server/async-ingest.test.ts
+++ b/src/__tests__/server/async-ingest.test.ts
@@ -1,0 +1,382 @@
+// Async Ingestion Test
+// Test Type: Integration Test
+// Tests that ingest_file and ingest_data return immediately and that progress
+// can be monitored via list_files.
+
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RAGServer } from '../../server/index.js'
+import type { FileEntry, SourceEntry } from '../../server/types.js'
+import { isFailedFileEntry } from '../helpers/type-guards.js'
+
+// ============================================
+// Test Configuration
+// ============================================
+
+const testDbPath = resolve('./tmp/test-async-ingest-db')
+const testBaseDir = resolve('./tmp/test-async-ingest-data')
+const testConfig = {
+  dbPath: testDbPath,
+  modelName: 'Xenova/all-MiniLM-L6-v2',
+  cacheDir: './tmp/test-model-cache',
+  baseDir: testBaseDir,
+  maxFileSize: 10 * 1024 * 1024,
+}
+
+const SUFFICIENT_TEXT =
+  'This is test content for async ingestion. ' +
+  'It contains enough text to produce at least one chunk. ' +
+  'The semantic chunker requires substantial input to process properly.'
+
+// ============================================
+// Tests
+// ============================================
+
+describe('Async Ingestion', () => {
+  let server: RAGServer
+
+  beforeAll(async () => {
+    await mkdir(testDbPath, { recursive: true })
+    await mkdir(testBaseDir, { recursive: true })
+    await mkdir(testConfig.cacheDir, { recursive: true })
+    server = new RAGServer(testConfig)
+    await server.initialize()
+  }, 120000) // 2 minutes for model download
+
+  afterAll(async () => {
+    await rm(testDbPath, { recursive: true, force: true })
+    await rm(testBaseDir, { recursive: true, force: true })
+  })
+
+  // --------------------------------------------
+  // ingest_file — immediate response
+  // --------------------------------------------
+  describe('ingest_file immediate response', () => {
+    it('returns status "started" without waiting for ingestion to complete', async () => {
+      const filePath = resolve(testBaseDir, 'async-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      const result = await server.handleIngestFile({ filePath })
+      const parsed = JSON.parse(result.content[0].text)
+
+      expect(parsed.status).toBe('started')
+      expect(parsed.filePath).toBe(filePath)
+      expect(parsed.startedAt).toBeDefined()
+      expect(parsed.message).toContain('list_files')
+
+      // Wait for background job to finish before the next test
+      await server.waitForIngestion(filePath)
+    })
+
+    it('returns status "in_progress" when the same file is submitted again while already ingesting', async () => {
+      const filePath = resolve(testBaseDir, 'in-progress-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      // First call — starts background job
+      await server.handleIngestFile({ filePath })
+
+      // Second call — job still running
+      const result = await server.handleIngestFile({ filePath })
+      const parsed = JSON.parse(result.content[0].text)
+
+      expect(parsed.status).toBe('in_progress')
+      expect(parsed.filePath).toBe(filePath)
+      expect(parsed.startedAt).toBeDefined()
+
+      await server.waitForIngestion(filePath)
+    })
+  })
+
+  // --------------------------------------------
+  // list_files — progress monitoring
+  // --------------------------------------------
+  describe('list_files progress monitoring', () => {
+    it('shows ingesting: true while a background job is active', async () => {
+      const filePath = resolve(testBaseDir, 'progress-monitor-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      // Start background ingestion
+      await server.handleIngestFile({ filePath })
+
+      // list_files immediately after starting should show ingesting: true
+      const listResult = await server.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: FileEntry) => f.filePath === filePath)
+
+      expect(entry).toBeDefined()
+      expect(entry.ingesting).toBe(true)
+      expect(entry.startedAt).toBeDefined()
+
+      await server.waitForIngestion(filePath)
+    })
+
+    it('shows ingested: true with chunkCount after ingestion completes', async () => {
+      const filePath = resolve(testBaseDir, 'completion-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      const listResult = await server.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: FileEntry) => f.filePath === filePath)
+
+      expect(entry).toBeDefined()
+      expect(entry.ingested).toBe(true)
+      expect(entry.chunkCount).toBeGreaterThan(0)
+      expect(entry.timestamp).toBeDefined()
+      // No longer ingesting
+      expect((entry as { ingesting?: unknown }).ingesting).toBeUndefined()
+    })
+
+    it('shows failed: true with error message after a failed ingestion', async () => {
+      // An empty file produces zero chunks → ingestion fails
+      const filePath = resolve(testBaseDir, 'empty-fail-test.txt')
+      await writeFile(filePath, '') // empty
+
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      const listResult = await server.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: FileEntry) => f.filePath === filePath)
+
+      expect(entry).toBeDefined()
+      expect(entry.ingested).toBe(false)
+      expect(isFailedFileEntry(entry)).toBe(true)
+      if (isFailedFileEntry(entry)) {
+        expect(entry.error).toBeDefined()
+      }
+    })
+
+    it('clears failed state and starts fresh when ingesting a previously-failed file again', async () => {
+      const filePath = resolve(testBaseDir, 'retry-test.txt')
+
+      // First attempt — empty file, will fail
+      await writeFile(filePath, '')
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      // Write proper content and retry
+      await writeFile(filePath, SUFFICIENT_TEXT)
+      const retryResult = await server.handleIngestFile({ filePath })
+      const parsed = JSON.parse(retryResult.content[0].text)
+      expect(parsed.status).toBe('started')
+
+      await server.waitForIngestion(filePath)
+
+      const listResult = await server.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: FileEntry) => f.filePath === filePath)
+
+      expect(entry.ingested).toBe(true)
+      expect(entry.chunkCount).toBeGreaterThan(0)
+    })
+  })
+
+  // --------------------------------------------
+  // ingest_data — immediate response
+  // --------------------------------------------
+  describe('ingest_data immediate response', () => {
+    it('returns status "started" without waiting for ingestion to complete', async () => {
+      const source = 'test://async-ingest-data-test'
+
+      const result = await server.handleIngestData({
+        content: SUFFICIENT_TEXT,
+        metadata: { source, format: 'text' },
+      })
+      const parsed = JSON.parse(result.content[0].text)
+
+      expect(parsed.status).toBe('started')
+      expect(parsed.filePath).toContain('raw-data')
+      expect(parsed.startedAt).toBeDefined()
+      expect(parsed.message).toContain(source)
+
+      await server.waitForIngestion(parsed.filePath)
+    })
+
+    it('returns status "in_progress" when the same source is submitted again while ingesting', async () => {
+      const source = 'test://async-ingest-data-in-progress'
+
+      const first = await server.handleIngestData({
+        content: SUFFICIENT_TEXT,
+        metadata: { source, format: 'text' },
+      })
+      const firstParsed = JSON.parse(first.content[0].text)
+
+      // Second call before background job completes
+      const second = await server.handleIngestData({
+        content: SUFFICIENT_TEXT,
+        metadata: { source, format: 'text' },
+      })
+      const secondParsed = JSON.parse(second.content[0].text)
+
+      expect(secondParsed.status).toBe('in_progress')
+      expect(secondParsed.startedAt).toBe(firstParsed.startedAt)
+
+      await server.waitForIngestion(firstParsed.filePath)
+    })
+
+    it('appears in list_files sources after ingestion completes', async () => {
+      const source = 'https://example.com/async-ingest-list-test'
+
+      const startResult = await server.handleIngestData({
+        content: SUFFICIENT_TEXT,
+        metadata: { source, format: 'text' },
+      })
+      const { filePath } = JSON.parse(startResult.content[0].text)
+
+      await server.waitForIngestion(filePath)
+
+      const listResult = await server.handleListFiles()
+      const { sources } = JSON.parse(listResult.content[0].text)
+      const entry = sources.find((s: SourceEntry) => 'source' in s && s.source === source)
+
+      expect(entry).toBeDefined()
+      expect((entry as { chunkCount?: number }).chunkCount).toBeGreaterThan(0)
+    })
+
+    it('shows source with ingesting: true in list_files while background job is active', async () => {
+      const source = 'test://async-source-progress'
+
+      const startResult = await server.handleIngestData({
+        content: SUFFICIENT_TEXT,
+        metadata: { source, format: 'text' },
+      })
+      const { filePath } = JSON.parse(startResult.content[0].text)
+
+      // Check list_files before job completes
+      const listResult = await server.handleListFiles()
+      const { sources } = JSON.parse(listResult.content[0].text)
+      const entry = sources.find(
+        (s: SourceEntry) => 'source' in s && (s as { source: string }).source === source
+      )
+
+      expect(entry).toBeDefined()
+      expect((entry as { ingesting?: boolean }).ingesting).toBe(true)
+
+      await server.waitForIngestion(filePath)
+    })
+  })
+
+  // --------------------------------------------
+  // delete_file — guard against active ingestion
+  // --------------------------------------------
+  describe('delete_file during active ingestion', () => {
+    it('rejects deletion while ingestion is in progress', async () => {
+      const filePath = resolve(testBaseDir, 'delete-guard-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      // Start background ingestion
+      await server.handleIngestFile({ filePath })
+
+      // Attempt to delete while still ingesting — should throw
+      await expect(server.handleDeleteFile({ filePath })).rejects.toThrow(/in progress/)
+
+      await server.waitForIngestion(filePath)
+    })
+
+    it('allows deletion after ingestion completes', async () => {
+      const filePath = resolve(testBaseDir, 'delete-after-ingest-test.txt')
+      await writeFile(filePath, SUFFICIENT_TEXT)
+
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      // Deletion should succeed now
+      const deleteResult = await server.handleDeleteFile({ filePath })
+      const parsed = JSON.parse(deleteResult.content[0].text)
+      expect(parsed.deleted).toBe(true)
+    })
+
+    it('clears failed job state on deletion', async () => {
+      const filePath = resolve(testBaseDir, 'delete-failed-job-test.txt')
+
+      // Create an empty file so ingestion fails (0 chunks)
+      await writeFile(filePath, '')
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      // Verify it shows as failed
+      const listBefore = await server.handleListFiles()
+      const filesBefore = JSON.parse(listBefore.content[0].text).files
+      const entryBefore = filesBefore.find((f: FileEntry) => f.filePath === filePath)
+      expect(isFailedFileEntry(entryBefore)).toBe(true)
+
+      // Delete should succeed and clear the failed job
+      await server.handleDeleteFile({ filePath })
+
+      // After deletion, the file should show as not ingested (no failed state)
+      const listAfter = await server.handleListFiles()
+      const filesAfter = JSON.parse(listAfter.content[0].text).files
+      const entryAfter = filesAfter.find((f: FileEntry) => f.filePath === filePath)
+      expect(entryAfter).toBeDefined()
+      expect(entryAfter.ingested).toBe(false)
+      expect(isFailedFileEntry(entryAfter)).toBe(false)
+    })
+  })
+
+  // --------------------------------------------
+  // Re-ingestion failure visibility
+  // --------------------------------------------
+  describe('re-ingestion failure visibility', () => {
+    it('shows failed: true with existing data preserved when re-ingestion fails', async () => {
+      const filePath = resolve(testBaseDir, 'reingest-fail-test.txt')
+
+      // First ingestion — succeeds
+      await writeFile(filePath, SUFFICIENT_TEXT)
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      const listBefore = await server.handleListFiles()
+      const filesBefore = JSON.parse(listBefore.content[0].text).files
+      const entryBefore = filesBefore.find((f: FileEntry) => f.filePath === filePath)
+      expect(entryBefore.ingested).toBe(true)
+      const originalChunkCount = entryBefore.chunkCount
+
+      // Re-ingest with empty content — background job will fail (0 chunks)
+      await writeFile(filePath, '')
+      await server.handleIngestFile({ filePath })
+      await server.waitForIngestion(filePath)
+
+      // list_files should show ingested: true (data preserved) + failed: true
+      const listAfter = await server.handleListFiles()
+      const filesAfter = JSON.parse(listAfter.content[0].text).files
+      const entryAfter = filesAfter.find((f: FileEntry) => f.filePath === filePath)
+      expect(entryAfter).toBeDefined()
+      expect(entryAfter.ingested).toBe(true)
+      expect(entryAfter.chunkCount).toBe(originalChunkCount)
+      expect((entryAfter as { failed?: boolean }).failed).toBe(true)
+      expect((entryAfter as { error?: string }).error).toContain('No chunks')
+    })
+  })
+
+  // --------------------------------------------
+  // Failed ingest_data visibility in sources
+  // --------------------------------------------
+  describe('failed ingest_data visibility in sources', () => {
+    it('shows failed source entry in list_files when ingest_data content produces 0 chunks', async () => {
+      // ingest_data with content too short to chunk — the raw-data file gets written,
+      // but the background ingestion fails because no chunks are produced.
+      // Use a very short string that passes HTML/readability but fails chunking.
+      const source = 'test://failed-source-visibility'
+      const result = await server.handleIngestData({
+        content: 'x', // too short for chunking
+        metadata: { source, format: 'text' },
+      })
+      const { filePath } = JSON.parse(result.content[0].text)
+      await server.waitForIngestion(filePath)
+
+      const listResult = await server.handleListFiles()
+      const { sources } = JSON.parse(listResult.content[0].text)
+      const entry = sources.find(
+        (s: SourceEntry) => 'source' in s && (s as { source: string }).source === source
+      )
+
+      expect(entry).toBeDefined()
+      expect((entry as { failed?: boolean }).failed).toBe(true)
+      expect((entry as { error?: string }).error).toBeDefined()
+    })
+  })
+})

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -57,9 +57,16 @@ describe('ingest_data Tool', () => {
       })
 
       const parsed = JSON.parse(result.content[0].text)
-      expect(parsed.chunkCount).toBeGreaterThan(0)
+      // Ingestion starts in the background — response is 'started'
+      expect(parsed.status).toBe('started')
       expect(parsed.filePath).toContain('raw-data')
       expect(parsed.filePath).toMatch(/\.md$/) // All formats use .md extension
+
+      // Wait for background ingestion and verify via list_files
+      await server.waitForIngestion(parsed.filePath)
+      const list = JSON.parse((await server.handleListFiles()).content[0].text)
+      const entry = list.sources.find((s: { source?: string }) => s.source === source)
+      expect(entry?.chunkCount).toBeGreaterThan(0)
     })
 
     it('saves raw text to raw-data directory', async () => {
@@ -77,9 +84,12 @@ describe('ingest_data Tool', () => {
         },
       })
 
+      // Raw-data file is written synchronously before background ingestion starts
       const parsed = JSON.parse(result.content[0].text)
       const savedContent = await readFile(parsed.filePath, 'utf-8')
       expect(savedContent).toBe(content)
+
+      await server.waitForIngestion(parsed.filePath)
     })
   })
 
@@ -108,8 +118,13 @@ This is markdown content with **bold** and _italic_ text.
       })
 
       const parsed = JSON.parse(result.content[0].text)
-      expect(parsed.chunkCount).toBeGreaterThan(0)
+      expect(parsed.status).toBe('started')
       expect(parsed.filePath).toMatch(/\.md$/)
+
+      await server.waitForIngestion(parsed.filePath)
+      const list = JSON.parse((await server.handleListFiles()).content[0].text)
+      const entry = list.sources.find((s: { source?: string }) => s.source === source)
+      expect(entry?.chunkCount).toBeGreaterThan(0)
     })
   })
 
@@ -140,9 +155,14 @@ This is markdown content with **bold** and _italic_ text.
       })
 
       const parsed = JSON.parse(result.content[0].text)
-      expect(parsed.chunkCount).toBeGreaterThan(0)
+      expect(parsed.status).toBe('started')
       // HTML is converted to markdown, so saved as .md
       expect(parsed.filePath).toMatch(/\.md$/)
+
+      await server.waitForIngestion(parsed.filePath)
+      const list = JSON.parse((await server.handleListFiles()).content[0].text)
+      const entry = list.sources.find((s: { source?: string }) => s.source === source)
+      expect(entry?.chunkCount).toBeGreaterThan(0)
     })
 
     it('extracts main content from HTML and removes noise', async () => {
@@ -169,18 +189,22 @@ This is markdown content with **bold** and _italic_ text.
         },
       })
 
+      // Raw-data file is written synchronously — content can be checked immediately
       const parsed = JSON.parse(result.content[0].text)
       const savedContent = await readFile(parsed.filePath, 'utf-8')
 
       // Main content should be present
       expect(savedContent).toContain('Main Article Title')
       expect(savedContent).toContain('main content that should be extracted')
+
+      await server.waitForIngestion(parsed.filePath)
     })
 
     it('throws error for HTML with no extractable content', async () => {
       const html = '<html><body></body></html>'
       const source = 'https://example.com/empty-html'
 
+      // HTML parsing is synchronous — error surfaces immediately
       await expect(
         server.handleIngestData({
           content: html,
@@ -209,6 +233,8 @@ This is markdown content with **bold** and _italic_ text.
         content,
         metadata: { source: source1, format: 'text' },
       })
+      // source2 normalizes to the same path as source1; if source1's job is still
+      // running the response will be 'in_progress' — both responses include filePath
       const result2 = await server.handleIngestData({
         content:
           'Updated content for URL normalization. ' +
@@ -222,6 +248,8 @@ This is markdown content with **bold** and _italic_ text.
 
       // Same normalized source should result in same file path
       expect(parsed1.filePath).toBe(parsed2.filePath)
+
+      await server.waitForIngestion(parsed1.filePath)
     })
   })
 
@@ -240,11 +268,13 @@ This is markdown content with **bold** and _italic_ text.
         'This new content replaces the original content. ' +
         'Re-ingestion functionality allows content updates.'
 
-      // Initial ingestion
-      await server.handleIngestData({
+      // Initial ingestion — must complete before re-ingesting the same path
+      const initResult = await server.handleIngestData({
         content: originalContent,
         metadata: { source, format: 'text' },
       })
+      const initParsed = JSON.parse(initResult.content[0].text)
+      await server.waitForIngestion(initParsed.filePath)
 
       // Re-ingestion with updated content
       const result = await server.handleIngestData({
@@ -252,11 +282,14 @@ This is markdown content with **bold** and _italic_ text.
         metadata: { source, format: 'text' },
       })
 
+      // Raw-data file is overwritten synchronously
       const parsed = JSON.parse(result.content[0].text)
       const savedContent = await readFile(parsed.filePath, 'utf-8')
 
       expect(savedContent).toBe(updatedContent)
       expect(savedContent).not.toContain('Original content for re-ingestion')
+
+      await server.waitForIngestion(parsed.filePath)
     })
   })
 
@@ -272,10 +305,14 @@ This is markdown content with **bold** and _italic_ text.
         'It needs to be substantial enough to create at least one chunk. ' +
         'The semantic chunker requires sufficient content to process properly.'
 
-      await server.handleIngestData({
+      const ingestResult = await server.handleIngestData({
         content,
         metadata: { source, format: 'text' },
       })
+      const { filePath } = JSON.parse(ingestResult.content[0].text)
+
+      // Wait for ingestion to complete so chunkCount is available
+      await server.waitForIngestion(filePath)
 
       const listResult = await server.handleListFiles()
       const files = JSON.parse(listResult.content[0].text)
@@ -317,9 +354,12 @@ This is markdown content with **bold** and _italic_ text.
       const parsed = JSON.parse(ingestResult.content[0].text)
       const filePath = parsed.filePath
 
-      // Verify file exists
+      // Verify file exists (raw-data file is written synchronously)
       const { stat } = await import('node:fs/promises')
       await expect(stat(filePath)).resolves.toBeDefined()
+
+      // Wait for background ingestion to finish before deleting
+      await server.waitForIngestion(filePath)
 
       // Delete via handleDeleteFile
       await server.handleDeleteFile({ filePath })
@@ -342,6 +382,9 @@ This is markdown content with **bold** and _italic_ text.
       const parsed = JSON.parse(ingestResult.content[0].text)
       const filePath = parsed.filePath
 
+      // Wait for background ingestion to finish before manually deleting the file
+      await server.waitForIngestion(filePath)
+
       // Manually delete the file first
       const { unlink } = await import('node:fs/promises')
       await unlink(filePath)
@@ -356,13 +399,15 @@ This is markdown content with **bold** and _italic_ text.
         'Content for testing deletion by source parameter. ' +
         'This needs to be long enough to create chunks for the test to work properly.'
 
-      // Ingest the data
-      await server.handleIngestData({
+      // Ingest the data and wait for completion so it appears in list_files
+      const ingestResult = await server.handleIngestData({
         content,
         metadata: { source, format: 'text' },
       })
+      const { filePath } = JSON.parse(ingestResult.content[0].text)
+      await server.waitForIngestion(filePath)
 
-      // Verify it's in list_files (under sources)
+      // Verify it's in list_files (under sources) with chunkCount
       const listBefore = await server.handleListFiles()
       const filesBefore = JSON.parse(listBefore.content[0].text)
       const targetBefore = filesBefore.sources.find((f: { source: string }) => f.source === source)
@@ -398,10 +443,14 @@ This is markdown content with **bold** and _italic_ text.
         'The RAG system should find this content using semantic search.'
       const source = 'test://query-integration-test'
 
-      await server.handleIngestData({
+      const ingestResult = await server.handleIngestData({
         content: uniqueContent,
         metadata: { source, format: 'text' },
       })
+      const { filePath } = JSON.parse(ingestResult.content[0].text)
+
+      // Wait for data to be in the vector DB before querying
+      await server.waitForIngestion(filePath)
 
       const queryResult = await server.handleQueryDocuments({
         query: 'UniqueSearchableContent12345',
@@ -420,10 +469,14 @@ This is markdown content with **bold** and _italic_ text.
         'This content verifies that source information is properly restored. ' +
         'The query results should include the original source URL.'
 
-      await server.handleIngestData({
+      const ingestResult = await server.handleIngestData({
         content,
         metadata: { source, format: 'text' },
       })
+      const { filePath } = JSON.parse(ingestResult.content[0].text)
+
+      // Wait for data to be in the vector DB before querying
+      await server.waitForIngestion(filePath)
 
       const queryResult = await server.handleQueryDocuments({
         query: 'SourceRestorationTestContent98765',

--- a/src/server/__tests__/rag-server.integration.test.ts
+++ b/src/server/__tests__/rag-server.integration.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { isFailedFileEntry } from '../../__tests__/helpers/type-guards.js'
 import { RAGServer } from '../index.js'
 import { generateMetaJsonPath, generateRawDataPath } from '../raw-data-utils.js'
 
@@ -253,6 +254,8 @@ describe('RAG MCP Server Integration Test - Phase 1', () => {
       )
 
       await localRagServer.handleIngestFile({ filePath: testFile })
+      // Ingestion runs in the background — wait for it to finish before tests run
+      await localRagServer.waitForIngestion(testFile)
     })
 
     afterAll(async () => {
@@ -369,21 +372,44 @@ describe('RAG MCP Server Integration Test - Phase 1', () => {
   })
 
   describe('AC-005: Error Handling (Basic)', () => {
-    // AC interpretation: [Error handling] Error message returned for non-existent file path
-    // Validation: Call ingest_file with non-existent file path, FileOperationError is returned
+    // AC interpretation: [Error handling] Error reported for non-existent file path
+    // Validation: Call ingest_file with non-existent file path, failed state reported via list_files
     it('FileOperationError returned for non-existent file path (e.g., /nonexistent/file.pdf)', async () => {
       const nonExistentFile = resolve(testDataDir, 'nonexistent-file.pdf')
-      await expect(ragServer.handleIngestFile({ filePath: nonExistentFile })).rejects.toThrow()
+      // With async ingestion, validateFilePath passes (path is inside BASE_DIR)
+      // but the actual read fails in the background job.
+      await ragServer.handleIngestFile({ filePath: nonExistentFile })
+      await ragServer.waitForIngestion(nonExistentFile)
+
+      const listResult = await ragServer.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: { filePath: string }) => f.filePath === nonExistentFile)
+      expect(entry).toBeDefined()
+      expect(isFailedFileEntry(entry)).toBe(true)
+      if (isFailedFileEntry(entry)) {
+        expect(entry.error).toBeDefined()
+      }
     })
 
-    // AC interpretation: [Error handling] Error message returned for corrupted PDF file
-    // Validation: Call ingest_file with corrupted PDF file, FileOperationError is returned
+    // AC interpretation: [Error handling] Error reported for corrupted PDF file
+    // Validation: Call ingest_file with corrupted PDF file, failed state reported via list_files
     it('FileOperationError returned for corrupted PDF file (e.g., invalid header)', async () => {
       // Create corrupted PDF file
       const corruptedPdf = resolve(testDataDir, 'corrupted.pdf')
       writeFileSync(corruptedPdf, 'This is not a valid PDF file')
 
-      await expect(ragServer.handleIngestFile({ filePath: corruptedPdf })).rejects.toThrow()
+      // With async ingestion the parse error surfaces in the background job.
+      await ragServer.handleIngestFile({ filePath: corruptedPdf })
+      await ragServer.waitForIngestion(corruptedPdf)
+
+      const listResult = await ragServer.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: { filePath: string }) => f.filePath === corruptedPdf)
+      expect(entry).toBeDefined()
+      expect(isFailedFileEntry(entry)).toBe(true)
+      if (isFailedFileEntry(entry)) {
+        expect(entry.error).toBeDefined()
+      }
     })
 
     // AC interpretation: [Error handling] Error message returned when LanceDB connection fails
@@ -570,18 +596,21 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
 
       await localRagServer.initialize()
 
-      // Ingest test documents (3 files)
+      // Ingest test documents (3 files) and wait for all to complete
       const testFile1 = resolve(localTestDataDir, 'test-file-1.txt')
       writeFileSync(testFile1, 'This is test file 1. '.repeat(50)) // Approx 1000 characters
       await localRagServer.handleIngestFile({ filePath: testFile1 })
+      await localRagServer.waitForIngestion(testFile1)
 
       const testFile2 = resolve(localTestDataDir, 'test-file-2.txt')
       writeFileSync(testFile2, 'This is test file 2. '.repeat(30)) // Approx 600 characters
       await localRagServer.handleIngestFile({ filePath: testFile2 })
+      await localRagServer.waitForIngestion(testFile2)
 
       const testFile3 = resolve(localTestDataDir, 'test-file-3.txt')
       writeFileSync(testFile3, 'This is test file 3. '.repeat(20)) // Approx 400 characters
       await localRagServer.handleIngestFile({ filePath: testFile3 })
+      await localRagServer.waitForIngestion(testFile3)
     })
 
     afterAll(async () => {
@@ -732,7 +761,7 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
 
       it('raw-data .md files inside dbPath excluded from files array', async () => {
         // Ingest data via handleIngestData to create raw-data .md in dbPath/raw-data/
-        await excludeServer.handleIngestData({
+        const ingestResult = await excludeServer.handleIngestData({
           content:
             'Integration test content for raw-data exclusion verification. ' +
             'This content is long enough to produce at least one chunk in the system.',
@@ -741,6 +770,8 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
             format: 'text',
           },
         })
+        const { filePath: excludeRawDataPath } = JSON.parse(ingestResult.content[0].text)
+        await excludeServer.waitForIngestion(excludeRawDataPath)
 
         const result = await excludeServer.handleListFiles()
         const parsed = JSON.parse(result.content[0].text)
@@ -828,41 +859,45 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
     // AC interpretation: [Functional requirement] When existing file is re-ingested, old data is completely deleted
     // Validation: Re-ingest with same file path, old chunks are deleted
     it('When existing file is re-ingested, old data is completely deleted', async () => {
-      // Initial ingestion
+      // Initial ingestion — must complete before re-ingesting the same path
       const testFile = resolve(localTestDataDir, 'test-reingest.txt')
       writeFileSync(testFile, 'This is the original content. '.repeat(50))
       await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
-      // Re-ingestion (content changed)
+      // Re-ingestion (content changed) — wait for completion then read from list_files
       writeFileSync(testFile, 'This is the updated content. '.repeat(30))
-      const result2 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest2 = JSON.parse(result2.content[0].text)
-      const updatedChunkCount = ingest2.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
       // Validation: Only one file exists in file list
       const listResult = await localRagServer.handleListFiles()
       const files = JSON.parse(listResult.content[0].text)
       const targetFiles = files.files.filter((f: { filePath: string }) => f.filePath === testFile)
       expect(targetFiles.length).toBe(1)
-      // Validation: Chunk count matches new data (not old + new combined)
-      expect(targetFiles[0].chunkCount).toBe(updatedChunkCount)
+      // Validation: Chunk count reflects new data only (ingested: true with chunkCount)
+      expect(targetFiles[0].chunkCount).toBeGreaterThan(0)
     })
 
     // AC interpretation: [Technical requirement] After re-ingestion, only new data exists (0 duplicate data)
     // Validation: After re-ingestion, chunks with same filePath contain only new data
     it('After re-ingestion, only new data exists (0 duplicate data, R-003)', async () => {
-      // Initial ingestion
+      // Initial ingestion — wait for completion to get original chunk count
       const testFile = resolve(localTestDataDir, 'test-no-duplicate.txt')
       writeFileSync(testFile, 'Original data. '.repeat(50))
-      const result1 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest1 = JSON.parse(result1.content[0].text)
-      const originalChunkCount = ingest1.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
-      // Re-ingestion
+      const listAfterFirst = JSON.parse((await localRagServer.handleListFiles()).content[0].text)
+      const firstEntry = listAfterFirst.files.find(
+        (f: { filePath: string }) => f.filePath === testFile
+      )
+      const originalChunkCount = firstEntry.chunkCount
+
+      // Re-ingestion — wait for completion then read updated state
       writeFileSync(testFile, 'Updated data. '.repeat(40))
-      const result2 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest2 = JSON.parse(result2.content[0].text)
-      const updatedChunkCount = ingest2.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
       // Validation: Only one file exists in file list (no duplicates)
       const listResult = await localRagServer.handleListFiles()
@@ -870,9 +905,11 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       const targetFiles = files.files.filter((f: { filePath: string }) => f.filePath === testFile)
       expect(targetFiles.length).toBe(1)
 
+      const updatedChunkCount = targetFiles[0].chunkCount
+
       // Validation: Chunk count matches new data only (not old + new)
-      expect(targetFiles[0].chunkCount).toBe(updatedChunkCount)
-      expect(targetFiles[0].chunkCount).not.toBe(originalChunkCount + updatedChunkCount)
+      expect(updatedChunkCount).toBeGreaterThan(0)
+      expect(updatedChunkCount).not.toBe(originalChunkCount + updatedChunkCount)
 
       // Validation: Timestamp is updated
       expect(targetFiles[0].timestamp).toBeDefined()
@@ -885,15 +922,19 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       // Here, verify that in normal case, old data is completely deleted and only new data exists
       const testFile = resolve(localTestDataDir, 'test-atomicity.txt')
       writeFileSync(testFile, 'Atomicity test data. '.repeat(50))
-      const result1 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest1 = JSON.parse(result1.content[0].text)
-      const originalChunkCount = ingest1.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
-      // Re-ingestion
+      const listAfterFirst = JSON.parse((await localRagServer.handleListFiles()).content[0].text)
+      const firstEntry = listAfterFirst.files.find(
+        (f: { filePath: string }) => f.filePath === testFile
+      )
+      const originalChunkCount = firstEntry.chunkCount
+
+      // Re-ingestion — wait for completion
       writeFileSync(testFile, 'Atomicity test updated. '.repeat(40))
-      const result2 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest2 = JSON.parse(result2.content[0].text)
-      const updatedChunkCount = ingest2.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
       // Validation: Only one file exists in file list (atomicity guaranteed)
       const listResult = await localRagServer.handleListFiles()
@@ -901,9 +942,11 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       const targetFiles = files.files.filter((f: { filePath: string }) => f.filePath === testFile)
       expect(targetFiles.length).toBe(1)
 
+      const updatedChunkCount = targetFiles[0].chunkCount
+
       // Validation: Chunk count proves atomicity - only new data exists (not old + new)
-      expect(targetFiles[0].chunkCount).toBe(updatedChunkCount)
-      expect(targetFiles[0].chunkCount).not.toBe(originalChunkCount + updatedChunkCount)
+      expect(updatedChunkCount).toBeGreaterThan(0)
+      expect(updatedChunkCount).not.toBe(originalChunkCount + updatedChunkCount)
     })
 
     // AC interpretation: [Error handling] On error, automatic rollback from backup
@@ -914,15 +957,19 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       // Rollback on error requires implementation-level test (using mocks)
       const testFile = resolve(localTestDataDir, 'test-rollback.txt')
       writeFileSync(testFile, 'Rollback test data. '.repeat(50))
-      const result1 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest1 = JSON.parse(result1.content[0].text)
-      const originalChunkCount = ingest1.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
-      // Re-ingest normally (no error)
+      const listAfterFirst = JSON.parse((await localRagServer.handleListFiles()).content[0].text)
+      const firstEntry = listAfterFirst.files.find(
+        (f: { filePath: string }) => f.filePath === testFile
+      )
+      const originalChunkCount = firstEntry.chunkCount
+
+      // Re-ingest normally (no error) — wait for completion
       writeFileSync(testFile, 'Rollback test updated. '.repeat(40))
-      const result2 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest2 = JSON.parse(result2.content[0].text)
-      const updatedChunkCount = ingest2.chunkCount
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
       // Validation: In normal case, no rollback occurs and new data exists
       const listResult = await localRagServer.handleListFiles()
@@ -930,36 +977,44 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       const targetFiles = files.files.filter((f: { filePath: string }) => f.filePath === testFile)
       expect(targetFiles.length).toBe(1)
 
+      const updatedChunkCount = targetFiles[0].chunkCount
+
       // Validation: Chunk count confirms successful re-ingestion (not old + new)
-      expect(targetFiles[0].chunkCount).toBe(updatedChunkCount)
-      expect(targetFiles[0].chunkCount).not.toBe(originalChunkCount + updatedChunkCount)
+      expect(updatedChunkCount).toBeGreaterThan(0)
+      expect(updatedChunkCount).not.toBe(originalChunkCount + updatedChunkCount)
 
       // Note: Rollback behavior on error needs to be verified in unit test
       // by mocking VectorStore.insertChunks to cause error
     })
 
     // AC interpretation: [Data protection] Prevent data loss when re-ingest results in 0 chunks
-    // Validation: When chunking produces 0 chunks, error is thrown before delete (preserves existing data)
-    it('Throws error when chunking produces 0 chunks (prevents data loss on re-ingest)', async () => {
-      // Initial ingestion with valid content
+    // Validation: When chunking produces 0 chunks, error is reported via list_files before delete (preserves existing data)
+    it('Reports failed status when chunking produces 0 chunks (prevents data loss on re-ingest)', async () => {
+      // Initial ingestion with valid content — wait for completion
       const testFile = resolve(localTestDataDir, 'test-empty-chunks.txt')
       writeFileSync(testFile, 'This is valid content for initial ingestion. '.repeat(50))
-      const result1 = await localRagServer.handleIngestFile({ filePath: testFile })
-      const ingest1 = JSON.parse(result1.content[0].text)
-      expect(ingest1.chunkCount).toBeGreaterThan(0)
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
-      // Re-ingest with empty content (should fail, preserving original data)
-      writeFileSync(testFile, '')
-      await expect(localRagServer.handleIngestFile({ filePath: testFile })).rejects.toThrow(
-        /No.*chunks/i
+      const listAfterFirst = JSON.parse((await localRagServer.handleListFiles()).content[0].text)
+      const firstEntry = listAfterFirst.files.find(
+        (f: { filePath: string }) => f.filePath === testFile
       )
+      expect(firstEntry.chunkCount).toBeGreaterThan(0)
+      const originalChunkCount = firstEntry.chunkCount
 
-      // Validation: Original data is preserved (not deleted)
+      // Re-ingest with empty content — ingestion starts (background) then fails
+      writeFileSync(testFile, '')
+      await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
+
+      // Validation: Original data is preserved (zero-chunks check happens before delete)
       const listResult = await localRagServer.handleListFiles()
       const files = JSON.parse(listResult.content[0].text)
       const targetFiles = files.files.filter((f: { filePath: string }) => f.filePath === testFile)
       expect(targetFiles.length).toBe(1)
-      expect(targetFiles[0].chunkCount).toBe(ingest1.chunkCount)
+      // File still shows as ingested with original chunk count
+      expect(targetFiles[0].chunkCount).toBe(originalChunkCount)
     })
   })
 
@@ -989,13 +1044,24 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       rmSync(localTestDataDir, { recursive: true, force: true })
     })
 
-    // AC interpretation: [Error handling] Error message returned for file without access permission
-    // Validation: Call ingest_file with file without access permission, FileOperationError is returned
+    // AC interpretation: [Error handling] Error reported for file without access permission
+    // Validation: Call ingest_file with non-existent file path, failed state reported via list_files
     it('FileOperationError returned for file without access permission (e.g., chmod 000)', async () => {
-      // Test with non-existent file since chmod 000 does not work on Windows
-      // (File read error occurs instead of access permission error)
+      // Test with non-existent file since chmod 000 does not work on Windows.
+      // With async ingestion, validateFilePath passes (path is inside BASE_DIR) but
+      // the actual read fails in the background job.
       const nonExistentFile = resolve(localTestDataDir, 'nonexistent-file.txt')
-      await expect(localRagServer.handleIngestFile({ filePath: nonExistentFile })).rejects.toThrow()
+      await localRagServer.handleIngestFile({ filePath: nonExistentFile })
+      await localRagServer.waitForIngestion(nonExistentFile)
+
+      const listResult = await localRagServer.handleListFiles()
+      const { files } = JSON.parse(listResult.content[0].text)
+      const entry = files.find((f: { filePath: string }) => f.filePath === nonExistentFile)
+      expect(entry).toBeDefined()
+      expect(isFailedFileEntry(entry)).toBe(true)
+      if (isFailedFileEntry(entry)) {
+        expect(entry.error).toBeDefined()
+      }
     })
 
     // AC interpretation: [Error handling] Size overflow error returned for files over 100MB
@@ -1117,6 +1183,8 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       const testFile = resolve(localTestDataDir, 'test-delete.txt')
       writeFileSync(testFile, 'This file will be deleted. '.repeat(50))
       await localRagServer.handleIngestFile({ filePath: testFile })
+      // Wait for ingestion to complete so the file shows as ingested before deletion
+      await localRagServer.waitForIngestion(testFile)
 
       // Verify file exists before deletion
       const listBefore = await localRagServer.handleListFiles()
@@ -1144,6 +1212,7 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       const testFile = resolve(localTestDataDir, 'test-search-delete.txt')
       writeFileSync(testFile, 'Unique keyword XYZABC123 for deletion test. '.repeat(30))
       await localRagServer.handleIngestFile({ filePath: testFile })
+      await localRagServer.waitForIngestion(testFile)
 
       // Search before deletion
       const searchBefore = await localRagServer.handleQueryDocuments({
@@ -1226,7 +1295,7 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
         </html>
       `
 
-      // Ingest HTML via ingest_data
+      // Ingest HTML via ingest_data — ingestion is async, wait before querying
       const ingestResult = await localRagServer.handleIngestData({
         content: html,
         metadata: {
@@ -1236,8 +1305,8 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
       })
 
       const ingestData = JSON.parse(ingestResult.content[0].text)
-      expect(ingestData.chunkCount).toBeGreaterThan(0)
-      expect(ingestData.fileTitle).toBe('RAG Architecture Guide')
+      expect(ingestData.status).toBe('started')
+      await localRagServer.waitForIngestion(ingestData.filePath)
 
       // Query and verify fileTitle appears in results
       const queryResult = await localRagServer.handleQueryDocuments({
@@ -1305,8 +1374,9 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
         },
       })
 
+      // .meta.json is written synchronously — no need to wait for full ingestion
       const ingestData = JSON.parse(ingestResult.content[0].text)
-      expect(ingestData.chunkCount).toBeGreaterThan(0)
+      expect(ingestData.status).toBe('started')
 
       // Derive the raw-data .md path and .meta.json path
       const rawDataPath = generateRawDataPath(
@@ -1400,13 +1470,15 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
         </html>
       `
 
-      await localRagServer.handleIngestData({
+      const dupIngestResult = await localRagServer.handleIngestData({
         content: html,
         metadata: {
           source: 'https://example.com/duplication-check',
           format: 'html',
         },
       })
+      const { filePath: dupFilePath } = JSON.parse(dupIngestResult.content[0].text)
+      await localRagServer.waitForIngestion(dupFilePath)
 
       // Query for the content
       const queryResult = await localRagServer.handleQueryDocuments({
@@ -1456,14 +1528,16 @@ describe('RAG MCP Server Integration Test - Phase 2', () => {
         </html>
       `
 
-      // Ingest the content
-      await localRagServer.handleIngestData({
+      // Ingest the content — .meta.json and raw-data file are written synchronously
+      const deleteMetaIngestResult = await localRagServer.handleIngestData({
         content: html,
         metadata: {
           source: 'https://example.com/delete-meta-test',
           format: 'html',
         },
       })
+      const { filePath: deleteMetaRawPath } = JSON.parse(deleteMetaIngestResult.content[0].text)
+      await localRagServer.waitForIngestion(deleteMetaRawPath)
 
       // Verify files exist before deletion
       const rawDataPath = generateRawDataPath(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { readFile, readdir, unlink } from 'node:fs/promises'
-import { extname, join, resolve } from 'node:path'
+import { extname, join, resolve, sep } from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
@@ -34,7 +34,9 @@ import type {
   FileEntry,
   IngestDataInput,
   IngestFileInput,
-  IngestResult,
+  IngestInProgressResult,
+  IngestStartedResult,
+  IngestionJob,
   ListFilesResult,
   QueryDocumentsInput,
   QueryResult,
@@ -53,6 +55,11 @@ export class RAGServer {
   private readonly baseDir: string
   // Used by handleListFiles filter to exclude system-managed directories
   private readonly excludePaths: string[]
+
+  // In-memory tracking of active and failed ingestion jobs, keyed by filePath
+  private readonly ingestionJobs: Map<string, IngestionJob> = new Map()
+  // Promises for pending background ingestions, keyed by filePath
+  private readonly pendingIngestions: Map<string, Promise<void>> = new Map()
 
   constructor(config: RAGServerConfig) {
     this.dbPath = config.dbPath
@@ -194,32 +201,31 @@ export class RAGServer {
   }
 
   /**
-   * ingest_file tool handler (re-ingestion support, transaction processing, rollback capability)
+   * Core ingestion logic executed in the background.
+   * On success the job is removed from ingestionJobs (DB is source of truth).
+   * On failure the job status is set to 'failed' with an error message.
+   * For raw-data paths a failure triggers rollback (file + .meta.json deletion).
    */
-  async handleIngestFile(
-    args: IngestFileInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  private async _executeFileIngestion(filePath: string): Promise<void> {
     let backup: VectorChunk[] | null = null
 
     try {
-      // Parse file (with header/footer filtering for PDFs)
-      // For raw-data files (from ingest_data), read directly without validation
-      // since the path is internally generated and content is already processed
-      const isPdf = args.filePath.toLowerCase().endsWith('.pdf')
+      // Parse file
+      const isPdf = filePath.toLowerCase().endsWith('.pdf')
       let text: string
       let title: string | null = null
-      if (isRawDataPath(args.filePath)) {
-        // Raw-data files: skip validation, read directly
-        text = await readFile(args.filePath, 'utf-8')
-        const meta = await loadMetaJson(args.filePath)
+
+      if (isRawDataPath(filePath)) {
+        text = await readFile(filePath, 'utf-8')
+        const meta = await loadMetaJson(filePath)
         title = meta?.title ?? null
-        console.error(`Read raw-data file: ${args.filePath} (${text.length} characters)`)
+        console.error(`Read raw-data file: ${filePath} (${text.length} characters)`)
       } else if (isPdf) {
-        const result = await this.parser.parsePdf(args.filePath, this.embedder)
+        const result = await this.parser.parsePdf(filePath, this.embedder)
         text = result.content
         title = result.title || null
       } else {
-        const result = await this.parser.parseFile(args.filePath)
+        const result = await this.parser.parseFile(filePath)
         text = result.content
         title = result.title || null
       }
@@ -232,7 +238,7 @@ export class RAGServer {
       if (chunks.length === 0) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          `No chunks generated from file: ${args.filePath}. The file may be empty or all content was filtered (minimum 50 characters required). Existing data has been preserved.`
+          `No chunks generated from file: ${filePath}. The file may be empty or all content was filtered (minimum 50 characters required). Existing data has been preserved.`
         )
       }
 
@@ -242,35 +248,33 @@ export class RAGServer {
       // Create backup (if existing data exists)
       try {
         const existingFiles = await this.vectorStore.listFiles()
-        const existingFile = existingFiles.find((file) => file.filePath === args.filePath)
+        const existingFile = existingFiles.find((file) => file.filePath === filePath)
         if (existingFile && existingFile.chunkCount > 0) {
-          // Backup existing data (retrieve via search)
           const queryVector = embeddings[0] || []
           if (queryVector.length > 0) {
-            const allChunks = await this.vectorStore.search(queryVector, undefined, 20) // Retrieve max 20 items
+            const allChunks = await this.vectorStore.search(queryVector, undefined, 20)
             backup = allChunks
-              .filter((chunk) => chunk.filePath === args.filePath)
+              .filter((chunk) => chunk.filePath === filePath)
               .map((chunk) => ({
                 id: randomUUID(),
                 filePath: chunk.filePath,
                 chunkIndex: chunk.chunkIndex,
                 text: chunk.text,
-                vector: queryVector, // Use dummy vector since actual vector cannot be retrieved
+                vector: queryVector,
                 metadata: chunk.metadata,
                 fileTitle: chunk.fileTitle ?? null,
                 timestamp: new Date().toISOString(),
               }))
           }
-          console.error(`Backup created: ${backup?.length || 0} chunks for ${args.filePath}`)
+          console.error(`Backup created: ${backup?.length || 0} chunks for ${filePath}`)
         }
       } catch (error) {
-        // Backup creation failure is warning only (for new files)
         console.warn('Failed to create backup (new file?):', error)
       }
 
       // Delete existing data
-      await this.vectorStore.deleteChunks(args.filePath)
-      console.error(`Deleted existing chunks for: ${args.filePath}`)
+      await this.vectorStore.deleteChunks(filePath)
+      console.error(`Deleted existing chunks for: ${filePath}`)
 
       // Create vector chunks
       const timestamp = new Date().toISOString()
@@ -281,29 +285,26 @@ export class RAGServer {
         }
         return {
           id: randomUUID(),
-          filePath: args.filePath,
+          filePath,
           chunkIndex: chunk.index,
           text: chunk.text,
           vector: embedding,
           metadata: {
-            fileName: args.filePath.split('/').pop() || args.filePath,
+            fileName: filePath.split('/').pop() || filePath,
             fileSize: text.length,
-            fileType: args.filePath.split('.').pop() || '',
+            fileType: filePath.split('.').pop() || '',
           },
           fileTitle: title || null,
           timestamp,
         }
       })
 
-      // Insert vectors (transaction processing)
+      // Insert vectors (with rollback on failure)
       try {
         await this.vectorStore.insertChunks(vectorChunks)
-        console.error(`Inserted ${vectorChunks.length} chunks for: ${args.filePath}`)
-
-        // Delete backup on success
+        console.error(`Inserted ${vectorChunks.length} chunks for: ${filePath}`)
         backup = null
       } catch (insertError) {
-        // Rollback on error
         if (backup && backup.length > 0) {
           console.error('Ingestion failed, rolling back...', insertError)
           try {
@@ -319,40 +320,99 @@ export class RAGServer {
         throw insertError
       }
 
-      // Result
-      const result: IngestResult = {
-        filePath: args.filePath,
-        chunkCount: chunks.length,
-        timestamp,
-        fileTitle: title || null,
-      }
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      }
+      // Success: remove job (DB is now the source of truth)
+      this.ingestionJobs.delete(filePath)
+      console.error(`Background ingestion completed: ${filePath}`)
     } catch (error) {
-      // Re-throw McpError as-is to preserve error code
-      if (error instanceof McpError) {
-        console.error('Failed to ingest file:', error.message)
-        throw error
+      // Update job to failed state
+      const job = this.ingestionJobs.get(filePath)
+      if (job) {
+        job.status = 'failed'
+        job.error = formatErrorMessage(error)
       }
 
-      const errorMessage = formatErrorMessage(error)
+      // Raw-data files are owned by the server — clean them up on failure so
+      // orphaned files don't accumulate in the raw-data directory.
+      if (isRawDataPath(filePath)) {
+        try {
+          await unlink(filePath)
+          await unlink(generateMetaJsonPath(filePath))
+          console.error(`Rolled back raw-data file: ${filePath}`)
+        } catch {
+          console.warn(`Failed to rollback raw-data file: ${filePath}`)
+        }
+      }
 
-      console.error('Failed to ingest file:', errorMessage)
-
-      throw new Error(`Failed to ingest file: ${errorMessage}`)
+      console.error(`Background ingestion failed for ${filePath}:`, error)
     }
   }
 
   /**
-   * ingest_data tool handler
-   * Saves raw content to raw-data directory and calls handleIngestFile internally
+   * Register an ingestion job and start background processing.
+   * Returns the 'started' MCP response. Shared by handleIngestFile and handleIngestData.
+   */
+  private _startIngestionJob(
+    filePath: string,
+    displayName: string
+  ): { content: [{ type: 'text'; text: string }] } {
+    const startedAt = new Date().toISOString()
+    const job: IngestionJob = { filePath, status: 'processing', startedAt }
+    this.ingestionJobs.set(filePath, job)
+
+    const ingestionPromise = this._executeFileIngestion(filePath)
+    this.pendingIngestions.set(filePath, ingestionPromise)
+    ingestionPromise.finally(() => this.pendingIngestions.delete(filePath))
+
+    const result: IngestStartedResult = {
+      filePath,
+      status: 'started',
+      message: `Ingestion started for: ${displayName}. Use list_files to monitor progress.`,
+      startedAt,
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }
+  }
+
+  /**
+   * ingest_file tool handler.
+   * Validates the file path immediately, then starts ingestion in the background
+   * and returns a 'started' response without waiting for completion.
+   * If the same file is already being ingested, returns an 'in_progress' response.
+   */
+  async handleIngestFile(
+    args: IngestFileInput
+  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+    // Duplicate-ingest guard
+    const existingJob = this.ingestionJobs.get(args.filePath)
+    if (existingJob?.status === 'processing') {
+      const result: IngestInProgressResult = {
+        filePath: args.filePath,
+        status: 'in_progress',
+        message: `Ingestion already in progress for: ${args.filePath}. Use list_files to monitor progress.`,
+        startedAt: existingJob.startedAt,
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }
+    }
+
+    // Clear any previous failed job for this path
+    this.ingestionJobs.delete(args.filePath)
+
+    try {
+      // Validate path upfront (fast I/O check) so obvious errors surface immediately
+      if (!isRawDataPath(args.filePath)) {
+        await this.parser.validateFilePath(args.filePath)
+      }
+    } catch (error) {
+      if (error instanceof McpError) throw error
+      throw new Error(`Failed to ingest file: ${formatErrorMessage(error)}`)
+    }
+
+    return this._startIngestionJob(args.filePath, args.filePath)
+  }
+
+  /**
+   * ingest_data tool handler.
+   * Saves raw content to raw-data directory synchronously, then starts ingestion
+   * in the background and returns a 'started' response without waiting for completion.
    *
    * For HTML content:
    * - Parses HTML and extracts main content using Readability
@@ -363,11 +423,32 @@ export class RAGServer {
     args: IngestDataInput
   ): Promise<{ content: [{ type: 'text'; text: string }] }> {
     try {
-      let contentToSave = args.content
-      let formatToSave: ContentFormat = args.metadata.format
-      let title: string | null = null
+      // Determine the storage format upfront so the duplicate guard can run
+      // before expensive content processing (e.g. HTML parsing via Readability).
+      // HTML is always converted to Markdown before saving.
+      const formatToSave: ContentFormat =
+        args.metadata.format === 'html' ? 'markdown' : args.metadata.format
+      const rawDataPath = generateRawDataPath(this.dbPath, args.metadata.source, formatToSave)
+
+      // Duplicate-ingest guard — checked early to avoid wasted work
+      const existingJob = this.ingestionJobs.get(rawDataPath)
+      if (existingJob?.status === 'processing') {
+        const result: IngestInProgressResult = {
+          filePath: rawDataPath,
+          status: 'in_progress',
+          message: `Ingestion already in progress for: ${args.metadata.source}. Use list_files to monitor progress.`,
+          startedAt: existingJob.startedAt,
+        }
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }
+      }
+
+      // Clear any previous failed job for this path
+      this.ingestionJobs.delete(rawDataPath)
 
       // Per-format title extraction and content preparation
+      let contentToSave = args.content
+      let title: string | null = null
+
       if (args.metadata.format === 'html') {
         console.error(`Parsing HTML from: ${args.metadata.source}`)
         const { content: markdown, title: htmlTitle } = await parseHtml(
@@ -383,7 +464,6 @@ export class RAGServer {
 
         title = htmlTitle || null
         contentToSave = markdown
-        formatToSave = 'markdown' // Save as .md file
         console.error(`Converted HTML to Markdown: ${markdown.length} characters`)
       } else if (args.metadata.format === 'markdown') {
         const result = extractMarkdownTitle(args.content, args.metadata.source)
@@ -394,13 +474,8 @@ export class RAGServer {
         title = result.source !== 'filename' ? result.title : null
       }
 
-      // Save content to raw-data directory
-      const rawDataPath = await saveRawData(
-        this.dbPath,
-        args.metadata.source,
-        contentToSave,
-        formatToSave
-      )
+      // Save content to raw-data directory (uses the same path as rawDataPath)
+      await saveRawData(this.dbPath, args.metadata.source, contentToSave, formatToSave)
 
       // Save metadata sidecar (.meta.json) alongside the raw-data file
       await saveMetaJson(rawDataPath, {
@@ -411,20 +486,7 @@ export class RAGServer {
 
       console.error(`Saved raw data: ${args.metadata.source} -> ${rawDataPath}`)
 
-      // Call existing ingest_file internally with rollback on failure
-      try {
-        return await this.handleIngestFile({ filePath: rawDataPath })
-      } catch (ingestError) {
-        // Rollback: delete the raw-data file and .meta.json if ingest fails
-        try {
-          await unlink(rawDataPath)
-          await unlink(generateMetaJsonPath(rawDataPath))
-          console.error(`Rolled back raw-data file: ${rawDataPath}`)
-        } catch {
-          console.warn(`Failed to rollback raw-data file: ${rawDataPath}`)
-        }
-        throw ingestError
-      }
+      return this._startIngestionJob(rawDataPath, args.metadata.source)
     } catch (error) {
       const errorMessage = formatErrorMessage(error)
 
@@ -435,8 +497,9 @@ export class RAGServer {
   }
 
   /**
-   * list_files tool handler
-   * Scans BASE_DIR for supported files and cross-references with ingested documents
+   * list_files tool handler.
+   * Scans BASE_DIR for supported files, cross-references with ingested documents,
+   * and overlays any active or failed ingestion jobs.
    */
   async handleListFiles(): Promise<{ content: [{ type: 'text'; text: string }] }> {
     try {
@@ -445,8 +508,6 @@ export class RAGServer {
       const ingestedMap = new Map(ingested.map((f) => [f.filePath, f]))
 
       // Scan BASE_DIR recursively for supported files.
-      // Errors propagate to the outer catch: if readdir fails, ingest_file and
-      // delete_file won't work either, so surfacing the error is appropriate.
       const entries = await readdir(this.baseDir, { recursive: true, withFileTypes: true })
       const baseDirFiles = entries
         .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
@@ -461,12 +522,49 @@ export class RAGServer {
 
       const baseDirSet = new Set(baseDirFiles)
 
-      // Files in BASE_DIR with ingestion status
+      // Files in BASE_DIR with ingestion status, overlaid with active/failed jobs
       const files: FileEntry[] = baseDirFiles.map((filePath) => {
-        const entry = ingestedMap.get(filePath)
-        return entry
-          ? { filePath, ingested: true, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
-          : { filePath, ingested: false }
+        const dbEntry = ingestedMap.get(filePath)
+        const job = this.ingestionJobs.get(filePath)
+
+        if (dbEntry) {
+          // Already ingested — show existing data, overlaid with re-ingestion status
+          if (job?.status === 'processing') {
+            return {
+              filePath,
+              ingested: true,
+              chunkCount: dbEntry.chunkCount,
+              timestamp: dbEntry.timestamp,
+              ingesting: true,
+              startedAt: job.startedAt,
+            }
+          }
+          if (job?.status === 'failed') {
+            return {
+              filePath,
+              ingested: true,
+              chunkCount: dbEntry.chunkCount,
+              timestamp: dbEntry.timestamp,
+              failed: true,
+              error: job.error ?? 'Unknown error',
+            }
+          }
+          return {
+            filePath,
+            ingested: true,
+            chunkCount: dbEntry.chunkCount,
+            timestamp: dbEntry.timestamp,
+          }
+        }
+
+        // Not yet ingested — may have an active or failed job
+        if (job?.status === 'processing') {
+          return { filePath, ingested: false, ingesting: true, startedAt: job.startedAt }
+        }
+        if (job?.status === 'failed') {
+          return { filePath, ingested: false, failed: true, error: job.error ?? 'Unknown error' }
+        }
+        return { filePath, ingested: false }
       })
 
       // Content ingested via ingest_data (web pages, clipboard, etc.) plus any
@@ -474,12 +572,72 @@ export class RAGServer {
       const sources: SourceEntry[] = ingested
         .filter((f) => !baseDirSet.has(f.filePath))
         .map((f) => {
+          const job = this.ingestionJobs.get(f.filePath)
           if (isRawDataPath(f.filePath)) {
             const source = extractSourceFromPath(f.filePath)
-            if (source) return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
+            if (source) {
+              if (job?.status === 'processing') {
+                return {
+                  source,
+                  chunkCount: f.chunkCount,
+                  timestamp: f.timestamp,
+                  ingesting: true,
+                  startedAt: job.startedAt,
+                }
+              }
+              if (job?.status === 'failed') {
+                return {
+                  source,
+                  chunkCount: f.chunkCount,
+                  timestamp: f.timestamp,
+                  failed: true,
+                  error: job.error ?? 'Unknown error',
+                }
+              }
+              return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
+            }
           }
           return { filePath: f.filePath, chunkCount: f.chunkCount, timestamp: f.timestamp }
         })
+
+      // Append active/failed ingest_data jobs not yet present in the DB
+      for (const [jobFilePath, job] of this.ingestionJobs) {
+        if (baseDirSet.has(jobFilePath) || ingestedMap.has(jobFilePath)) continue
+        if (!isRawDataPath(jobFilePath)) continue
+        const source = extractSourceFromPath(jobFilePath)
+        if (!source) continue
+        if (job.status === 'processing') {
+          sources.push({ source, ingesting: true, startedAt: job.startedAt })
+        } else if (job.status === 'failed') {
+          sources.push({ source, failed: true, error: job.error ?? 'Unknown error' })
+        }
+      }
+
+      // Append active/failed jobs for files within BASE_DIR that were not found in the
+      // filesystem scan (e.g., the file does not exist or was deleted before ingestion
+      // could run). This makes failed ingest attempts visible via list_files.
+      const resolvedBaseDir = resolve(this.baseDir)
+      const baseDirPrefix = resolvedBaseDir.endsWith(sep) ? resolvedBaseDir : resolvedBaseDir + sep
+      for (const [jobFilePath, job] of this.ingestionJobs) {
+        if (isRawDataPath(jobFilePath)) continue
+        if (baseDirSet.has(jobFilePath) || ingestedMap.has(jobFilePath)) continue
+        if (!jobFilePath.startsWith(baseDirPrefix)) continue
+        if (job.status === 'processing') {
+          files.push({
+            filePath: jobFilePath,
+            ingested: false,
+            ingesting: true,
+            startedAt: job.startedAt,
+          })
+        } else if (job.status === 'failed') {
+          files.push({
+            filePath: jobFilePath,
+            ingested: false,
+            failed: true,
+            error: job.error ?? 'Unknown error',
+          })
+        }
+      }
 
       const result: ListFilesResult = { baseDir: this.baseDir, files, sources }
       return {
@@ -539,6 +697,19 @@ export class RAGServer {
         await this.parser.validateFilePath(targetPath)
       }
 
+      // Block deletion while an ingestion job is actively running for this path.
+      // Without this guard, the background job would re-insert chunks after the
+      // delete completes, causing the file to silently reappear.
+      const activeJob = this.ingestionJobs.get(targetPath)
+      if (activeJob?.status === 'processing') {
+        throw new Error(
+          `Cannot delete while ingestion is in progress for: ${targetPath}. Wait for ingestion to complete, then retry.`
+        )
+      }
+
+      // Clear any lingering failed job for this path since the user is deleting it
+      this.ingestionJobs.delete(targetPath)
+
       // Delete chunks from vector database
       await this.vectorStore.deleteChunks(targetPath)
 
@@ -580,6 +751,18 @@ export class RAGServer {
 
       throw new Error(`Failed to delete file: ${errorMessage}`)
     }
+  }
+
+  /**
+   * Wait for a background ingestion to complete.
+   * Resolves immediately if no ingestion is pending for the given file path.
+   *
+   * Useful for programmatic consumers that need synchronous completion semantics,
+   * and for tests that must await ingestion before asserting on results.
+   */
+  async waitForIngestion(filePath: string): Promise<void> {
+    const pending = this.pendingIngestions.get(filePath)
+    if (pending) await pending
   }
 
   /**

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -31,7 +31,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'ingest_file',
     description:
-      'Ingest a document file (PDF, DOCX, TXT, MD) into the vector database for semantic search. File path must be an absolute path. Supports re-ingestion to update existing documents.',
+      'Ingest a document file (PDF, DOCX, TXT, MD) into the vector database for semantic search. File path must be an absolute path. Supports re-ingestion to update existing documents. Returns immediately with a "started" status — ingestion runs in the background. Use list_files to monitor progress. Submitting the same path while ingestion is running returns an "in_progress" status instead of starting a duplicate job.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -47,7 +47,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'ingest_data',
     description:
-      'Ingest content as a string, not from a file. Use for: fetched web pages (format: html), copied text (format: text), or markdown strings (format: markdown). The source identifier enables re-ingestion to update existing content. For files on disk, use ingest_file instead.',
+      'Ingest content as a string, not from a file. Use for: fetched web pages (format: html), copied text (format: text), or markdown strings (format: markdown). The source identifier enables re-ingestion to update existing content. For files on disk, use ingest_file instead. Returns immediately with a "started" status — ingestion runs in the background. Use list_files to monitor progress. Submitting the same source while ingestion is running returns an "in_progress" status instead of starting a duplicate job.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -98,7 +98,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'list_files',
     description:
-      'List all files in BASE_DIR (PDF, DOCX, TXT, MD) and show which are ingested into the vector database. Also lists any other ingested items (web pages, clipboard content, etc.) that are outside BASE_DIR.',
+      'List all files in BASE_DIR (PDF, DOCX, TXT, MD) and show their ingestion status: ingested (with chunk count), currently ingesting, failed (with error), or not yet ingested. Also lists any other ingested items (web pages, clipboard content, etc.) that are outside BASE_DIR, including those whose ingestion is in progress.',
     inputSchema: { type: 'object', properties: {} },
   },
   {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -77,24 +77,75 @@ export interface DeleteFileInput {
 }
 
 /**
- * ingest_file tool output
+ * Status of an in-progress or failed ingestion job
  */
-export interface IngestResult {
-  /** File path */
+export type IngestionJobStatus = 'processing' | 'failed'
+
+/**
+ * In-memory record tracking an active or failed ingestion job
+ */
+export interface IngestionJob {
+  /** File path being ingested */
   filePath: string
-  /** Chunk count */
-  chunkCount: number
-  /** Timestamp */
-  timestamp: string
-  /** Document title extracted from file content (display-only, not used for scoring) */
-  fileTitle: string | null
+  /** Current status */
+  status: IngestionJobStatus
+  /** ISO timestamp when ingestion was started */
+  startedAt: string
+  /** Error message (only set when status is 'failed') */
+  error?: string
+}
+
+/**
+ * Immediate response returned when ingestion is accepted and started in the background
+ */
+export interface IngestStartedResult {
+  /** File path being ingested */
+  filePath: string
+  /** Always 'started' */
+  status: 'started'
+  /** Human-readable message */
+  message: string
+  /** ISO timestamp when ingestion was started */
+  startedAt: string
+}
+
+/**
+ * Response returned when the same file is submitted while already being ingested
+ */
+export interface IngestInProgressResult {
+  /** File path being ingested */
+  filePath: string
+  /** Always 'in_progress' */
+  status: 'in_progress'
+  /** Human-readable message */
+  message: string
+  /** ISO timestamp when ingestion was originally started */
+  startedAt: string
 }
 
 /**
  * list_files tool output — entry for a file found in BASE_DIR
  */
 export type FileEntry =
+  | {
+      filePath: string
+      ingested: true
+      chunkCount: number
+      timestamp: string
+      ingesting: true
+      startedAt: string
+    }
+  | {
+      filePath: string
+      ingested: true
+      chunkCount: number
+      timestamp: string
+      failed: true
+      error: string
+    }
   | { filePath: string; ingested: true; chunkCount: number; timestamp: string }
+  | { filePath: string; ingested: false; ingesting: true; startedAt: string }
+  | { filePath: string; ingested: false; failed: true; error: string }
   | { filePath: string; ingested: false }
 
 /**
@@ -102,7 +153,11 @@ export type FileEntry =
  * or an orphaned DB entry whose file no longer exists on disk
  */
 export type SourceEntry =
+  | { source: string; chunkCount: number; timestamp: string; ingesting: true; startedAt: string }
+  | { source: string; chunkCount: number; timestamp: string; failed: true; error: string }
   | { source: string; chunkCount: number; timestamp: string }
+  | { source: string; ingesting: true; startedAt: string }
+  | { source: string; failed: true; error: string }
   | { filePath: string; chunkCount: number; timestamp: string }
 
 /**


### PR DESCRIPTION
## Why

Large PDFs and long documents were causing MCP timeout errors (`error -32001`) because `ingest_file` and `ingest_data` blocked the MCP connection while running the full embedding pipeline synchronously. On slower machines or with large files this routinely exceeded the MCP timeout window.

## What changed

`ingest_file` and `ingest_data` now return immediately with `{ status: 'started' }`. The embedding pipeline runs in a background Promise. `list_files` is extended to overlay job state on every entry so callers can poll for completion.

**Response shape changes:**
- `ingest_file` / `ingest_data` → `{ status: 'started' | 'in_progress', filePath, startedAt, message }`
- `list_files` files entries gain optional `ingesting: true` / `failed: true` / `error` fields
- `list_files` sources entries gain the same optional fields for `ingest_data` jobs

**Behaviour:**
- Submitting the same path while already ingesting returns `{ status: 'in_progress' }` instead of starting a duplicate job
- `delete_file` rejects with a clear error if ingestion is active for that path (without this guard the background job would re-insert chunks after the delete)
- Failed re-ingestion is surfaced in `list_files` while the original DB data is preserved
- Failed `ingest_data` jobs appear in the `sources` section of `list_files`

## Implementation notes

- `_startIngestionJob` helper consolidates the duplicated job-registration pattern that would otherwise exist in both `handleIngestFile` and `handleIngestData`
- The duplicate guard in `handleIngestData` now runs before HTML parsing so Readability isn't invoked unnecessarily when the source is already being processed
- `rawDataPath` is computed once upfront; the previously-discarded return value of `saveRawData` is no longer needed
- `FileEntry` and `SourceEntry` union types gain variants for the re-ingestion failure case
- `src/__tests__/helpers/type-guards.ts` provides narrow type guards that replace repeated inline `(entry as { failed?: boolean })` casts across test files

## Tests

- New dedicated test file: `src/__tests__/server/async-ingest.test.ts` (10 tests)
- 5 additional tests covering the new behaviours: delete guard during active ingestion, re-ingestion failure visibility, failed `ingest_data` visibility in sources
- All existing tests updated to use `waitForIngestion()` for synchronisation
- **328 tests passing**, full quality gate green (`biome`, `tsc`, `vitest`, unused-exports, circular-deps)

