### PR TITLE
feat: surface config warnings via MCP response annotations

### DIFF
--- a/src/__tests__/server/config-warnings.test.ts
+++ b/src/__tests__/server/config-warnings.test.ts
@@ -1,0 +1,262 @@
+// Configuration Warnings Test
+// Test Type: Unit Test (parsers) + Integration Test (warning delivery via MCP annotations)
+
+import { mkdir, rm } from 'node:fs/promises'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RAGServer } from '../../server/index.js'
+import {
+  parseGroupingMode,
+  parseHybridWeight,
+  parseMaxDistance,
+  parseMaxFiles,
+} from '../../server-main.js'
+
+// ============================================
+// Unit Tests: Parser Functions
+// ============================================
+
+describe('parseGroupingMode', () => {
+  it('returns undefined with no warning for empty input', () => {
+    expect(parseGroupingMode(undefined)).toEqual({ value: undefined })
+    expect(parseGroupingMode('')).toEqual({ value: undefined })
+  })
+
+  it('returns valid grouping modes', () => {
+    expect(parseGroupingMode('similar')).toEqual({ value: 'similar' })
+    expect(parseGroupingMode('related')).toEqual({ value: 'related' })
+    expect(parseGroupingMode('SIMILAR')).toEqual({ value: 'similar' })
+    expect(parseGroupingMode(' Related ')).toEqual({ value: 'related' })
+  })
+
+  it('returns warning for invalid values', () => {
+    const result = parseGroupingMode('invalid')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_GROUPING')
+    expect(result.warning).toContain('"invalid"')
+  })
+})
+
+describe('parseMaxDistance', () => {
+  it('returns undefined with no warning for empty input', () => {
+    expect(parseMaxDistance(undefined)).toEqual({ value: undefined })
+    expect(parseMaxDistance('')).toEqual({ value: undefined })
+  })
+
+  it('returns valid positive numbers', () => {
+    expect(parseMaxDistance('0.5')).toEqual({ value: 0.5 })
+    expect(parseMaxDistance('1.0')).toEqual({ value: 1.0 })
+    expect(parseMaxDistance('0.001')).toEqual({ value: 0.001 })
+  })
+
+  it('returns warning for zero', () => {
+    const result = parseMaxDistance('0')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_DISTANCE')
+  })
+
+  it('returns warning for negative values', () => {
+    const result = parseMaxDistance('-1')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_DISTANCE')
+  })
+
+  it('returns warning for non-numeric input', () => {
+    const result = parseMaxDistance('abc')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_DISTANCE')
+  })
+
+  it('returns warning for Infinity', () => {
+    const result = parseMaxDistance('Infinity')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_DISTANCE')
+  })
+})
+
+describe('parseMaxFiles', () => {
+  it('returns undefined with no warning for empty input', () => {
+    expect(parseMaxFiles(undefined)).toEqual({ value: undefined })
+    expect(parseMaxFiles('')).toEqual({ value: undefined })
+  })
+
+  it('returns valid positive integers', () => {
+    expect(parseMaxFiles('1')).toEqual({ value: 1 })
+    expect(parseMaxFiles('10')).toEqual({ value: 10 })
+  })
+
+  it('returns warning for zero', () => {
+    const result = parseMaxFiles('0')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_FILES')
+    expect(result.warning).toContain('"0"')
+  })
+
+  it('returns warning for negative values', () => {
+    const result = parseMaxFiles('-1')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_FILES')
+  })
+
+  it('returns warning for non-numeric input', () => {
+    const result = parseMaxFiles('abc')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_MAX_FILES')
+  })
+})
+
+describe('parseHybridWeight', () => {
+  it('returns undefined with no warning for empty input', () => {
+    expect(parseHybridWeight(undefined)).toEqual({ value: undefined })
+    expect(parseHybridWeight('')).toEqual({ value: undefined })
+  })
+
+  it('returns valid values in 0.0-1.0 range', () => {
+    expect(parseHybridWeight('0')).toEqual({ value: 0 })
+    expect(parseHybridWeight('0.5')).toEqual({ value: 0.5 })
+    expect(parseHybridWeight('1')).toEqual({ value: 1 })
+    expect(parseHybridWeight('1.0')).toEqual({ value: 1.0 })
+  })
+
+  it('returns warning for values below 0', () => {
+    const result = parseHybridWeight('-0.1')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_HYBRID_WEIGHT')
+  })
+
+  it('returns warning for values above 1', () => {
+    const result = parseHybridWeight('1.1')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_HYBRID_WEIGHT')
+  })
+
+  it('returns warning for non-numeric input', () => {
+    const result = parseHybridWeight('abc')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid RAG_HYBRID_WEIGHT')
+  })
+})
+
+// ============================================
+// Integration Tests: Warning Delivery via MCP Annotations
+// ============================================
+
+const testDbPath = './tmp/test-config-warnings-db'
+const baseConfig = {
+  dbPath: testDbPath,
+  modelName: 'Xenova/all-MiniLM-L6-v2',
+  cacheDir: './tmp/test-model-cache',
+  baseDir: '.',
+  maxFileSize: 10 * 1024 * 1024,
+}
+
+describe('Config warning delivery via MCP annotations', () => {
+  afterAll(async () => {
+    await rm(testDbPath, { recursive: true, force: true })
+  })
+
+  describe('status tool', () => {
+    let server: RAGServer
+
+    beforeAll(async () => {
+      await mkdir(testDbPath, { recursive: true })
+      server = new RAGServer({
+        ...baseConfig,
+        configWarnings: [
+          'Invalid RAG_MAX_FILES value: "0". Expected positive integer (>= 1). Ignoring.',
+        ],
+      })
+      await server.initialize()
+    })
+
+    it('always includes warning content blocks with annotations', async () => {
+      const result = await server.handleStatus()
+
+      expect(result.content.length).toBe(2)
+
+      const warningBlock = result.content[1]
+      expect(warningBlock?.text).toContain('Warning:')
+      expect(warningBlock?.text).toContain('RAG_MAX_FILES')
+      expect(warningBlock?.annotations).toEqual({
+        audience: ['user', 'assistant'],
+        priority: 0.3,
+      })
+    })
+
+    it('includes warnings on repeated status calls', async () => {
+      const result1 = await server.handleStatus()
+      const result2 = await server.handleStatus()
+
+      expect(result1.content.length).toBe(2)
+      expect(result2.content.length).toBe(2)
+    })
+  })
+
+  describe('status tool without warnings', () => {
+    let server: RAGServer
+
+    beforeAll(async () => {
+      await mkdir(testDbPath, { recursive: true })
+      server = new RAGServer(baseConfig)
+      await server.initialize()
+    })
+
+    it('returns only status data when no config warnings exist', async () => {
+      const result = await server.handleStatus()
+      expect(result.content.length).toBe(1)
+      expect(result.content[0]?.text).not.toContain('Warning:')
+    })
+  })
+
+  describe('query_documents tool', () => {
+    let server: RAGServer
+
+    beforeAll(async () => {
+      await mkdir(testDbPath, { recursive: true })
+      server = new RAGServer({
+        ...baseConfig,
+        configWarnings: [
+          'Invalid RAG_MAX_DISTANCE value: "-1". Expected positive number. Ignoring.',
+        ],
+      })
+      await server.initialize()
+    })
+
+    it('includes warnings on first query call only', async () => {
+      const result1 = await server.handleQueryDocuments({ query: 'test' })
+      expect(result1.content.length).toBe(2)
+      expect(result1.content[1]?.text).toContain('Warning:')
+      expect(result1.content[1]?.annotations).toEqual({
+        audience: ['user', 'assistant'],
+        priority: 0.3,
+      })
+
+      const result2 = await server.handleQueryDocuments({ query: 'test again' })
+      expect(result2.content.length).toBe(1)
+    })
+  })
+
+  describe('multiple warnings', () => {
+    let server: RAGServer
+
+    beforeAll(async () => {
+      await mkdir(testDbPath, { recursive: true })
+      server = new RAGServer({
+        ...baseConfig,
+        configWarnings: [
+          'Invalid RAG_MAX_FILES value: "0". Expected positive integer (>= 1). Ignoring.',
+          'Invalid RAG_HYBRID_WEIGHT value: "2.0". Expected 0.0-1.0. Using default (0.6).',
+        ],
+      })
+      await server.initialize()
+    })
+
+    it('combines multiple warnings into a single content block', async () => {
+      const result = await server.handleStatus()
+      const warningBlock = result.content[1]
+
+      expect(warningBlock?.text).toContain('RAG_MAX_FILES')
+      expect(warningBlock?.text).toContain('RAG_HYBRID_WEIGHT')
+      expect(warningBlock?.text).toContain(' | ')
+    })
+  })
+})

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -6,62 +6,62 @@ import type { GroupingMode } from './vectordb/index.js'
 // Environment Variable Parsers
 // ============================================
 
