### PR TITLE
docs: add maintainer-edit requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ Before submitting a pull request:
 2. **Run `pnpm run check:all`** and ensure everything passes
 3. **Update documentation** if behavior changes
 4. **Keep commits focused** — one logical change per PR
+5. **Enable "Allow edits from maintainers"** when opening your PR — this lets us push small fixes directly and speeds up the review cycle
 
 ## What We Look For
 


### PR DESCRIPTION
## Summary

- Added "Allow edits from maintainers" as a PR requirement in CONTRIBUTING.md
- Enabling this option lets maintainers push small fixes directly, which speeds up the review cycle

## Test plan

- [ ] Verify the new item renders correctly in the PR Requirements list


🤖 Generated with [Claude Code](https://claude.com/claude-code)