### PR TITLE
feat: add configurable minChunkLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Both MCP and CLI use the same environment variables. The CLI also accepts equiva
 | `CACHE_DIR` | `--cache-dir` | `./models/` | Model cache directory |
 | `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model ID ([available models](https://huggingface.co/models?library=transformers.js&pipeline_tag=feature-extraction)) |
 | `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100MB) | Maximum file size in bytes |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Minimum chunk length in characters (1–10000) |
 
 **Model choice tips:**
 - Multilingual docs → e.g., `onnx-community/embeddinggemma-300m-ONNX` (100+ languages)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.11.1",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },
@@ -71,6 +71,13 @@
         {
           "name": "RAG_MAX_FILES",
           "description": "Maximum number of files to keep in search results. Results are filtered to include only chunks from the top N best-scoring files. For example, 1 returns only the single best-matching file's chunks. Unset means no file filtering.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "CHUNK_MIN_LENGTH",
+          "description": "Minimum chunk length in characters (1-10000, defaults to 50). Chunks shorter than this threshold are filtered out during ingestion.",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -876,6 +876,32 @@ describe('CLI ingest', () => {
         errorSpy.mockRestore()
       }
     })
+
+    it('should parse --chunk-min-length flag', () => {
+      const result = parseArgs(['--chunk-min-length', '100', '/target'])
+      expect(result.positional).toBe('/target')
+      expect(result.options.chunkMinLength).toBe(100)
+    })
+
+    it('should error when --chunk-min-length value is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--chunk-min-length'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('Missing value for --chunk-min-length')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
+    it('should error when --chunk-min-length value is non-numeric', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--chunk-min-length', 'abc', '/target'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('Invalid value for --chunk-min-length: "abc"')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
   })
 
   // --------------------------------------------