+/** Result of parsing an environment variable */
+export interface ParseResult<T> {
+  value: T | undefined
+  warning?: string
+}
+
 /**
  * Parse grouping mode from environment variable
  */
-function parseGroupingMode(value: string | undefined): GroupingMode | undefined {
-  if (!value) return undefined
+export function parseGroupingMode(value: string | undefined): ParseResult<GroupingMode> {
+  if (!value) return { value: undefined }
   const normalized = value.toLowerCase().trim()
   if (normalized === 'similar' || normalized === 'related') {
-    return normalized
+    return { value: normalized }
   }
-  console.error(
-    `Invalid RAG_GROUPING value: "${value}". Expected "similar" or "related". Ignoring.`
-  )
-  return undefined
+  const warning = `Invalid RAG_GROUPING value: "${value}". Expected "similar" or "related". Ignoring.`
+  return { value: undefined, warning }
 }
 
 /**
  * Parse max distance from environment variable
  */
-function parseMaxDistance(value: string | undefined): number | undefined {
-  if (!value) return undefined
+export function parseMaxDistance(value: string | undefined): ParseResult<number> {
+  if (!value) return { value: undefined }
   const parsed = Number.parseFloat(value)
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    console.error(`Invalid RAG_MAX_DISTANCE value: "${value}". Expected positive number. Ignoring.`)
-    return undefined
+  if (Number.isNaN(parsed) || parsed <= 0 || !Number.isFinite(parsed)) {
+    const warning = `Invalid RAG_MAX_DISTANCE value: "${value}". Expected positive number. Ignoring.`
+    return { value: undefined, warning }
   }
-  return parsed
+  return { value: parsed }
 }
 
 /**
  * Parse max files from environment variable
  */
-function parseMaxFiles(value: string | undefined): number | undefined {
-  if (!value) return undefined
+export function parseMaxFiles(value: string | undefined): ParseResult<number> {
+  if (!value) return { value: undefined }
   const parsed = Number.parseInt(value, 10)
   if (Number.isNaN(parsed) || parsed < 1) {
-    console.error(
-      `Invalid RAG_MAX_FILES value: "${value}". Expected positive integer (>= 1). Ignoring.`
-    )
-    return undefined
+    const warning = `Invalid RAG_MAX_FILES value: "${value}". Expected positive integer (>= 1). Ignoring.`
+    return { value: undefined, warning }
   }
-  return parsed
+  return { value: parsed }
 }
 
 /**
  * Parse hybrid weight from environment variable
  */
-function parseHybridWeight(value: string | undefined): number | undefined {
-  if (!value) return undefined
+export function parseHybridWeight(value: string | undefined): ParseResult<number> {
+  if (!value) return { value: undefined }
   const parsed = Number.parseFloat(value)
   if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
-    console.error(
-      `Invalid RAG_HYBRID_WEIGHT value: "${value}". Expected 0.0-1.0. Using default (0.6).`
-    )
-    return undefined
+    const warning = `Invalid RAG_HYBRID_WEIGHT value: "${value}". Expected 0.0-1.0. Using default (0.6).`
+    return { value: undefined, warning }
   }
-  return parsed
+  return { value: parsed }
 }
 
 // ============================================
@@ -82,22 +82,42 @@ export async function startServer(): Promise<void> {
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
     }
 
+    // Collect configuration warnings
+    const configWarnings: string[] = []
+
     // Add quality filter settings only if defined
     const maxDistance = parseMaxDistance(process.env['RAG_MAX_DISTANCE'])
     const grouping = parseGroupingMode(process.env['RAG_GROUPING'])
     const maxFiles = parseMaxFiles(process.env['RAG_MAX_FILES'])
     const hybridWeight = parseHybridWeight(process.env['RAG_HYBRID_WEIGHT'])
-    if (maxDistance !== undefined) {
-      config.maxDistance = maxDistance
+    if (maxDistance.value !== undefined) {
+      config.maxDistance = maxDistance.value
     }
-    if (grouping !== undefined) {
-      config.grouping = grouping
+    if (maxDistance.warning) {
+      configWarnings.push(maxDistance.warning)
     }
-    if (maxFiles !== undefined) {
-      config.maxFiles = maxFiles
+    if (grouping.value !== undefined) {
+      config.grouping = grouping.value
     }
-    if (hybridWeight !== undefined) {
-      config.hybridWeight = hybridWeight
+    if (grouping.warning) {
+      configWarnings.push(grouping.warning)
+    }
+    if (maxFiles.value !== undefined) {
+      config.maxFiles = maxFiles.value
+    }
+    if (maxFiles.warning) {
+      configWarnings.push(maxFiles.warning)
+    }
+    if (hybridWeight.value !== undefined) {
+      config.hybridWeight = hybridWeight.value
+    }
+    if (hybridWeight.warning) {
+      configWarnings.push(hybridWeight.warning)
+    }
+
+    if (configWarnings.length > 0) {
+      config.configWarnings = configWarnings
+      console.error('Configuration warnings:', configWarnings.join(' | '))
     }
 
     console.error('Starting RAG MCP Server...')

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import { extname, join, resolve } from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
+  type Annotations,
   CallToolRequestSchema,
   ErrorCode,
   ListToolsRequestSchema,
@@ -53,10 +54,13 @@ export class RAGServer {
   private readonly baseDir: string
   // Used by handleListFiles filter to exclude system-managed directories
   private readonly excludePaths: string[]
+  private readonly configWarnings: string[]
+  private queryWarningsShown = false
 
   constructor(config: RAGServerConfig) {
     this.dbPath = config.dbPath
     this.baseDir = config.baseDir
+    this.configWarnings = config.configWarnings ?? []
     this.excludePaths = [`${resolve(config.dbPath)}/`, `${resolve(config.cacheDir)}/`]
     this.server = new Server(
       { name: 'rag-mcp-server', version: '1.0.0' },
@@ -94,6 +98,28 @@ export class RAGServer {
     })
 
     this.setupHandlers()
+  }
+
+  /**
+   * Build warning content blocks with MCP annotations.
+   * Returns an empty array if no warnings exist.
+   */
+  private buildWarningContentBlocks(): Array<{
+    type: 'text'
+    text: string
+    annotations: Annotations
+  }> {
+    if (this.configWarnings.length === 0) return []
+    return [
+      {
+        type: 'text' as const,
+        text: `Warning: ${this.configWarnings.join(' | ')}`,
+        annotations: {
+          audience: ['user', 'assistant'] as const,
+          priority: 0.3,
+        },
+      },
+    ]
   }
 
   /**
@@ -150,7 +176,7 @@ export class RAGServer {
    */
   async handleQueryDocuments(
     args: QueryDocumentsInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  ): Promise<{ content: Array<{ type: 'text'; text: string; annotations?: Annotations }> }> {
     try {
       // Generate query embedding
       const queryVector = await this.embedder.embed(args.query)
@@ -179,14 +205,20 @@ export class RAGServer {
         return queryResult
       })
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(results, null, 2),
-          },
-        ],
+      const content: Array<{ type: 'text'; text: string; annotations?: Annotations }> = [
+        {
+          type: 'text',
+          text: JSON.stringify(results, null, 2),
+        },
+      ]
+
+      // Append config warnings on first query call only
+      if (!this.queryWarningsShown) {
+        content.push(...this.buildWarningContentBlocks())
+        this.queryWarningsShown = true
       }
+
+      return { content }
     } catch (error) {
       console.error('Failed to query documents:', error)
       throw error
@@ -492,17 +524,22 @@ export class RAGServer {
   /**
    * status tool handler (Phase 1: basic implementation)
    */
-  async handleStatus(): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  async handleStatus(): Promise<{
+    content: Array<{ type: 'text'; text: string; annotations?: Annotations }>
+  }> {
     try {
       const status = await this.vectorStore.getStatus()
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(status, null, 2),
-          },
-        ],
-      }
+      const content: Array<{ type: 'text'; text: string; annotations?: Annotations }> = [
+        {
+          type: 'text',
+          text: JSON.stringify(status, null, 2),
+        },
+      ]
+
+      // Always append config warnings to status responses
+      content.push(...this.buildWarningContentBlocks())
+
+      return { content }
     } catch (error) {
       console.error('Failed to get status:', error)
       throw error

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -25,6 +25,8 @@ export interface RAGServerConfig {
   hybridWeight?: number
   /** Maximum number of files to keep in search results (optional) */
   maxFiles?: number
+  /** Configuration validation warnings to surface to users via MCP annotations */
+  configWarnings?: string[]
 }
 
 /**


### PR DESCRIPTION
## Summary

- Refactor env variable parsers to return `ParseResult<T>` with optional warning string instead of logging to stderr (invisible to MCP clients)
- Collect config validation warnings at startup and pass via `RAGServerConfig.configWarnings`
- Append annotated warning content blocks to `status` (always) and `query_documents` (first call only) responses using MCP `Annotations` (`audience: ["user", "assistant"], priority: 0.3`)
- Fix `parseMaxDistance` accepting `Infinity` as valid input

## Test plan

- [x] Unit tests for all 4 parser functions (valid, invalid, boundary, edge cases including Infinity)
- [x] Integration tests: `status` includes warnings, `query_documents` first-call-only behavior, no warnings when config is valid, multiple warnings combined
- [x] Manual verification via stdio: confirmed annotations appear in JSON-RPC response
- [x] All 357 tests pass, TypeScript type check, Biome lint, build all green

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)