### PR TITLE
fix: enable read consistency for external database modifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -44,7 +44,11 @@ export class VectorStore {
   async initialize(): Promise<void> {
     try {
       // Connect to LanceDB
-      this.db = await connect(this.config.dbPath)
+      // readConsistencyInterval: 0 ensures every read checks for external changes.
+      // Without this, a cached Table object becomes stale when another process
+      // (e.g., CLI ingestion from a different terminal) modifies the database,
+      // causing "Failed to search vectors" errors until restart.
+      this.db = await connect(this.config.dbPath, { readConsistencyInterval: 0 })
 
       // Check table existence and create if needed
       const tableNames = await this.db.tableNames()


### PR DESCRIPTION
## Summary

- Set `readConsistencyInterval: 0` on LanceDB `connect()` so every read checks for external updates
- Fixes stale `Table` object when another process (e.g., CLI ingestion from a different terminal) modifies the database
- Bump version to 0.8.1

## Root Cause

`VectorStore` opens the table once during `initialize()` and caches it. Without `readConsistencyInterval`, LanceDB defaults to never checking for external changes, so the cached table becomes stale and queries fail with "Failed to search vectors".

## Benchmarks

Overhead of `readConsistencyInterval: 0` (checked every read) vs no interval:

| Chunks | No interval | interval=0 | Overhead |
|--------|------------|------------|----------|
| 100 | 0.460ms | 0.435ms | ~0ms |
| 1,000 | 0.497ms | 0.512ms | +0.015ms |
| 5,000 | 0.892ms | 0.913ms | +0.020ms |
| 10,000 | 2.222ms | 2.265ms | +0.043ms |

Overhead is constant (~0.03ms) regardless of data size — it only checks a version metadata file.

## Test plan

- [x] All 355 existing tests pass
- [x] `pnpm run check:all` passes (lint, format, build, test)
- [x] Verified with a test script that `readConsistencyInterval: 0` correctly detects external changes while the default does not

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)