@@ -916,6 +942,7 @@ describe('CLI ingest', () => {
     afterEach(() => {
       delete process.env['BASE_DIR']
       delete process.env['MAX_FILE_SIZE']
+      delete process.env['CHUNK_MIN_LENGTH']
     })
 
     it('should error when BASE_DIR env var points to sensitive path', () => {
@@ -992,6 +1019,60 @@ describe('CLI ingest', () => {
         expect(() => resolveConfig(globalConfig, { maxFileSize: 0 })).toThrow('process.exit(1)')
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 524288000')
+        )
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
+    it('should resolve chunkMinLength from CLI option', () => {
+      const globalConfig = resolveGlobalConfig({})
+      const result = resolveConfig(globalConfig, { chunkMinLength: 200 })
+      expect(result.chunkMinLength).toBe(200)
+    })
+
+    it('should resolve chunkMinLength from CHUNK_MIN_LENGTH env var', () => {
+      process.env['CHUNK_MIN_LENGTH'] = '300'
+      const globalConfig = resolveGlobalConfig({})
+      const result = resolveConfig(globalConfig)
+      expect(result.chunkMinLength).toBe(300)
+    })
+
+    it('should prefer CLI chunkMinLength over env var', () => {
+      process.env['CHUNK_MIN_LENGTH'] = '300'
+      const globalConfig = resolveGlobalConfig({})
+      const result = resolveConfig(globalConfig, { chunkMinLength: 100 })
+      expect(result.chunkMinLength).toBe(100)
+    })
+
+    it('should leave chunkMinLength undefined when not specified', () => {
+      const globalConfig = resolveGlobalConfig({})
+      const result = resolveConfig(globalConfig)
+      expect(result.chunkMinLength).toBeUndefined()
+    })
+
+    it('should error when --chunk-min-length CLI option is zero', () => {
+      const globalConfig = resolveGlobalConfig({})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => resolveConfig(globalConfig, { chunkMinLength: 0 })).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('must be between 1 and 10000')
+        )
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
+    it('should error when --chunk-min-length CLI option exceeds 10000', () => {
+      const globalConfig = resolveGlobalConfig({})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => resolveConfig(globalConfig, { chunkMinLength: 10001 })).toThrow(
+          'process.exit(1)'
+        )
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('must be between 1 and 10000')
         )
       } finally {
         errorSpy.mockRestore()

--- a/src/__tests__/server/config-warnings.test.ts
+++ b/src/__tests__/server/config-warnings.test.ts
@@ -5,6 +5,7 @@ import { mkdir, rm } from 'node:fs/promises'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RAGServer } from '../../server/index.js'
 import {
+  parseChunkMinLength,
   parseGroupingMode,
   parseHybridWeight,
   parseMaxDistance,
@@ -133,6 +134,52 @@ describe('parseHybridWeight', () => {
     const result = parseHybridWeight('abc')
     expect(result.value).toBeUndefined()
     expect(result.warning).toContain('Invalid RAG_HYBRID_WEIGHT')
+  })
+})
+
+describe('parseChunkMinLength', () => {
+  it('returns undefined with no warning for empty input', () => {
+    expect(parseChunkMinLength(undefined)).toEqual({ value: undefined })
+    expect(parseChunkMinLength('')).toEqual({ value: undefined })
+  })
+
+  it('returns valid integer values', () => {
+    expect(parseChunkMinLength('100')).toEqual({ value: 100 })
+    expect(parseChunkMinLength('50')).toEqual({ value: 50 })
+  })
+
+  it('returns valid boundary values', () => {
+    expect(parseChunkMinLength('1')).toEqual({ value: 1 })
+    expect(parseChunkMinLength('10000')).toEqual({ value: 10000 })
+  })
+
+  it('returns warning for value below minimum', () => {
+    const result = parseChunkMinLength('0')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid CHUNK_MIN_LENGTH')
+  })
+
+  it('returns warning for negative value', () => {
+    const result = parseChunkMinLength('-1')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid CHUNK_MIN_LENGTH')
+  })
+
+  it('returns warning for value above maximum', () => {
+    const result = parseChunkMinLength('10001')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid CHUNK_MIN_LENGTH')
+  })
+
+  it('returns warning for non-numeric input', () => {
+    const result = parseChunkMinLength('abc')
+    expect(result.value).toBeUndefined()
+    expect(result.warning).toContain('Invalid CHUNK_MIN_LENGTH')
+  })
+
+  it('truncates float input to integer via parseInt', () => {
+    // parseInt('50.5') returns 50, which is valid — consistent with parseMaxFiles behavior
+    expect(parseChunkMinLength('50.5')).toEqual({ value: 50 })
   })
 })
 

--- a/src/chunker/index.ts
+++ b/src/chunker/index.ts
@@ -8,4 +8,4 @@ export interface TextChunk {
   index: number
 }
 
-export { SemanticChunker } from './semantic-chunker.js'
+export { DEFAULT_MIN_CHUNK_LENGTH, SemanticChunker } from './semantic-chunker.js'

--- a/src/chunker/semantic-chunker.ts
+++ b/src/chunker/semantic-chunker.ts
@@ -87,11 +87,14 @@ export function isGarbageChunk(text: string): boolean {
 // Default Configuration
 // ============================================
 
+/** Default minimum chunk length in characters */
+export const DEFAULT_MIN_CHUNK_LENGTH = 50
+
 const DEFAULT_SEMANTIC_CHUNKER_CONFIG: SemanticChunkerConfig = {
   hardThreshold: 0.6,
   initConst: 1.5,
   c: 0.9,
-  minChunkLength: 50,
+  minChunkLength: DEFAULT_MIN_CHUNK_LENGTH,
 }
 
 // ============================================

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -10,7 +10,12 @@ import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import type { VectorChunk, VectorStore } from '../vectordb/index.js'
 import { createEmbedder, createVectorStore } from './common.js'
 import type { GlobalOptions, ResolvedGlobalConfig } from './options.js'
-import { resolveGlobalConfig, validateMaxFileSize, validatePath } from './options.js'
+import {
+  resolveGlobalConfig,
+  validateChunkMinLength,
+  validateMaxFileSize,
+  validatePath,
+} from './options.js'
 
 // ============================================
 // Constants
@@ -28,6 +33,7 @@ interface IngestConfig {
   cacheDir: string
   modelName: string
   maxFileSize: number
+  chunkMinLength?: number
 }
 
 interface IngestSummary {
@@ -39,6 +45,7 @@ interface IngestSummary {
 interface IngestCliOptions {
   baseDir?: string | undefined
   maxFileSize?: number | undefined
+  chunkMinLength?: number | undefined
 }
 
 interface ParsedArgs {
@@ -64,14 +71,15 @@ const HELP_TEXT = `Usage: mcp-local-rag [global-options] ingest [options] <path>
 Ingest a single file or all supported files under a directory.
 
 Options:
-  --base-dir <path>      Base directory for documents (default: cwd)
-  --max-file-size <n>    Max file size in bytes (default: ${INGEST_DEFAULTS.maxFileSize})
-  -h, --help             Show this help
+  --base-dir <path>        Base directory for documents (default: cwd)
+  --max-file-size <n>      Max file size in bytes (default: ${INGEST_DEFAULTS.maxFileSize})
+  --chunk-min-length <n>   Minimum chunk length in characters (default: 50, range: 1-10000)
+  -h, --help               Show this help
 
 Global options (must appear before "ingest"):
-  --db-path <path>       LanceDB database path
-  --cache-dir <path>     Model cache directory
-  --model-name <name>    Embedding model`
+  --db-path <path>         LanceDB database path
+  --cache-dir <path>       Model cache directory
+  --model-name <name>      Embedding model`
 
 // ============================================
 // Arg Parsing
@@ -113,10 +121,26 @@ export function parseArgs(args: string[]): ParsedArgs {
           process.exit(1)
         }
         if (!/^\d+$/.test(raw)) {
-          console.error(`Invalid value for --max-file-size: "${raw}"`)
+          console.error(`Invalid value for --max-file-size: "${raw.slice(0, 100)}"`)
+
           process.exit(1)
         }
         options.maxFileSize = Number.parseInt(raw, 10)
+        i++
+        break
+      }
+      case '--chunk-min-length': {
+        const raw = args[++i]
+        if (raw === undefined || raw.startsWith('-')) {
+          console.error('Missing value for --chunk-min-length')
+          process.exit(1)
+        }
+        if (!/^\d+$/.test(raw)) {
+          console.error(`Invalid value for --chunk-min-length: "${raw.slice(0, 100)}"`)
+
+          process.exit(1)
+        }
+        options.chunkMinLength = Number.parseInt(raw, 10)
         i++
         break
       }
@@ -159,6 +183,11 @@ export function resolveConfig(
     (process.env['MAX_FILE_SIZE']
       ? Number.parseInt(process.env['MAX_FILE_SIZE'], 10)
       : INGEST_DEFAULTS.maxFileSize)
+  const chunkMinLength =
+    ingestOptions.chunkMinLength ??
+    (process.env['CHUNK_MIN_LENGTH']
+      ? Number.parseInt(process.env['CHUNK_MIN_LENGTH'], 10)
+      : undefined)
 
   // Validate baseDir path
   const baseDirError = validatePath(baseDir, '--base-dir')
@@ -174,13 +203,26 @@ export function resolveConfig(
     process.exit(1)
   }
 
-  return {
+  // Validate chunkMinLength range (if provided)
+  if (chunkMinLength !== undefined) {
+    const chunkMinLengthError = validateChunkMinLength(chunkMinLength)
+    if (chunkMinLengthError) {
+      console.error(chunkMinLengthError)
+      process.exit(1)
+    }
+  }
+
+  const resolved: IngestConfig = {
     dbPath: globalConfig.dbPath,
     cacheDir: globalConfig.cacheDir,
     modelName: globalConfig.modelName,
     baseDir,
     maxFileSize,
   }
+  if (chunkMinLength !== undefined) {
+    resolved.chunkMinLength = chunkMinLength
+  }
+  return resolved
 }
 
 // ============================================
@@ -384,7 +426,9 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
     baseDir: config.baseDir,
     maxFileSize: config.maxFileSize,
   })
-  const chunker = new SemanticChunker()
+  const chunker = new SemanticChunker(
+    config.chunkMinLength !== undefined ? { minChunkLength: config.chunkMinLength } : {}
+  )
   const embedder = createEmbedder(globalConfig)
   const vectorStore = createVectorStore(globalConfig)
   await vectorStore.initialize()

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -66,6 +66,17 @@ export function validateMaxFileSize(value: number): string | undefined {
   return undefined
 }
 
+/**
+ * Validate chunk minimum length is within acceptable range.
+ * Returns an error message if invalid, or undefined if valid.
+ */
+export function validateChunkMinLength(value: number): string | undefined {
+  if (!Number.isFinite(value) || value < 1 || value > 10000) {
+    return '--chunk-min-length must be between 1 and 10000'
+  }
+  return undefined
+}
+
 // ============================================
 // Types
 // ============================================

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -21,7 +21,7 @@ export function parseGroupingMode(value: string | undefined): ParseResult<Groupi
   if (normalized === 'similar' || normalized === 'related') {
     return { value: normalized }
   }
-  const warning = `Invalid RAG_GROUPING value: "${value}". Expected "similar" or "related". Ignoring.`
+  const warning = `Invalid RAG_GROUPING value: "${value.slice(0, 100)}". Expected "similar" or "related". Ignoring.`
   return { value: undefined, warning }
 }
 
@@ -32,7 +32,7 @@ export function parseMaxDistance(value: string | undefined): ParseResult<number>
   if (!value) return { value: undefined }
   const parsed = Number.parseFloat(value)
   if (Number.isNaN(parsed) || parsed <= 0 || !Number.isFinite(parsed)) {
-    const warning = `Invalid RAG_MAX_DISTANCE value: "${value}". Expected positive number. Ignoring.`
+    const warning = `Invalid RAG_MAX_DISTANCE value: "${value.slice(0, 100)}". Expected positive number. Ignoring.`
     return { value: undefined, warning }
   }
   return { value: parsed }
@@ -45,7 +45,7 @@ export function parseMaxFiles(value: string | undefined): ParseResult<number> {
   if (!value) return { value: undefined }
   const parsed = Number.parseInt(value, 10)
   if (Number.isNaN(parsed) || parsed < 1) {
-    const warning = `Invalid RAG_MAX_FILES value: "${value}". Expected positive integer (>= 1). Ignoring.`
+    const warning = `Invalid RAG_MAX_FILES value: "${value.slice(0, 100)}". Expected positive integer (>= 1). Ignoring.`
     return { value: undefined, warning }
   }
   return { value: parsed }
@@ -58,7 +58,20 @@ export function parseHybridWeight(value: string | undefined): ParseResult<number
   if (!value) return { value: undefined }
   const parsed = Number.parseFloat(value)
   if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
-    const warning = `Invalid RAG_HYBRID_WEIGHT value: "${value}". Expected 0.0-1.0. Using default (0.6).`
+    const warning = `Invalid RAG_HYBRID_WEIGHT value: "${value.slice(0, 100)}". Expected 0.0-1.0. Using default (0.6).`
+    return { value: undefined, warning }
+  }
+  return { value: parsed }
+}
+
+/**
+ * Parse chunk minimum length from environment variable
+ */
+export function parseChunkMinLength(value: string | undefined): ParseResult<number> {
+  if (!value) return { value: undefined }
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 10000) {
+    const warning = `Invalid CHUNK_MIN_LENGTH value: "${value.slice(0, 100)}". Expected integer between 1 and 10000. Ignoring.`
     return { value: undefined, warning }
   }
   return { value: parsed }
@@ -90,6 +103,7 @@ export async function startServer(): Promise<void> {
     const grouping = parseGroupingMode(process.env['RAG_GROUPING'])
     const maxFiles = parseMaxFiles(process.env['RAG_MAX_FILES'])
     const hybridWeight = parseHybridWeight(process.env['RAG_HYBRID_WEIGHT'])
+    const chunkMinLength = parseChunkMinLength(process.env['CHUNK_MIN_LENGTH'])
     if (maxDistance.value !== undefined) {
       config.maxDistance = maxDistance.value
     }
@@ -113,6 +127,12 @@ export async function startServer(): Promise<void> {
     }
     if (hybridWeight.warning) {
       configWarnings.push(hybridWeight.warning)
+    }
+    if (chunkMinLength.value !== undefined) {
+      config.chunkMinLength = chunkMinLength.value
+    }
+    if (chunkMinLength.warning) {
+      configWarnings.push(chunkMinLength.warning)
     }
 
     if (configWarnings.length > 0) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,7 @@ import {
   ListToolsRequestSchema,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js'
-import { SemanticChunker } from '../chunker/index.js'
+import { DEFAULT_MIN_CHUNK_LENGTH, SemanticChunker } from '../chunker/index.js'
 import { Embedder } from '../embedder/index.js'
 import { parseHtml } from '../parser/html-parser.js'
 import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
@@ -55,12 +55,14 @@ export class RAGServer {
   // Used by handleListFiles filter to exclude system-managed directories
   private readonly excludePaths: string[]
   private readonly configWarnings: string[]
+  private readonly minChunkLength: number
   private queryWarningsShown = false
 
   constructor(config: RAGServerConfig) {
     this.dbPath = config.dbPath
     this.baseDir = config.baseDir
     this.configWarnings = config.configWarnings ?? []
+    this.minChunkLength = config.chunkMinLength ?? DEFAULT_MIN_CHUNK_LENGTH
     this.excludePaths = [`${resolve(config.dbPath)}/`, `${resolve(config.cacheDir)}/`]
     this.server = new Server(
       { name: 'rag-mcp-server', version: '1.0.0' },
@@ -91,7 +93,9 @@ export class RAGServer {
       batchSize: 16,
       cacheDir: config.cacheDir,
     })
-    this.chunker = new SemanticChunker()
+    this.chunker = new SemanticChunker(
+      config.chunkMinLength !== undefined ? { minChunkLength: config.chunkMinLength } : {}
+    )
     this.parser = new DocumentParser({
       baseDir: config.baseDir,
       maxFileSize: config.maxFileSize,
@@ -264,7 +268,7 @@ export class RAGServer {
       if (chunks.length === 0) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          `No chunks generated from file: ${args.filePath}. The file may be empty or all content was filtered (minimum 50 characters required). Existing data has been preserved.`
+          `No chunks generated from file: ${args.filePath}. The file may be empty or all content was filtered (minimum ${this.minChunkLength} characters required). Existing data has been preserved.`
         )
       }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -25,6 +25,8 @@ export interface RAGServerConfig {
   hybridWeight?: number
   /** Maximum number of files to keep in search results (optional) */
   maxFiles?: number
+  /** Minimum chunk length in characters (optional, default: 50) */
+  chunkMinLength?: number
   /** Configuration validation warnings to surface to users via MCP annotations */
   configWarnings?: string[]
 }


### PR DESCRIPTION
## Summary

- Add `CHUNK_MIN_LENGTH` env var and `--chunk-min-length` CLI flag to configure minimum chunk length (range: 1–10,000, default: 50)
- Export `DEFAULT_MIN_CHUNK_LENGTH` from chunker as single source of truth — eliminates the scattered-default bug identified in PR #91
- CLI rejects invalid input with error (fail-fast); env var warns and ignores (consistent with existing parsers)
- Update error message in `server/index.ts` to reflect actual configured value instead of hardcoded "50"
- Truncate user input to 100 chars in all env var/CLI warning messages (security hardening, applied to all existing parsers)
- Bump version to 0.12.0

Supersedes #91. Thanks to @rkmmadm and @Vinit-source for the original contribution and iteration.

### Files changed (12)

| File | Change |
|------|--------|
| `src/chunker/semantic-chunker.ts` | Export `DEFAULT_MIN_CHUNK_LENGTH` constant |
| `src/chunker/index.ts` | Re-export from barrel |
| `src/server/types.ts` | Add `chunkMinLength?` to `RAGServerConfig` |
| `src/server-main.ts` | Add `parseChunkMinLength()` + wire to config |
| `src/server/index.ts` | Pass config to `SemanticChunker`; dynamic error message |
| `src/cli/options.ts` | Add `validateChunkMinLength()` |
| `src/cli/ingest.ts` | Add `--chunk-min-length` flag + env var resolution |
| `src/__tests__/server/config-warnings.test.ts` | 8 tests for `parseChunkMinLength` |
| `src/__tests__/cli/ingest.test.ts` | 9 tests for CLI flag parsing + config resolution |
| `server.json` | Add `CHUNK_MIN_LENGTH` to MCP registry manifest |
| `README.md` | Add to configuration table |
| `package.json` | Bump to 0.12.0 |

## Test plan

- [x] `pnpm run check:all` passes (lint, format, unused exports, circular deps, build, 530 tests)
- [ ] Verify `CHUNK_MIN_LENGTH=100` env var applies to MCP server
- [ ] Verify `--chunk-min-length 100` CLI flag applies to ingest
- [ ] Verify invalid values are rejected (CLI) or warned (env var)
- [ ] Verify default behavior unchanged when neither is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)