### PR TITLE
feat: add read_chunk_neighbors MCP tool and CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ mcp-local-rag provides two interfaces: an **MCP server** for AI coding tools and
 
 ### Using with MCP
 
-The MCP server provides 6 tools: `ingest_file`, `ingest_data`, `query_documents`, `list_files`, `delete_file`, `status`.
+The MCP server provides 7 tools: `ingest_file`, `ingest_data`, `query_documents`, `read_chunk_neighbors`, `list_files`, `delete_file`, `status`.
 
 #### Ingesting Documents
 
@@ -148,6 +148,16 @@ Search uses semantic similarity with keyword boost. This means `useEffect` finds
 
 Results include text content, source file, document title, and relevance score. The document title provides context for each chunk, helping identify which document a result belongs to. Adjust result count with `limit` (1-20, default 10).
 
+#### Expanding Context Around a Result
+
+When a search result needs more surrounding context, use `read_chunk_neighbors` to read the chunks before and after it:
+
+```
+"That result about authentication looks relevant — read the surrounding chunks for the full explanation"
+```
+
+Pass the `filePath` and `chunkIndex` from the search result. The response includes the target chunk (marked `isTarget: true`) plus its neighbors, sorted by chunk index. Defaults to 2 chunks before and 2 after (adjustable up to 50 each).
+
 #### Managing Files
 
 ```
@@ -163,13 +173,14 @@ All MCP tools are also available as CLI commands — no MCP server needed:
 ```bash
 npx mcp-local-rag ingest ./docs/               # Bulk ingest files
 npx mcp-local-rag query "authentication API"    # Search documents
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5  # Expand context
 npx mcp-local-rag list                          # Show ingestion status
 npx mcp-local-rag status                        # Database stats
 npx mcp-local-rag delete ./docs/old.pdf         # Remove content
 npx mcp-local-rag delete --source "https://..."  # Remove by source URL
 ```
 
-`query`, `list`, `status`, and `delete` output JSON to stdout for piping (e.g., `| jq`). `ingest` outputs progress to stderr. Global options (`--db-path`, `--cache-dir`, `--model-name`) go before the subcommand. Run `npx mcp-local-rag --help` for details.
+`query`, `read-neighbors`, `list`, `status`, and `delete` output JSON to stdout for piping (e.g., `| jq`). `ingest` outputs progress to stderr. Global options (`--db-path`, `--cache-dir`, `--model-name`) go before the subcommand. Run `npx mcp-local-rag --help` for details.
 
 > ⚠️ The CLI does **not** read your MCP client config (`mcp.json`, `config.toml`, etc.). Configure the CLI via flags or environment variables as shown below.
 
@@ -476,7 +487,7 @@ pnpm run check:all     # Full quality check
 src/
   index.ts      # Entry point
   server/       # MCP tool handlers
-  cli/          # CLI subcommands (ingest)
+  cli/          # CLI subcommands (ingest, query, list, delete, read-neighbors, etc.)
   parser/       # PDF, DOCX, TXT, MD parsing
   chunker/      # Text splitting
   embedder/     # Transformers.js embeddings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.12.0",
+  "version": "0.13.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },
@@ -90,6 +90,7 @@
             "query_documents",
             "ingest_file",
             "ingest_data",
+            "read_chunk_neighbors",
             "list_files",
             "delete_file",
             "status"

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -15,6 +15,7 @@ description: Ingest, search, list, update, or delete content in a local mcp-loca
 | `delete_file` | `npx mcp-local-rag delete <path>` | Remove ingested content |
 | `list_files` | `npx mcp-local-rag list` | File ingestion status |
 | `status` | `npx mcp-local-rag status` | Database stats |
+| `read_chunk_neighbors` | `npx mcp-local-rag read-neighbors` | After locating a chunk via query_documents or grep, read surrounding context (not a search tool) |
 
 ## Search: Core Rules
 
@@ -82,6 +83,16 @@ Each result includes `fileTitle` (document title extracted from content). Null w
 | Disambiguate chunks | Use fileTitle to identify which document the chunk belongs to |
 | Group related chunks | Same fileTitle = same document context |
 | Deprioritize mismatches | fileTitle unrelated to query AND score > 0.5 → rank lower |
+
+## Context Expansion (read_chunk_neighbors)
+
+`read_chunk_neighbors` (CLI: `read-neighbors`) reads chunks adjacent to a known `chunkIndex` within the same document. It is **not a search tool** and is **not a replacement for `query_documents`**.
+
+Typical workflow:
+
+1. Use `query_documents` (or external `grep`) to find a chunk of interest.
+2. Take that chunk's `filePath` and `chunkIndex`.
+3. Call `read_chunk_neighbors` with those values to read the surrounding chunks.
 
 ## Ingestion
 

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-local-rag
-description: Ingest, search, list, update, or delete content in a local mcp-local-rag index when the user is working with local documents or pasted/fetched HTML, Markdown, or text. Use this skill to choose the right MCP tool or `npx mcp-local-rag` CLI command, formulate effective queries, interpret search scores, and manage source metadata.
+description: Search, ingest, expand chunk context, or manage local documents via a local RAG MCP server (tools: query_documents, read_chunk_neighbors, ingest_file, ingest_data, delete_file, list_files). Use when user says "search my docs", "save this page", "read around that chunk", "what did I save about X", or invokes `npx mcp-local-rag`.
 ---
 
 # MCP Local RAG Skills
@@ -15,7 +15,7 @@ description: Ingest, search, list, update, or delete content in a local mcp-loca
 | `delete_file` | `npx mcp-local-rag delete <path>` | Remove ingested content |
 | `list_files` | `npx mcp-local-rag list` | File ingestion status |
 | `status` | `npx mcp-local-rag status` | Database stats |
-| `read_chunk_neighbors` | `npx mcp-local-rag read-neighbors` | After locating a chunk via query_documents or grep, read surrounding context (not a search tool) |
+| `read_chunk_neighbors` | `npx mcp-local-rag read-neighbors` | Read N chunks adjacent to a known chunkIndex (context expansion; call after `query_documents` or grep) |
 
 ## Search: Core Rules
 
@@ -86,13 +86,22 @@ Each result includes `fileTitle` (document title extracted from content). Null w
 
 ## Context Expansion (read_chunk_neighbors)
 
-`read_chunk_neighbors` (CLI: `read-neighbors`) reads chunks adjacent to a known `chunkIndex` within the same document. It is **not a search tool** and is **not a replacement for `query_documents`**.
+`read_chunk_neighbors` (CLI: `read-neighbors`) is an **on-demand context expansion utility**, not a routine follow-up to every `query_documents` call. Chunks in this index are **semantic units** — sentences or paragraphs grouped by topic via Max-Min semantic chunking, not fixed-size text slices. Reading the chunks immediately before and after a target chunk yields coherent surrounding context, not arbitrary fragments.
 
-Typical workflow:
+Each `query_documents` result item already includes `filePath` and `chunkIndex`. Pass those to `read_chunk_neighbors` to expand a specific hit in place.
 
-1. Use `query_documents` (or external `grep`) to find a chunk of interest.
+Trigger this tool only when one of these signals is present:
+- **Insufficient context for your answer**: during response generation, the target chunk alone is not enough to reach a grounded conclusion (e.g., it references "this approach" or "as shown above" without the referent).
+- **Explicit user request for more context**: the user asks for surrounding detail ("what comes before that?", "read more around that section", "show me the full explanation").
+
+If neither signal is present, stop at the `query_documents` results.
+
+Typical workflow when triggered:
+1. Identify the specific chunk to expand (from a prior `query_documents` hit or `grep`).
 2. Take that chunk's `filePath` and `chunkIndex`.
-3. Call `read_chunk_neighbors` with those values to read the surrounding chunks.
+3. Call `read_chunk_neighbors` with those values; the response contains the target chunk plus its semantic neighbors, sorted by `chunkIndex`.
+
+See [cli-reference.md](references/cli-reference.md#read-neighbors) for output fields and an example.
 
 ## Ingestion
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -132,7 +132,7 @@ Example output (truncated):
 ]
 ```
 
-Out-of-range indices are silently omitted (no error). If no chunks in `[chunkIndex - before, chunkIndex + after]` exist, the response is an empty array.
+Out-of-range indices are filtered; only existing chunks within the document are returned. The response can be an empty array.
 
 ## Config Matching
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -72,6 +72,68 @@ Either `--source` or `<file-path>`, not both. Idempotent (non-existent target ex
 
 Output: JSON to stdout.
 
+### read-neighbors
+
+```bash
+npx mcp-local-rag [global-options] read-neighbors [options]
+```
+
+Read N chunks before and after a target chunk within the same document.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--file-path <abs-path>` | — | File path of ingested content (absolute path) |
+| `--source <id>` | — | Source identifier (for content ingested via `ingest_data`) |
+| `--chunk-index <n>` | — | Target chunk index (zero-based, required, non-negative integer) |
+| `--before <n>` | `2` | Number of chunks before the target (non-negative integer) |
+| `--after <n>` | `2` | Number of chunks after the target (non-negative integer) |
+| `-h, --help` | — | Show usage |
+
+Defaults: `before=2, after=2` (`grep -C 2` convention).
+
+Either `--source` or `--file-path` is required, not both.
+
+Example:
+
+```bash
+npx mcp-local-rag read-neighbors --file-path /abs/path/file.md --chunk-index 12 --before 3 --after 3
+```
+
+Output: JSON array to stdout, sorted ascending by `chunkIndex`. Each item includes `filePath`, `chunkIndex`, `text`, `isTarget`, and `fileTitle`. The item whose `chunkIndex` matches the requested value has `isTarget: true`; all other items (and every item when the target chunk does not exist) have `isTarget: false`. Items from documents ingested via `ingest_data` also include a `source` field.
+
+Example output (truncated):
+
+```json
+[
+  {
+    "filePath": "/abs/path/raw-data/example.com/page.md",
+    "chunkIndex": 10,
+    "text": "Earlier context paragraph...",
+    "isTarget": false,
+    "fileTitle": "Page Title",
+    "source": "https://example.com/page"
+  },
+  {
+    "filePath": "/abs/path/raw-data/example.com/page.md",
+    "chunkIndex": 12,
+    "text": "Target chunk content...",
+    "isTarget": true,
+    "fileTitle": "Page Title",
+    "source": "https://example.com/page"
+  },
+  {
+    "filePath": "/abs/path/raw-data/example.com/page.md",
+    "chunkIndex": 14,
+    "text": "Later context paragraph...",
+    "isTarget": false,
+    "fileTitle": "Page Title",
+    "source": "https://example.com/page"
+  }
+]
+```
+
+Out-of-range indices are silently omitted (no error). If no chunks in `[chunkIndex - before, chunkIndex + after]` exist, the response is an empty array.
+
 ## Config Matching
 
 When operating against an existing database, options must match the MCP server config — especially `--model-name`. Using a different embedding model produces vectors in a different space, silently degrading search quality.

--- a/src/__tests__/cli/read-neighbors.test.ts
+++ b/src/__tests__/cli/read-neighbors.test.ts
@@ -1,0 +1,293 @@
+// CLI read-neighbors Tests
+// Test Type: Unit Test
+// Tests runReadNeighbors functionality with mocked dependencies.
+//
+// AC parity: runReadNeighbors does not instantiate an embedder; this test file
+// does not import createEmbedder. This provides a static-analysis-level guarantee
+// that the read-neighbors CLI path never constructs an embedder.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ============================================
+// Mock Setup (vi.hoisted for isolate: false)
+// ============================================
+
+const mocks = vi.hoisted(() => {
+  return {
+    // VectorStore instance methods used by runReadNeighbors
+    initialize: vi.fn(),
+    getChunksByRange: vi.fn(),
+  }
+})
+
+// Mock cli/common.js (createVectorStore factory).
+// Intentionally omit createEmbedder — runReadNeighbors must never call it.
+vi.mock('../../cli/common.js', () => ({
+  createVectorStore: vi.fn().mockImplementation(() => ({
+    initialize: mocks.initialize,
+    getChunksByRange: mocks.getChunksByRange,
+  })),
+}))
+
+// Import after mocks are set up
+import { runReadNeighbors } from '../../cli/read-neighbors.js'
+
+// ============================================
+// Helpers
+// ============================================
+
+/**
+ * Capture stderr output during a function call.
+ * Uses vi.spyOn on console.error since the implementation writes diagnostics
+ * (help text and errors) via console.error.
+ */
+function captureStderr(fn: () => Promise<void>): Promise<{ output: string[]; error: unknown }> {
+  const output: string[] = []
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    output.push(args.map(String).join(' '))
+  })
+
+  return fn()
+    .then(() => ({ output, error: undefined }))
+    .catch((error: unknown) => ({ output, error }))
+    .finally(() => {
+      spy.mockRestore()
+    })
+}
+
+// ============================================
+// Tests
+// ============================================
+
+describe('CLI read-neighbors', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock process.exit to throw so we can catch it in test code
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: number | string | null | undefined) => {
+        throw new Error(`process.exit(${code})`)
+      })
+    // Spy on process.stdout.write to capture JSON output
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    // Default: VectorStore methods succeed
+    mocks.initialize.mockResolvedValue(undefined)
+    mocks.getChunksByRange.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    exitSpy.mockRestore()
+    stdoutSpy.mockRestore()
+    process.exitCode = undefined
+  })
+
+  // --------------------------------------------
+  // Test 1 — --help prints HELP_TEXT and exit 0
+  // --------------------------------------------
+  it('should print HELP_TEXT and exit 0 when --help flag provided', async () => {
+    const { output, error } = await captureStderr(() => runReadNeighbors(['--help']))
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(0)')
+
+    const joined = output.join('\n')
+    expect(joined).toContain('Usage:')
+    expect(joined).toContain('read-neighbors')
+    expect(joined).toContain('--chunk-index')
+    expect(joined).toContain('Either --file-path or --source')
+
+    // No DB access when --help is handled
+    expect(mocks.initialize).not.toHaveBeenCalled()
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 2 — XOR: both --file-path and --source provided
+  // --------------------------------------------
+  it('should exit 1 when both --file-path and --source are provided', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors([
+        '--file-path',
+        '/abs/path.md',
+        '--source',
+        'http://ex.com',
+        '--chunk-index',
+        '5',
+      ])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('Cannot specify both --file-path and --source')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 3 — XOR: neither --file-path nor --source provided
+  // --------------------------------------------
+  it('should exit 1 when neither --file-path nor --source is provided', async () => {
+    const { output, error } = await captureStderr(() => runReadNeighbors(['--chunk-index', '5']))
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('Either --file-path or --source is required')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 4 — Missing --chunk-index
+  // --------------------------------------------
+  it('should exit 1 when --chunk-index is missing', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md'])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('--chunk-index')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 5 — Non-integer --chunk-index ("abc")
+  // --------------------------------------------
+  it('should exit 1 when --chunk-index is non-integer ("abc")', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', 'abc'])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('--chunk-index')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 6 — Negative --chunk-index ("-1")
+  // --------------------------------------------
+  it('should exit 1 when --chunk-index is negative ("-1")', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '-1'])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('--chunk-index')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 7 — Non-integer --before ("2.5")
+  // --------------------------------------------
+  it('should exit 1 when --before is non-integer ("2.5")', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '5', '--before', '2.5'])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('--before')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
+  // Test 8 — Defaults applied (AC-008, AC-012)
+  // --------------------------------------------
+  it('should use default before=2/after=2 window when neither flag is provided', async () => {
+    mocks.getChunksByRange.mockResolvedValueOnce([
+      { filePath: '/abs/path.md', chunkIndex: 5, text: 'x', fileTitle: null },
+    ])
+
+    const { error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '5'])
+    )
+
+    expect(error).toBeUndefined()
+    expect(mocks.initialize).toHaveBeenCalledTimes(1)
+    expect(mocks.getChunksByRange).toHaveBeenCalledTimes(1)
+    // handler-side clamp: minIdx = max(0, 5 - 2) = 3; maxIdx = 5 + 2 = 7
+    expect(mocks.getChunksByRange).toHaveBeenCalledWith('/abs/path.md', 3, 7)
+  })
+
+  // --------------------------------------------
+  // Test 9 — JSON output shape (AC-011)
+  // --------------------------------------------
+  it('should write JSON output to stdout matching JSON.stringify(items, null, 2) + "\\n"', async () => {
+    const rows = [
+      { filePath: '/abs/path.md', chunkIndex: 4, text: 'before', fileTitle: 'Doc' },
+      { filePath: '/abs/path.md', chunkIndex: 5, text: 'target', fileTitle: 'Doc' },
+      { filePath: '/abs/path.md', chunkIndex: 6, text: 'after', fileTitle: 'Doc' },
+    ]
+    mocks.getChunksByRange.mockResolvedValueOnce(rows)
+
+    const { error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '5'])
+    )
+
+    expect(error).toBeUndefined()
+    expect(stdoutSpy).toHaveBeenCalledTimes(1)
+
+    const expectedItems = [
+      {
+        filePath: '/abs/path.md',
+        chunkIndex: 4,
+        text: 'before',
+        isTarget: false,
+        fileTitle: 'Doc',
+      },
+      { filePath: '/abs/path.md', chunkIndex: 5, text: 'target', isTarget: true, fileTitle: 'Doc' },
+      { filePath: '/abs/path.md', chunkIndex: 6, text: 'after', isTarget: false, fileTitle: 'Doc' },
+    ]
+    const written = stdoutSpy.mock.calls[0]![0] as string
+    expect(written).toBe(`${JSON.stringify(expectedItems, null, 2)}\n`)
+  })
+
+  // --------------------------------------------
+  // Test 10 — --source alternative (AC-003, AC-012, AC-020 CLI path)
+  // --------------------------------------------
+  it('should generate raw-data path from --source and attach source to response items', async () => {
+    const SOURCE = 'https://example.com/test'
+
+    // The primitive is called with a generated raw-data path. Capture it via mock
+    // and return a row whose filePath is the raw-data path — so runReadNeighbors
+    // will extract the source from that path and attach it to each item.
+    mocks.getChunksByRange.mockImplementationOnce(
+      async (targetPath: string, _minIdx: number, _maxIdx: number) => [
+        { filePath: targetPath, chunkIndex: 0, text: 'hello', fileTitle: null },
+      ]
+    )
+
+    const { error } = await captureStderr(() =>
+      runReadNeighbors(['--source', SOURCE, '--chunk-index', '0'])
+    )
+
+    expect(error).toBeUndefined()
+    expect(mocks.getChunksByRange).toHaveBeenCalledTimes(1)
+
+    // The first argument is the generated raw-data path.
+    const [calledPath] = mocks.getChunksByRange.mock.calls[0] as [string, number, number]
+    expect(calledPath).toContain('/raw-data/')
+    expect(calledPath).toMatch(/\.md$/)
+    // Not the raw source string itself.
+    expect(calledPath).not.toBe(SOURCE)
+
+    // Response items should include the original source field extracted from the
+    // raw-data path.
+    expect(stdoutSpy).toHaveBeenCalledTimes(1)
+    const written = stdoutSpy.mock.calls[0]![0] as string
+    const parsed = JSON.parse(written) as Array<{
+      filePath: string
+      chunkIndex: number
+      text: string
+      isTarget: boolean
+      fileTitle: string | null
+      source?: string
+    }>
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0]!.source).toBe(SOURCE)
+    expect(parsed[0]!.isTarget).toBe(true)
+  })
+})

--- a/src/__tests__/cli/read-neighbors.test.ts
+++ b/src/__tests__/cli/read-neighbors.test.ts
@@ -194,6 +194,20 @@ describe('CLI read-neighbors', () => {
   })
 
   // --------------------------------------------
+  // Test 7b — --before exceeds max (51)
+  // --------------------------------------------
+  it('should exit 1 when --before exceeds max (51)', async () => {
+    const { output, error } = await captureStderr(() =>
+      runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '5', '--before', '51'])
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+    expect(output.join('\n')).toContain('before must be between 0 and 50')
+    expect(mocks.getChunksByRange).not.toHaveBeenCalled()
+  })
+
+  // --------------------------------------------
   // Test 8 — Defaults applied (AC-008, AC-012)
   // --------------------------------------------
   it('should use default before=2/after=2 window when neither flag is provided', async () => {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -5,6 +5,7 @@ import { runIngest } from './cli/ingest.js'
 import { runList } from './cli/list.js'
 import type { GlobalOptions } from './cli/options.js'
 import { runQuery } from './cli/query.js'
+import { runReadNeighbors } from './cli/read-neighbors.js'
 import { runStatus } from './cli/status.js'
 
 /**
@@ -49,9 +50,15 @@ export async function handleCli(args: string[], globalOptions: GlobalOptions = {
       await runDelete(args.slice(1), globalOptions)
       break
 
+    case 'read-neighbors':
+      await runReadNeighbors(args.slice(1), globalOptions)
+      break
+
     default:
       console.error(`Unknown command: ${subcommand}`)
-      console.error('Available commands: skills, ingest, list, query, status, delete')
+      console.error(
+        'Available commands: skills, ingest, list, query, status, delete, read-neighbors'
+      )
       process.exit(1)
   }
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -123,6 +123,7 @@ Options:
 Commands:
   ingest <path>          Ingest files into the vector database
   query <text>           Search ingested documents
+  read-neighbors         Read N chunks before and after a target chunk within the same document
   list                   List files and ingestion status
   status                 Show database status
   delete <path>          Delete ingested content

--- a/src/cli/read-neighbors.ts
+++ b/src/cli/read-neighbors.ts
@@ -177,7 +177,13 @@ export async function runReadNeighbors(
     const chunkIndex = parsed.chunkIndex
 
     const before = parsed.before ?? READ_NEIGHBORS_DEFAULTS.before
+    if (before > 50) {
+      throw new Error(`before must be between 0 and 50 (got ${before})`)
+    }
     const after = parsed.after ?? READ_NEIGHBORS_DEFAULTS.after
+    if (after > 50) {
+      throw new Error(`after must be between 0 and 50 (got ${after})`)
+    }
 
     // XOR: exactly one of --file-path / --source
     const hasFilePath = parsed.filePath !== undefined

--- a/src/cli/read-neighbors.ts
+++ b/src/cli/read-neighbors.ts
@@ -1,0 +1,242 @@
+// CLI read-neighbors subcommand — read N chunks before/after a target chunk within one document
+
+import { resolve } from 'node:path'
+import {
+  extractSourceFromPath,
+  generateRawDataPath,
+  isRawDataPath,
+} from '../utils/raw-data-utils.js'
+import { createVectorStore } from './common.js'
+import type { GlobalOptions } from './options.js'
+import { resolveGlobalConfig, validatePath } from './options.js'
+
+// ============================================
+// Defaults
+// ============================================
+
+const READ_NEIGHBORS_DEFAULTS = {
+  before: 2,
+  after: 2,
+} as const
+
+// ============================================
+// Help
+// ============================================
+
+const HELP_TEXT = `Usage: mcp-local-rag [global-options] read-neighbors [options]
+
+Read N chunks before and after a target chunk within the same document.
+
+Either --file-path or --source is required, not both.
+
+Options:
+  --file-path <abs-path>   File path of ingested content (absolute path)
+  --source <id>            Source identifier (for content ingested via ingest_data)
+  --chunk-index <n>        Target chunk index (zero-based, required, non-negative integer)
+  --before <n>             Number of chunks before the target (default: ${READ_NEIGHBORS_DEFAULTS.before}, non-negative integer)
+  --after <n>              Number of chunks after the target (default: ${READ_NEIGHBORS_DEFAULTS.after}, non-negative integer)
+  -h, --help               Show this help
+
+Defaults: before=${READ_NEIGHBORS_DEFAULTS.before}, after=${READ_NEIGHBORS_DEFAULTS.after} (grep -C 2 convention)
+
+Example:
+  npx mcp-local-rag read-neighbors --file-path /abs/path/file.md --chunk-index 12 --before 3 --after 3
+
+Global options (must appear before "read-neighbors"):
+  --db-path <path>         LanceDB database path
+  --cache-dir <path>       Model cache directory
+  --model-name <name>      Embedding model`
+
+// ============================================
+// Arg Parsing
+// ============================================
+
+interface ReadNeighborsArgs {
+  help: boolean
+  filePath?: string
+  source?: string
+  chunkIndex?: number
+  before?: number
+  after?: number
+}
+
+/**
+ * Parse a value expected to be a non-negative integer flag value.
+ * Throws a descriptive Error on malformed input; the outer runReadNeighbors
+ * try/catch converts this into `console.error` + `process.exit(1)`.
+ */
+function parseNonNegativeInteger(flag: string, rawValue: string | undefined): number {
+  if (rawValue === undefined || rawValue.startsWith('-')) {
+    throw new Error(`Missing value for ${flag}`)
+  }
+  const parsed = Number.parseInt(rawValue, 10)
+  if (!Number.isInteger(parsed) || parsed < 0 || String(parsed) !== rawValue) {
+    throw new Error(`${flag} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+/**
+ * Parse read-neighbors CLI arguments.
+ * Flags: --file-path, --source, --chunk-index, --before, --after, -h/--help.
+ * Integer flags are validated syntactically (must be non-negative integer).
+ * Semantic validation (required-ness, XOR) is performed in runReadNeighbors.
+ */
+function parseArgs(args: string[]): ReadNeighborsArgs {
+  let help = false
+  let filePath: string | undefined
+  let source: string | undefined
+  let chunkIndex: number | undefined
+  let before: number | undefined
+  let after: number | undefined
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]!
+
+    if (arg === '-h' || arg === '--help') {
+      help = true
+      i++
+    } else if (arg === '--file-path') {
+      const value = args[++i]
+      if (value === undefined || value.startsWith('-')) {
+        throw new Error('Missing value for --file-path')
+      }
+      filePath = value
+      i++
+    } else if (arg === '--source') {
+      const value = args[++i]
+      if (value === undefined || value.startsWith('-')) {
+        throw new Error('Missing value for --source')
+      }
+      source = value
+      i++
+    } else if (arg === '--chunk-index') {
+      chunkIndex = parseNonNegativeInteger('--chunk-index', args[++i])
+      i++
+    } else if (arg === '--before') {
+      before = parseNonNegativeInteger('--before', args[++i])
+      i++
+    } else if (arg === '--after') {
+      after = parseNonNegativeInteger('--after', args[++i])
+      i++
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`)
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`)
+    }
+  }
+
+  const result: ReadNeighborsArgs = { help }
+  if (filePath !== undefined) result.filePath = filePath
+  if (source !== undefined) result.source = source
+  if (chunkIndex !== undefined) result.chunkIndex = chunkIndex
+  if (before !== undefined) result.before = before
+  if (after !== undefined) result.after = after
+  return result
+}
+
+// ============================================
+// Main Entry Point
+// ============================================
+
+/**
+ * Run the read-neighbors CLI subcommand.
+ * Reads chunks adjacent to a target chunkIndex within a single document.
+ * Does NOT perform any search; this is an index-adjacent retrieval utility.
+ *
+ * @param args - Arguments after "read-neighbors"
+ * @param globalOptions - Global options parsed before the subcommand
+ */
+export async function runReadNeighbors(
+  args: string[],
+  globalOptions: GlobalOptions = {}
+): Promise<void> {
+  try {
+    // Parse CLI options
+    const parsed = parseArgs(args)
+
+    // Handle --help
+    if (parsed.help) {
+      console.error(HELP_TEXT)
+      process.exit(0)
+    }
+
+    // Validation order: chunkIndex → before → after → XOR (matches handler per Design Doc).
+    if (parsed.chunkIndex === undefined) {
+      throw new Error('--chunk-index is required and must be a non-negative integer')
+    }
+    const chunkIndex = parsed.chunkIndex
+
+    const before = parsed.before ?? READ_NEIGHBORS_DEFAULTS.before
+    const after = parsed.after ?? READ_NEIGHBORS_DEFAULTS.after
+
+    // XOR: exactly one of --file-path / --source
+    const hasFilePath = parsed.filePath !== undefined
+    const hasSource = parsed.source !== undefined
+    if (!hasFilePath && !hasSource) {
+      throw new Error('Either --file-path or --source is required')
+    }
+    if (hasFilePath && hasSource) {
+      throw new Error('Cannot specify both --file-path and --source')
+    }
+
+    // Resolve global config
+    const globalConfig = resolveGlobalConfig(globalOptions)
+
+    // Determine target file path (dual-input resolution).
+    let targetPath: string
+    if (parsed.source !== undefined) {
+      // Generate raw-data path from source identifier.
+      targetPath = generateRawDataPath(globalConfig.dbPath, parsed.source, 'markdown')
+    } else {
+      // Resolve to absolute path and validate (mirrors runDelete).
+      targetPath = resolve(parsed.filePath!)
+      const pathError = validatePath(targetPath, '--file-path')
+      if (pathError) {
+        console.error(pathError)
+        process.exit(1)
+      }
+    }
+
+    // Create and initialize VectorStore (no embedder needed for index-only read).
+    const vectorStore = createVectorStore(globalConfig)
+    await vectorStore.initialize()
+
+    // Range composition (handler-side clamp; primitive stays feature-agnostic).
+    const minIdx = Math.max(0, chunkIndex - before)
+    const maxIdx = chunkIndex + after
+
+    // Primitive call.
+    const rows = await vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
+
+    // Post-fetch marking: isTarget per item; source attached for raw-data rows.
+    const isRaw = isRawDataPath(targetPath)
+    const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
+    const items = rows.map((row) => {
+      const item: {
+        filePath: string
+        chunkIndex: number
+        text: string
+        isTarget: boolean
+        fileTitle: string | null
+        source?: string
+      } = {
+        filePath: row.filePath,
+        chunkIndex: row.chunkIndex,
+        text: row.text,
+        isTarget: row.chunkIndex === chunkIndex,
+        fileTitle: row.fileTitle ?? null,
+      }
+      if (sourceForAll) item.source = sourceForAll
+      return item
+    })
+
+    // Output JSON to stdout (2-space indent per query.ts convention).
+    process.stdout.write(`${JSON.stringify(items, null, 2)}\n`)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.error(`Error: ${reason}`)
+    process.exit(1)
+  }
+}

--- a/src/cli/read-neighbors.ts
+++ b/src/cli/read-neighbors.ts
@@ -152,16 +152,24 @@ export async function runReadNeighbors(
   args: string[],
   globalOptions: GlobalOptions = {}
 ): Promise<void> {
+  // Parse CLI options (parse errors are caught and converted to exit(1) below).
+  let parsed: ReadNeighborsArgs
   try {
-    // Parse CLI options
-    const parsed = parseArgs(args)
+    parsed = parseArgs(args)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.error(`Error: ${reason}`)
+    process.exit(1)
+  }
 
-    // Handle --help
-    if (parsed.help) {
-      console.error(HELP_TEXT)
-      process.exit(0)
-    }
+  // Handle --help OUTSIDE the main try/catch so exit(0) is not converted to exit(1).
+  // Mirrors src/cli/delete.ts and src/cli/query.ts.
+  if (parsed.help) {
+    console.error(HELP_TEXT)
+    process.exit(0)
+  }
 
+  try {
     // Validation order: chunkIndex → before → after → XOR (matches handler per Design Doc).
     if (parsed.chunkIndex === undefined) {
       throw new Error('--chunk-index is required and must be a non-negative integer')

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,15 @@ import { startServer } from './server-main.js'
 // Routing
 // ============================================
 
-const SUBCOMMANDS = new Set(['skills', 'ingest', 'list', 'query', 'status', 'delete'])
+const SUBCOMMANDS = new Set([
+  'skills',
+  'ingest',
+  'list',
+  'query',
+  'status',
+  'delete',
+  'read-neighbors',
+])
 
 const { globalOptions, remainingArgs } = parseGlobalOptions(process.argv.slice(2))
 const firstArg = remainingArgs[0]

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -14,17 +14,39 @@
 //   - afterAll: rmSync tmp dirs recursively
 //   - Use handleIngestFile / handleIngestData to seed real chunks
 
-import { describe, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { isRawDataPath } from '../../utils/raw-data-utils.js'
+import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
+import { RAGServer } from '../index.js'
+import type { ReadChunkNeighborsInput, ReadChunkNeighborsResultItem } from '../types.js'
 
-describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () => {
-  it.todo('Test 1: Default window returns 5 sorted chunks with core fields and isTarget')
-  it.todo('Test 2: Single-call sufficiency (PRD Quantitative Metric 3)')
-  it.todo('Test 3: Near-start target returns clamped window (AC-005)')
-  it.todo('Test 4: Missing target and fully out-of-range behavior (AC-006)')
-  it.todo('Test 5: source input resolves to same document as filePath (AC-003)')
-  it.todo('Test 6: Raw-data row includes source field (AC-020)')
-  it.todo('Test 7: P95 under 100ms on 10k chunk document (NFR)')
+/**
+ * Local helper: access the private vectorStore instance on a RAGServer.
+ * Mirrors the pattern in rag-server ingest-rollback tests. Kept local;
+ * per task scope boundary we do not introduce cross-file test utilities.
+ */
+function getVectorStore(server: RAGServer): VectorStore {
+  return (server as unknown as { vectorStore: VectorStore }).vectorStore
+}
 
+/**
+ * Local helper: parse the JSON payload of a tool response.
+ */
+function parseItems(response: {
+  content: Array<{ type: 'text'; text: string }>
+}): ReadChunkNeighborsResultItem[] {
+  const text = response.content[0]?.text
+  if (typeof text !== 'string') {
+    throw new Error('Response content[0].text is missing')
+  }
+  return JSON.parse(text) as ReadChunkNeighborsResultItem[]
+}
+
+describe('read_chunk_neighbors integration', () => {
   // =============================================================================
   // Test 1: Default window returns 5 sorted chunks with core fields and isTarget
   // =============================================================================
@@ -69,6 +91,65 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   //
   // Pass criteria:
   //   - All verification items above hold.
+  describe('Test 1: Default window returns 5 sorted chunks with core fields and isTarget', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t1')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t1')
+    let ingestedFilePath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'default-window.txt')
+      // Large enough content that chunker produces >= 7 chunks.
+      writeFileSync(ingestedFilePath, 'The quick brown fox jumps over the lazy dog. '.repeat(200))
+      const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+      const ingest = JSON.parse(ingestRes.content[0].text)
+      expect(ingest.chunkCount).toBeGreaterThanOrEqual(7)
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('returns 5 sorted items with core fields, exactly one isTarget true', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: ingestedFilePath,
+        chunkIndex: 3,
+      })
+      const items = parseItems(response)
+
+      expect(items).toHaveLength(5)
+      expect(items.map((i) => i.chunkIndex)).toEqual([1, 2, 3, 4, 5])
+
+      for (const item of items) {
+        expect(typeof item.chunkIndex).toBe('number')
+        expect(typeof item.text).toBe('string')
+        expect(item.text.length).toBeGreaterThan(0)
+        expect(item.filePath).toBe(ingestedFilePath)
+        expect(typeof item.isTarget).toBe('boolean')
+        // fileTitle is string | null per ReadChunkNeighborsResultItem
+        expect(item.fileTitle === null || typeof item.fileTitle === 'string').toBe(true)
+        // AC-002 minimal core: no score, no metadata on ChunkRow-derived items.
+        expect('score' in item).toBe(false)
+        expect('metadata' in item).toBe(false)
+      }
+
+      const targets = items.filter((i) => i.isTarget)
+      expect(targets).toHaveLength(1)
+      expect(targets[0]?.chunkIndex).toBe(3)
+    })
+  })
 
   // =============================================================================
   // Test 2: Single-call sufficiency (PRD Quantitative Metric 3)
@@ -104,6 +185,74 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   // Pass criteria:
   //   - Spy call count equals 1 on the neighbor call.
   //   - Arguments match the expected minIdx/maxIdx range.
+  describe('Test 2: Single-call sufficiency (PRD Quantitative Metric 3)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t2')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t2')
+    let ingestedFilePath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'single-call.txt')
+      writeFileSync(
+        ingestedFilePath,
+        'Distinctive marker ZZQWERTY12345 appears in this document. '.repeat(60)
+      )
+      await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+    }, 30000)
+
+    afterAll(() => {
+      vi.restoreAllMocks()
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('invokes getChunksByRange exactly once with correct range arguments', async () => {
+      const queryRes = await ragServer.handleQueryDocuments({
+        query: 'ZZQWERTY12345',
+        limit: 5,
+      })
+      const hits = JSON.parse(queryRes.content[0].text) as Array<{
+        filePath: string
+        chunkIndex: number
+      }>
+      expect(hits.length).toBeGreaterThan(0)
+      const firstHit = hits[0]
+      if (!firstHit) throw new Error('Expected at least one query hit')
+      const { filePath: hitFilePath, chunkIndex: hitChunkIndex } = firstHit
+
+      // Install spy AFTER the query step so query path doesn't contribute
+      const vectorStore = getVectorStore(ragServer)
+      const spy = vi.spyOn(vectorStore, 'getChunksByRange')
+      spy.mockClear()
+
+      const neighborRes = await ragServer.handleReadChunkNeighbors({
+        filePath: hitFilePath,
+        chunkIndex: hitChunkIndex,
+      })
+      // Sanity: response resolved with valid payload
+      expect(neighborRes.content[0]).toBeDefined()
+
+      expect(spy.mock.calls).toHaveLength(1)
+      // Handler clamps minIdx via Math.max(0, chunkIndex - before) per Design Doc
+      // §Main Components → Handler. maxIdx is unclamped.
+      const expectedMinIdx = Math.max(0, hitChunkIndex - 2)
+      const expectedMaxIdx = hitChunkIndex + 2
+      expect(spy.mock.calls[0]).toEqual([hitFilePath, expectedMinIdx, expectedMaxIdx])
+
+      spy.mockRestore()
+    })
+  })
 
   // =============================================================================
   // Test 3: Near-start target returns clamped window (AC-005)
@@ -134,6 +283,53 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   //
   // Pass criteria:
   //   - All verification items above hold; response is the clamped window.
+  describe('Test 3: Near-start target returns clamped window (AC-005)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t3')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t3')
+    let ingestedFilePath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'near-start.txt')
+      writeFileSync(ingestedFilePath, 'Alpha beta gamma delta epsilon zeta eta theta. '.repeat(120))
+      const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+      const ingest = JSON.parse(ingestRes.content[0].text)
+      expect(ingest.chunkCount).toBeGreaterThanOrEqual(4)
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('returns only existing chunks [0,1,2] with isTarget at 0', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: ingestedFilePath,
+        chunkIndex: 0,
+      })
+      const items = parseItems(response)
+
+      expect(items).toHaveLength(3)
+      expect(items.map((i) => i.chunkIndex)).toEqual([0, 1, 2])
+      for (const item of items) {
+        expect(item.chunkIndex).toBeGreaterThanOrEqual(0)
+      }
+      expect(items[0]?.isTarget).toBe(true)
+      expect(items[1]?.isTarget).toBe(false)
+      expect(items[2]?.isTarget).toBe(false)
+    })
+  })
 
   // =============================================================================
   // Test 4: Missing target and fully out-of-range behavior (AC-006)
@@ -176,6 +372,72 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   //
   // Pass criteria:
   //   - Both sub-scenarios hold as specified.
+  describe('Test 4: Missing target and fully out-of-range behavior (AC-006)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t4')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t4')
+    let ingestedFilePath: string
+    let chunkCount: number
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'missing-target.txt')
+      writeFileSync(
+        ingestedFilePath,
+        'Lorem ipsum dolor sit amet consectetur adipiscing elit. '.repeat(150)
+      )
+      const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+      const ingest = JSON.parse(ingestRes.content[0].text)
+      chunkCount = ingest.chunkCount
+      expect(chunkCount).toBeGreaterThanOrEqual(3)
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('(a) target just past last index: returns surrounding chunks with all isTarget false', async () => {
+      // Request chunkIndex = chunkCount (one past the last valid index = chunkCount-1)
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: ingestedFilePath,
+        chunkIndex: chunkCount,
+      })
+      const items = parseItems(response)
+
+      expect(items.length).toBeGreaterThan(0)
+      for (const item of items) {
+        expect(item.isTarget).toBe(false)
+        expect(item.chunkIndex).toBeLessThanOrEqual(chunkCount - 1)
+      }
+      // Strictly ascending
+      for (let i = 1; i < items.length; i++) {
+        const prev = items[i - 1]
+        const curr = items[i]
+        if (!prev || !curr) throw new Error('Unexpected undefined item in ascending check')
+        expect(curr.chunkIndex).toBeGreaterThan(prev.chunkIndex)
+      }
+    })
+
+    it('(b) target far outside document: returns empty array', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: ingestedFilePath,
+        chunkIndex: 999,
+      })
+      const items = parseItems(response)
+      expect(items).toEqual([])
+    })
+  })
 
   // =============================================================================
   // Test 5: source input resolves to same document as filePath (AC-003)
@@ -210,6 +472,56 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   // Pass criteria:
   //   - Source-based resolution yields a valid neighbor window from the same
   //     raw-data document.
+  describe('Test 5: source input resolves to same document as filePath (AC-003)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t5')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t5')
+    const SOURCE = 'https://example.com/read-neighbors-test'
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      const content = `# Read Neighbors Source Test\n\n${'Markdown paragraph content with stable wording. '.repeat(200)}`
+      const ingestRes = await ragServer.handleIngestData({
+        content,
+        metadata: { source: SOURCE, format: 'markdown' },
+      })
+      const ingest = JSON.parse(ingestRes.content[0].text)
+      expect(ingest.chunkCount).toBeGreaterThanOrEqual(3)
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('resolves source identifier to the raw-data document and returns a window', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        source: SOURCE,
+        chunkIndex: 1,
+      })
+      const items = parseItems(response)
+
+      expect(items.length).toBeGreaterThan(0)
+      const filePaths = new Set(items.map((i) => i.filePath))
+      expect(filePaths.size).toBe(1)
+      const sharedPath = items[0]?.filePath ?? ''
+      expect(isRawDataPath(sharedPath)).toBe(true)
+
+      const targets = items.filter((i) => i.isTarget)
+      expect(targets).toHaveLength(1)
+      expect(targets[0]?.chunkIndex).toBe(1)
+    })
+  })
 
   // =============================================================================
   // Test 6: Raw-data row includes source field (AC-020)
@@ -246,6 +558,71 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   // Pass criteria:
   //   - source present and correct on raw-data items; absent on file-backed
   //     items.
+  describe('Test 6: Raw-data row includes source field (AC-020)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t6')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t6')
+    const KNOWN_SOURCE = 'https://example.com/read-neighbors-source-field'
+    let fileBackedPath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      // Raw-data document
+      const rawContent = `# Source field test\n\n${'Paragraph body content for source field test. '.repeat(120)}`
+      await ragServer.handleIngestData({
+        content: rawContent,
+        metadata: { source: KNOWN_SOURCE, format: 'markdown' },
+      })
+
+      // File-backed document (cross-check negative)
+      fileBackedPath = resolve(testDataDir, 'file-backed.txt')
+      writeFileSync(fileBackedPath, 'File backed document content. '.repeat(100))
+      await ragServer.handleIngestFile({ filePath: fileBackedPath })
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('raw-data items carry source === ingestion identifier', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        source: KNOWN_SOURCE,
+        chunkIndex: 0,
+      })
+      const items = parseItems(response)
+
+      expect(items.length).toBeGreaterThan(0)
+      for (const item of items) {
+        expect(typeof item.source).toBe('string')
+        expect(item.source).toBe(KNOWN_SOURCE)
+      }
+    })
+
+    it('file-backed items do NOT carry a source field', async () => {
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: fileBackedPath,
+        chunkIndex: 0,
+      })
+      const items = parseItems(response)
+
+      expect(items.length).toBeGreaterThan(0)
+      for (const item of items) {
+        // source key is either absent or undefined on file-backed items
+        expect(item.source).toBeUndefined()
+      }
+    })
+  })
 
   // =============================================================================
   // Test 7: P95 under 100ms on 10k chunk document (NFR)
@@ -301,4 +678,326 @@ describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () 
   //     on GitHub Actions shared runners (Design Doc §Risks). If the test
   //     flakes in practice, relax to P95 < 150 ms and record the observed
   //     distribution per Design Doc mitigation guidance.
+  describe('Test 7: P95 under 100ms on 10k chunk document (NFR)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t7')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t7')
+    // Synthetic path must live under baseDir so validateFilePath accepts it.
+    // The file itself need not exist on disk (must exist as a real path for
+    // validation: writeFileSync an empty file).
+    const syntheticFilePath = resolve(testDataDir, 'read-neighbors-perf.txt')
+    const TOTAL_CHUNKS = 10000
+    const EMBEDDING_DIM = 384
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      // Create a minimal placeholder file so validateFilePath's realpath/BASE_DIR
+      // check succeeds. Content is irrelevant — we bypass ingest and write chunks
+      // directly via vectorStore.insertChunks.
+      writeFileSync(syntheticFilePath, 'placeholder')
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      // Direct vectorStore insertion bypasses the embedder pipeline for speed.
+      // Use a constant small vector — content matters for predicate filtering,
+      // not for the (unused-here) search pathway.
+      const vectorStore = getVectorStore(ragServer)
+      const timestamp = new Date().toISOString()
+      const constantVector = new Array(EMBEDDING_DIM).fill(0.01)
+
+      // Insert in batches of 1000 to keep each insert call modest.
+      const BATCH = 1000
+      for (let start = 0; start < TOTAL_CHUNKS; start += BATCH) {
+        const end = Math.min(start + BATCH, TOTAL_CHUNKS)
+        const batch: VectorChunk[] = []
+        for (let i = start; i < end; i++) {
+          batch.push({
+            id: randomUUID(),
+            filePath: syntheticFilePath,
+            chunkIndex: i,
+            text: `synthetic chunk ${i}`,
+            vector: constantVector,
+            metadata: {
+              fileName: 'read-neighbors-perf.txt',
+              fileSize: 0,
+              fileType: 'txt',
+            },
+            fileTitle: null,
+            timestamp,
+          })
+        }
+        await vectorStore.insertChunks(batch)
+      }
+      await vectorStore.optimize()
+    }, 120000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('P95 of 20 neighbor reads under 100 ms', async () => {
+      // Warm-up (discard timings): varied indices to avoid cold-cache bias
+      for (const warmIdx of [100, 5000, 9500]) {
+        await ragServer.handleReadChunkNeighbors({
+          filePath: syntheticFilePath,
+          chunkIndex: warmIdx,
+        })
+      }
+
+      // Measurement: 20 calls cycling through start/middle/end indices
+      const cycle = [50, 2500, 5000, 7500, 9950]
+      const timings: number[] = []
+      for (let iter = 0; iter < 4; iter++) {
+        for (const idx of cycle) {
+          const start = performance.now()
+          await ragServer.handleReadChunkNeighbors({
+            filePath: syntheticFilePath,
+            chunkIndex: idx,
+          })
+          timings.push(performance.now() - start)
+        }
+      }
+
+      expect(timings).toHaveLength(20)
+      const sorted = [...timings].sort((a, b) => a - b)
+      // P95 at n=20: Math.ceil(0.95 * 20) - 1 = index 18 (19th smallest)
+      const p95 = sorted[Math.ceil(0.95 * 20) - 1] ?? Number.NaN
+
+      // Emit for PR description capture (PRD Success Criteria 2)
+      console.error(`P95: ${p95.toFixed(2)} ms`)
+
+      expect(Number.isFinite(p95)).toBe(true)
+      expect(p95).toBeGreaterThan(0)
+
+      if (!(p95 < 100)) {
+        // Attach timings to the assertion failure message for diagnostics
+        throw new Error(
+          `P95 ${p95.toFixed(2)} ms exceeded 100 ms. Full timings (ms): ${JSON.stringify(timings)}`
+        )
+      }
+      expect(p95).toBeLessThan(100)
+    }, 60000)
+  })
+
+  // =============================================================================
+  // Test 8 (extension): AC-007 over-large window clamped to document boundaries
+  // =============================================================================
+  // AC: AC-007 "When before/after request a window larger than the document,
+  //     the tool returns only the chunks that exist with no error."
+  // Behavior: Seed a small document (~5 chunks). Call handleReadChunkNeighbors
+  //   with before=100, after=100 centered at chunkIndex=2. Assert the response
+  //   contains only existing chunks (length <= 5), no error, ascending order.
+  // @category: edge-case
+  // @dependency: RAGServer, VectorStore, LanceDB
+  describe('Test 8: Over-large window clamped (AC-007 extension)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t8')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t8')
+    let ingestedFilePath: string
+    let chunkCount: number
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'small-doc.txt')
+      writeFileSync(
+        ingestedFilePath,
+        'Compact document content for over-large window test. '.repeat(100)
+      )
+      const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+      const ingest = JSON.parse(ingestRes.content[0].text)
+      chunkCount = ingest.chunkCount
+      expect(chunkCount).toBeGreaterThan(0)
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('clamps to existing chunks when before/after far exceed document size', async () => {
+      const targetIndex = Math.min(2, Math.max(0, chunkCount - 1))
+      const response = await ragServer.handleReadChunkNeighbors({
+        filePath: ingestedFilePath,
+        chunkIndex: targetIndex,
+        before: 100,
+        after: 100,
+      })
+      const items = parseItems(response)
+
+      expect(items.length).toBeLessThanOrEqual(chunkCount)
+      expect(items.length).toBeGreaterThan(0)
+      // Strictly ascending
+      for (let i = 1; i < items.length; i++) {
+        const prev = items[i - 1]
+        const curr = items[i]
+        if (!prev || !curr) throw new Error('Unexpected undefined item in ascending check')
+        expect(curr.chunkIndex).toBeGreaterThan(prev.chunkIndex)
+      }
+      // All returned chunkIndex values are within the actual document range
+      for (const item of items) {
+        expect(item.chunkIndex).toBeGreaterThanOrEqual(0)
+        expect(item.chunkIndex).toBeLessThanOrEqual(chunkCount - 1)
+      }
+    })
+  })
+
+  // =============================================================================
+  // Test 9 (extension): AC-009 negative / non-integer before/after at MCP boundary
+  // =============================================================================
+  // AC: AC-009 "When before or after is negative or non-integer, the tool
+  //     returns a validation error (McpError InvalidParams) without accessing
+  //     storage."
+  // Behavior: Call handleReadChunkNeighbors with before: -1 and after: 2.5 in
+  //   separate invocations. Assert both reject with McpError whose code is
+  //   ErrorCode.InvalidParams.
+  describe('Test 9: Negative / non-integer before/after at MCP boundary (AC-009 extension)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t9')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t9')
+    let ingestedFilePath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'validation-doc.txt')
+      writeFileSync(ingestedFilePath, 'Validation boundary test content. '.repeat(60))
+      await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('rejects negative before with McpError InvalidParams', async () => {
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: 5,
+          before: -1,
+        })
+      ).rejects.toThrow(McpError)
+
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: 5,
+          before: -1,
+        })
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
+    })
+
+    it('rejects non-integer after with McpError InvalidParams', async () => {
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: 5,
+          after: 2.5,
+        })
+      ).rejects.toThrow(McpError)
+
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: 5,
+          after: 2.5,
+        })
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
+    })
+  })
+
+  // =============================================================================
+  // Test 10 (extension): AC-010 missing / negative chunkIndex at MCP boundary
+  // =============================================================================
+  // AC: AC-010 "When chunkIndex is missing, negative, or non-integer, the tool
+  //     returns a validation error (McpError InvalidParams) without accessing
+  //     storage."
+  // Behavior: Call handleReadChunkNeighbors without chunkIndex (cast through
+  //   unknown), and with chunkIndex: -1. Assert both reject with McpError
+  //   whose code is ErrorCode.InvalidParams.
+  describe('Test 10: Missing / negative chunkIndex at MCP boundary (AC-010 extension)', () => {
+    let ragServer: RAGServer
+    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t10')
+    const testDataDir = resolve('./tmp/test-data-read-neighbors-t10')
+    let ingestedFilePath: string
+
+    beforeAll(async () => {
+      mkdirSync(testDbPath, { recursive: true })
+      mkdirSync(testDataDir, { recursive: true })
+      ragServer = new RAGServer({
+        dbPath: testDbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: './tmp/models',
+        baseDir: testDataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+      await ragServer.initialize()
+
+      ingestedFilePath = resolve(testDataDir, 'validation-chunk-index.txt')
+      writeFileSync(ingestedFilePath, 'chunkIndex validation test content. '.repeat(60))
+      await ragServer.handleIngestFile({ filePath: ingestedFilePath })
+    }, 30000)
+
+    afterAll(() => {
+      rmSync(testDbPath, { recursive: true, force: true })
+      rmSync(testDataDir, { recursive: true, force: true })
+    })
+
+    it('rejects missing chunkIndex with McpError InvalidParams', async () => {
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+        } as unknown as ReadChunkNeighborsInput)
+      ).rejects.toThrow(McpError)
+
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+        } as unknown as ReadChunkNeighborsInput)
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
+    })
+
+    it('rejects negative chunkIndex with McpError InvalidParams', async () => {
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: -1,
+        })
+      ).rejects.toThrow(McpError)
+
+      await expect(
+        ragServer.handleReadChunkNeighbors({
+          filePath: ingestedFilePath,
+          chunkIndex: -1,
+        })
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
+    })
+  })
 })

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -17,7 +17,7 @@
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { isRawDataPath } from '../../utils/raw-data-utils.js'
 import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
@@ -777,13 +777,10 @@ describe('read_chunk_neighbors integration', () => {
       expect(Number.isFinite(p95)).toBe(true)
       expect(p95).toBeGreaterThan(0)
 
-      if (!(p95 < 100)) {
-        // Attach timings to the assertion failure message for diagnostics
-        throw new Error(
-          `P95 ${p95.toFixed(2)} ms exceeded 100 ms. Full timings (ms): ${JSON.stringify(timings)}`
-        )
-      }
-      expect(p95).toBeLessThan(100)
+      expect(
+        p95,
+        `P95 latency ${p95.toFixed(2)} ms exceeds 100 ms threshold. Timings: ${JSON.stringify(timings)}`
+      ).toBeLessThan(100)
     }, 60000)
   })
 
@@ -837,8 +834,8 @@ describe('read_chunk_neighbors integration', () => {
       const response = await ragServer.handleReadChunkNeighbors({
         filePath: ingestedFilePath,
         chunkIndex: targetIndex,
-        before: 100,
-        after: 100,
+        before: 50,
+        after: 50,
       })
       const items = parseItems(response)
 
@@ -903,14 +900,6 @@ describe('read_chunk_neighbors integration', () => {
           chunkIndex: 5,
           before: -1,
         })
-      ).rejects.toThrow(McpError)
-
-      await expect(
-        ragServer.handleReadChunkNeighbors({
-          filePath: ingestedFilePath,
-          chunkIndex: 5,
-          before: -1,
-        })
       ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
     })
 
@@ -921,13 +910,15 @@ describe('read_chunk_neighbors integration', () => {
           chunkIndex: 5,
           after: 2.5,
         })
-      ).rejects.toThrow(McpError)
+      ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
+    })
 
+    it('rejects before > 50 with McpError InvalidParams', async () => {
       await expect(
         ragServer.handleReadChunkNeighbors({
           filePath: ingestedFilePath,
           chunkIndex: 5,
-          after: 2.5,
+          before: 51,
         })
       ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
     })
@@ -975,23 +966,10 @@ describe('read_chunk_neighbors integration', () => {
         ragServer.handleReadChunkNeighbors({
           filePath: ingestedFilePath,
         } as unknown as ReadChunkNeighborsInput)
-      ).rejects.toThrow(McpError)
-
-      await expect(
-        ragServer.handleReadChunkNeighbors({
-          filePath: ingestedFilePath,
-        } as unknown as ReadChunkNeighborsInput)
       ).rejects.toMatchObject({ code: ErrorCode.InvalidParams })
     })
 
     it('rejects negative chunkIndex with McpError InvalidParams', async () => {
-      await expect(
-        ragServer.handleReadChunkNeighbors({
-          filePath: ingestedFilePath,
-          chunkIndex: -1,
-        })
-      ).rejects.toThrow(McpError)
-
       await expect(
         ragServer.handleReadChunkNeighbors({
           filePath: ingestedFilePath,

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -1,0 +1,304 @@
+// read_chunk_neighbors Integration Test - Design Doc: read-chunk-neighbors-design.md
+// Generated: 2026-04-16 | Budget Used: 7/3 integration (Design Doc explicitly prescribes
+// AC-005/006/007/011/013/019 + single-call sufficiency + P95; budget overrun reported)
+// PRD reference: docs/prd/read-chunk-neighbors-prd.md (AC-001..AC-020)
+//
+// Test framework: vitest (pool: forks, maxWorkers: 1, isolate: false)
+// Mock boundary decisions (Design Doc §Test Boundaries):
+//   @real-dependency: RAGServer, VectorStore, LanceDB, DocumentParser, raw-data-utils
+//   Mocked: none in this file (except the single-call-sufficiency spy on vectorStore.getChunksByRange)
+//
+// Follow existing pattern from rag-server.delete.integration.test.ts:
+//   - describe block per AC (or AC group) with its own tmp dbPath + baseDir
+//   - beforeAll: create dirs, construct RAGServer, initialize, seed fixtures
+//   - afterAll: rmSync tmp dirs recursively
+//   - Use handleIngestFile / handleIngestData to seed real chunks
+
+import { describe, it } from 'vitest'
+
+describe.skip('read_chunk_neighbors integration (awaiting Task 2.4 / #008)', () => {
+  it.todo('Test 1: Default window returns 5 sorted chunks with core fields and isTarget')
+  it.todo('Test 2: Single-call sufficiency (PRD Quantitative Metric 3)')
+  it.todo('Test 3: Near-start target returns clamped window (AC-005)')
+  it.todo('Test 4: Missing target and fully out-of-range behavior (AC-006)')
+  it.todo('Test 5: source input resolves to same document as filePath (AC-003)')
+  it.todo('Test 6: Raw-data row includes source field (AC-020)')
+  it.todo('Test 7: P95 under 100ms on 10k chunk document (NFR)')
+
+  // =============================================================================
+  // Test 1: Default window returns 5 sorted chunks with core fields and isTarget
+  // =============================================================================
+  // AC: AC-001 "Given an ingested document at filePath, when a client calls
+  //     read_chunk_neighbors({ filePath, chunkIndex: N }) with the defaults
+  //     (before=2, after=2), then the response contains all existing chunks from
+  //     index N-2 to N+2 in the same document, sorted by chunkIndex ascending."
+  // AC: AC-002 "Each item contains exactly the core required fields: chunkIndex,
+  //     text, filePath."
+  // AC: AC-008 "Default before=2, after=2."
+  // AC: AC-018 "Response array is always sorted by chunkIndex ascending."
+  // AC: AC-019 "Each item includes isTarget (boolean); exactly one item in a
+  //     non-empty response has isTarget: true; that item's chunkIndex equals the
+  //     requested chunkIndex."
+  // ROI: 109 (BV:10 x Freq:10 + Legal:0 + Defect:9)
+  // Behavior: Ingest document with >=5 chunks -> call handleReadChunkNeighbors
+  //   with filePath + chunkIndex in mid-document -> response is ordered 5-item
+  //   window with correct fields and exactly one isTarget:true at the requested
+  //   chunkIndex.
+  // @category: core-functionality
+  // @dependency: RAGServer, VectorStore, LanceDB, DocumentParser
+  // @complexity: medium
+  //
+  // Setup:
+  //   - Ingest a text file large enough to produce at least 7 chunks
+  //     (use '. '.repeat(N) pattern from rag-server.delete.integration.test.ts
+  //      or a file sized against CHUNK_MIN_LENGTH to guarantee >= 7 chunks).
+  //   - Record the filePath and pick a mid-document chunkIndex (e.g., 3).
+  //
+  // Verification items:
+  //   - Response shape: { content: [{ type: 'text', text: <json> }] }
+  //   - Parsed JSON is an array of length 5
+  //   - chunkIndex values equal [N-2, N-1, N, N+1, N+2] in that exact order
+  //     (ascending sort guarantee; AC-018)
+  //   - Every item has keys: chunkIndex (number), text (non-empty string),
+  //     filePath (matches ingested path), isTarget (boolean), fileTitle
+  //     (string or null)
+  //   - Exactly one item has isTarget === true (AC-019)
+  //   - The isTarget:true item's chunkIndex equals the requested chunkIndex
+  //   - No item carries a 'score' field (Design Doc §Data Representation Decision)
+  //   - No item carries a 'metadata' field
+  //
+  // Pass criteria:
+  //   - All verification items above hold.
+
+  // =============================================================================
+  // Test 2: Single-call sufficiency (PRD Quantitative Metric 3)
+  // =============================================================================
+  // AC: Metric 3 "In an end-to-end agent scenario (query_documents hit ->
+  //     read_chunk_neighbors), the agent produces the expected surrounding
+  //     context in exactly one follow-up tool call with no retries, measured by
+  //     at least one integration test that asserts call count = 1."
+  // ROI: 78 (BV:9 x Freq:8 + Legal:0 + Defect:6)
+  // Behavior: Simulate agent workflow: query_documents returns a hit -> use
+  //   that hit's filePath+chunkIndex -> call read_chunk_neighbors once ->
+  //   vectorStore.getChunksByRange is invoked exactly once for the neighbor call.
+  // @category: core-functionality
+  // @dependency: RAGServer, VectorStore, LanceDB (real), vi.spyOn on getChunksByRange
+  // @complexity: medium
+  //
+  // Setup:
+  //   - Ingest a document containing a distinctive query term so
+  //     handleQueryDocuments returns a deterministic hit.
+  //   - Install vi.spyOn(vectorStore, 'getChunksByRange') AFTER the query step
+  //     so the query path itself does not contribute to the call count.
+  //     Alternative: reset the spy with spy.mockClear() between the two steps.
+  //
+  // Verification items:
+  //   - handleQueryDocuments returns at least one hit; extract filePath and
+  //     chunkIndex from results[0]
+  //   - After handleReadChunkNeighbors is called with those values,
+  //     getChunksByRange spy call count === 1 (not 0, not 2+)
+  //   - The single call's arguments match (ingestedFilePath, chunkIndex-2,
+  //     chunkIndex+2) — confirming default window + correct filePath plumbing
+  //   - Response resolves (no exception thrown)
+  //
+  // Pass criteria:
+  //   - Spy call count equals 1 on the neighbor call.
+  //   - Arguments match the expected minIdx/maxIdx range.
+
+  // =============================================================================
+  // Test 3: Near-start target returns clamped window (AC-005)
+  // =============================================================================
+  // AC: AC-005 "Given a target chunkIndex near the start or end of the document
+  //     (e.g., chunkIndex: 0 with before=2), when the tool runs, then the
+  //     response includes only the chunks that exist (e.g., indices 0, 1, 2)
+  //     with no error and no placeholder entries for missing indices."
+  // ROI: 71 (BV:9 x Freq:7 + Legal:0 + Defect:8)
+  // Behavior: Request neighbors centered on chunkIndex=0 with default before=2 ->
+  //   no error; response contains only indices [0, 1, 2]; no negative-index
+  //   placeholder rows.
+  // @category: edge-case
+  // @dependency: RAGServer, VectorStore, LanceDB
+  // @complexity: low
+  //
+  // Setup:
+  //   - Ingest a document producing at least 4 chunks (so chunks 0,1,2 all exist).
+  //   - Call handleReadChunkNeighbors with chunkIndex=0 (defaults on before/after).
+  //
+  // Verification items:
+  //   - Operation resolves without throwing
+  //   - Response is an array of length 3
+  //   - chunkIndex values are exactly [0, 1, 2] in order
+  //   - The item with chunkIndex === 0 has isTarget: true
+  //   - The other two items have isTarget: false
+  //   - No item has a negative chunkIndex
+  //
+  // Pass criteria:
+  //   - All verification items above hold; response is the clamped window.
+
+  // =============================================================================
+  // Test 4: Missing target and fully out-of-range behavior (AC-006)
+  // =============================================================================
+  // AC: AC-006 "When the target chunkIndex itself does not exist, the tool
+  //     returns only the surrounding chunks (within [N-before, N+after]) that
+  //     do exist; if none of the requested range exists, it returns an empty
+  //     array. No error is raised."
+  // AC (cross-reference): AC-019 "when the target chunkIndex itself does not
+  //     exist in the document, all returned items have isTarget: false."
+  // ROI: 63 (BV:9 x Freq:6 + Legal:0 + Defect:9)
+  // Behavior: Two sub-scenarios in a single test:
+  //   (a) Target chunkIndex is just past the last valid index (e.g., doc has
+  //       chunks 0..5, request chunkIndex=6): surrounding indices 4,5 remain.
+  //   (b) Target chunkIndex is far past the document (e.g., chunkIndex=999):
+  //       response is an empty array, no error.
+  // @category: edge-case
+  // @dependency: RAGServer, VectorStore, LanceDB
+  // @complexity: medium
+  //
+  // Setup:
+  //   - Ingest a document yielding exactly N known chunks (e.g., N=6 -> last
+  //     valid chunkIndex = 5). The exact chunk count is not asserted here
+  //     (chunker is deterministic enough via fixed input text) — the test
+  //     reads the count via handleListFiles or a prior getChunksByRange call
+  //     if needed.
+  //
+  // Verification items (sub-scenario a):
+  //   - Request chunkIndex=(N) with default before=2 after=2
+  //   - Operation resolves without throwing
+  //   - Response is a non-empty array
+  //   - All returned items have isTarget: false (target itself absent)
+  //   - All returned chunkIndex values are <= N-1 (no item beyond doc end)
+  //   - chunkIndex values are strictly ascending
+  //
+  // Verification items (sub-scenario b):
+  //   - Request chunkIndex=999 (far outside) with default before=2 after=2
+  //   - Operation resolves without throwing
+  //   - Response is an empty array ([])
+  //
+  // Pass criteria:
+  //   - Both sub-scenarios hold as specified.
+
+  // =============================================================================
+  // Test 5: source input resolves to same document as filePath (AC-003)
+  // =============================================================================
+  // AC: AC-003 "Given the caller passes source (the identifier used in
+  //     ingest_data) instead of filePath, when the tool runs, then it resolves
+  //     the internal storage key via the same raw-data-utils helpers used by
+  //     delete_file and returns neighbors for that document."
+  // ROI: 47 (BV:8 x Freq:5 + Legal:0 + Defect:7)
+  // Behavior: Ingest raw data via handleIngestData(content, metadata.source=X)
+  //   -> call handleReadChunkNeighbors({ source: X, chunkIndex: N }) -> response
+  //   items belong to the same underlying document (same internal filePath).
+  // @category: integration
+  // @dependency: RAGServer, VectorStore, LanceDB, raw-data-utils
+  // @complexity: medium
+  //
+  // Setup:
+  //   - Call handleIngestData with distinctive content and metadata:
+  //     { source: 'https://example.com/read-neighbors-test', format: 'html' or 'markdown' }.
+  //   - Capture ingest result; confirm chunkCount >= 3 so chunkIndex=1 yields a
+  //     full window.
+  //   - Call handleReadChunkNeighbors({ source: 'https://example.com/...', chunkIndex: 1 }).
+  //
+  // Verification items:
+  //   - Operation resolves without throwing
+  //   - Response is a non-empty array
+  //   - All returned items share the same filePath value
+  //   - The shared filePath is under the raw-data storage directory
+  //     (isRawDataPath(filePath) === true)
+  //   - Exactly one item has isTarget: true with chunkIndex === 1
+  //
+  // Pass criteria:
+  //   - Source-based resolution yields a valid neighbor window from the same
+  //     raw-data document.
+
+  // =============================================================================
+  // Test 6: Raw-data row includes source field (AC-020)
+  // =============================================================================
+  // AC: AC-020 "Given a document ingested via ingest_data, when
+  //     read_chunk_neighbors returns its chunks, each item includes a source
+  //     field whose value equals the ingestion source URL/identifier."
+  // ROI: 35 (BV:7 x Freq:4 + Legal:0 + Defect:7)
+  // Behavior: Reuse the raw-data document from Test 5 (or seed a new one) ->
+  //   verify every returned item carries source === the ingestion identifier.
+  // @category: core-functionality
+  // @dependency: RAGServer, VectorStore, LanceDB, raw-data-utils
+  // @complexity: low
+  //
+  // Setup:
+  //   - Ingest content via handleIngestData with metadata.source = KNOWN_SOURCE.
+  //   - Call handleReadChunkNeighbors with either { source: KNOWN_SOURCE,
+  //     chunkIndex: 0 } or { filePath: <rawDataPath>, chunkIndex: 0 }.
+  //     Both paths must surface the source field (Design Doc §Field
+  //     Propagation Map: source is derived from targetPath via
+  //     extractSourceFromPath, not from the input key).
+  //
+  // Verification items:
+  //   - Response is a non-empty array
+  //   - Every item has a 'source' property of type string
+  //   - Every item's source === KNOWN_SOURCE (exact match)
+  //
+  // Cross-check negative:
+  //   - For a handleIngestFile-seeded document (non-raw-data), call
+  //     handleReadChunkNeighbors and confirm items do NOT carry a 'source' key
+  //     (or source is undefined). This guards against source being incorrectly
+  //     populated for file-backed documents.
+  //
+  // Pass criteria:
+  //   - source present and correct on raw-data items; absent on file-backed
+  //     items.
+
+  // =============================================================================
+  // Test 7: P95 under 100ms on 10k chunk document (NFR)
+  // =============================================================================
+  // AC: PRD Non-Functional Requirement "P95 under 100 ms for a window of
+  //     before=2, after=2 on a document with up to 10,000 chunks, measured in
+  //     CI on the default GitHub Actions runner."
+  // ROI: 85 (BV:8 x Freq:10 + Legal:0 + Defect:5)
+  // Behavior: Seed a LanceDB table with 10,000 chunks for a single filePath ->
+  //   warm up with 3 discarded calls -> measure 20 consecutive neighbor calls
+  //   -> assert computed P95 < 100 ms.
+  // @category: core-functionality
+  // @dependency: RAGServer, VectorStore, LanceDB
+  // @complexity: high
+  //
+  // Setup (per Design Doc §Performance Measurement Mechanism):
+  //   - Insert 10,000 contiguous chunks for one synthetic filePath. Use a
+  //     small constant vector (e.g., zeros of embedding dimension) to keep
+  //     insertion fast; this is setup, not part of the measured section.
+  //   - Consider bypassing the full handleIngestFile pipeline (which invokes
+  //     the real embedder) by inserting directly through vectorStore if the
+  //     existing test helper (createTestChunk from vectordb unit tests)
+  //     allows — otherwise accept longer setup and rely on vitest's 10s
+  //     default timeout; if setup exceeds that, split via beforeAll so only
+  //     the measured section runs under the per-test timeout.
+  //
+  // Measurement protocol:
+  //   - Warm up: call handleReadChunkNeighbors 3 times with before=2, after=2
+  //     on varied chunkIndex values (e.g., 100, 5000, 9500); discard timings.
+  //   - Measurement: call handleReadChunkNeighbors 20 times with before=2,
+  //     after=2 on a varied set of chunkIndex values spanning start / middle /
+  //     end (e.g., a cycle through [50, 2500, 5000, 7500, 9950] four times).
+  //   - Record per-call wall-clock using performance.now() deltas (start
+  //     BEFORE the call, end AFTER the awaited promise resolves).
+  //   - Sort timings ascending; P95 = timings[Math.ceil(0.95 * 20) - 1]
+  //     (index 18 of the sorted 20-element array, i.e., the 19th smallest).
+  //
+  // Verification items:
+  //   - All 20 measured calls resolve without throwing
+  //   - P95 value is a finite number > 0 (sanity)
+  //   - P95 < 100 (milliseconds)
+  //   - Emit the observed P95 via console.error(`P95: ${p95.toFixed(2)} ms`)
+  //     so CI logs capture the value for the PR description (PRD Success
+  //     Criteria 2)
+  //
+  // Pass criteria:
+  //   - P95 strictly below 100 ms.
+  //   - On failure, the failure message includes the full timings array for
+  //     the PR author (Design Doc §Performance Measurement Mechanism).
+  //
+  // Flake mitigation note:
+  //   - The 100 ms target includes headroom vs. the expected operation cost
+  //     on GitHub Actions shared runners (Design Doc §Risks). If the test
+  //     flakes in practice, relax to P95 < 150 ms and record the observed
+  //     distribution per Design Doc mitigation guidance.
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -654,9 +654,18 @@ export class RAGServer {
       if (!Number.isInteger(before) || before < 0) {
         throw new McpError(ErrorCode.InvalidParams, 'before must be a non-negative integer')
       }
+      if (before > 50) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `before must be between 0 and 50 (got ${before})`
+        )
+      }
       const after = args.after ?? 2
       if (!Number.isInteger(after) || after < 0) {
         throw new McpError(ErrorCode.InvalidParams, 'after must be a non-negative integer')
+      }
+      if (after > 50) {
+        throw new McpError(ErrorCode.InvalidParams, `after must be between 0 and 50 (got ${after})`)
       }
       const hasFilePath = args.filePath !== undefined
       const hasSource = args.source !== undefined

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import {
   saveRawData,
 } from '../utils/raw-data-utils.js'
 import { type VectorChunk, VectorStore } from '../vectordb/index.js'
+import { DatabaseError } from '../vectordb/types.js'
 import { formatErrorMessage } from './error-utils.js'
 import { toolDefinitions } from './tool-definitions.js'
 import type {
@@ -40,6 +41,8 @@ import type {
   QueryDocumentsInput,
   QueryResult,
   RAGServerConfig,
+  ReadChunkNeighborsInput,
+  ReadChunkNeighborsResultItem,
   SourceEntry,
 } from './types.js'
 
@@ -155,6 +158,10 @@ export class RAGServer {
           case 'delete_file':
             return await this.handleDeleteFile(
               request.params.arguments as unknown as DeleteFileInput
+            )
+          case 'read_chunk_neighbors':
+            return await this.handleReadChunkNeighbors(
+              request.params.arguments as unknown as ReadChunkNeighborsInput
             )
           case 'list_files':
             return await this.handleListFiles()
@@ -623,6 +630,95 @@ export class RAGServer {
       console.error('Failed to delete file:', errorMessage)
 
       throw new Error(`Failed to delete file: ${errorMessage}`)
+    }
+  }
+
+  /**
+   * read_chunk_neighbors tool handler
+   * Returns chunks around a target chunkIndex within a single ingested document.
+   * Context-expansion utility — not a search tool. Mirrors handleDeleteFile's
+   * dual-input (filePath XOR source) resolution pattern.
+   */
+  async handleReadChunkNeighbors(
+    args: ReadChunkNeighborsInput
+  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+    try {
+      // Validation (all before DB access, per Design Doc §Main Components → Handler).
+      // Intentional: use McpError(InvalidParams) (upgrade from handleDeleteFile's plain Error).
+      // See Design Doc §Main Components → Handler and §Risks — this asymmetry is documented;
+      // do not "fix" it.
+      if (!Number.isInteger(args.chunkIndex) || args.chunkIndex < 0) {
+        throw new McpError(ErrorCode.InvalidParams, 'chunkIndex must be a non-negative integer')
+      }
+      const before = args.before ?? 2
+      if (!Number.isInteger(before) || before < 0) {
+        throw new McpError(ErrorCode.InvalidParams, 'before must be a non-negative integer')
+      }
+      const after = args.after ?? 2
+      if (!Number.isInteger(after) || after < 0) {
+        throw new McpError(ErrorCode.InvalidParams, 'after must be a non-negative integer')
+      }
+      const hasFilePath = args.filePath !== undefined
+      const hasSource = args.source !== undefined
+      if (hasFilePath === hasSource) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          'Either filePath or source must be provided, not both'
+        )
+      }
+
+      // Dual-input resolution (mirrors handleDeleteFile).
+      let targetPath: string
+      let skipValidation = false
+      if (args.source !== undefined) {
+        targetPath = generateRawDataPath(this.dbPath, args.source, 'markdown')
+        skipValidation = true
+      } else {
+        // XOR above guarantees filePath is defined here.
+        targetPath = args.filePath as string
+      }
+      if (!skipValidation) {
+        await this.parser.validateFilePath(targetPath)
+      }
+
+      // Range composition (handler-side clamp; primitive stays feature-agnostic).
+      const minIdx = Math.max(0, args.chunkIndex - before)
+      const maxIdx = args.chunkIndex + after
+
+      // Primitive call.
+      const rows = await this.vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
+
+      // Post-fetch marking: isTarget per item; source attached for raw-data rows.
+      const isRaw = isRawDataPath(targetPath)
+      const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
+      const items: ReadChunkNeighborsResultItem[] = rows.map((row) => {
+        const item: ReadChunkNeighborsResultItem = {
+          filePath: row.filePath,
+          chunkIndex: row.chunkIndex,
+          text: row.text,
+          isTarget: row.chunkIndex === args.chunkIndex,
+          fileTitle: row.fileTitle ?? null,
+        }
+        if (sourceForAll) item.source = sourceForAll
+        return item
+      })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(items, null, 2),
+          },
+        ],
+      }
+    } catch (error) {
+      // Re-throw McpError / DatabaseError as-is to preserve semantics.
+      if (error instanceof McpError || error instanceof DatabaseError) {
+        throw error
+      }
+      const errorMessage = formatErrorMessage(error)
+      console.error('Failed to read chunk neighbors:', errorMessage)
+      throw new Error(`Failed to read chunk neighbors: ${errorMessage}`)
     }
   }
 

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -110,7 +110,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'read_chunk_neighbors',
     description:
-      'Read chunks surrounding a known chunk index within a single ingested document. This is a context-expansion utility, not a search tool: use it after you have already located a target chunk via query_documents or grep, to read the chunks immediately before and after it. It is not a replacement for query_documents and does not improve search accuracy. Provide either filePath (for files ingested via ingest_file) or source (for data ingested via ingest_data), not both. Out-of-range requests are handled leniently: only existing chunks in the requested range are returned, with no error.',
+      "Expand a query_documents result by reading the chunks immediately before and after it in the same document. Use when the hit needs more surrounding context — for example, a definition without its example, or a conclusion without its reasoning. Pass chunkIndex from the query_documents result, along with the document's filePath (from ingest_file) or source (from ingest_data). Returns the target chunk (isTarget: true) plus neighbors, sorted ascending by chunkIndex. Out-of-range indices are silently clamped to existing chunks. Defaults: before=2, after=2 (max 50 each). Provide exactly one of filePath or source.",
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -107,4 +107,37 @@ export const toolDefinitions: Tool[] = [
       'Get system status including total documents, total chunks, database size, and configuration information.',
     inputSchema: { type: 'object', properties: {} },
   },
+  {
+    name: 'read_chunk_neighbors',
+    description:
+      'Read chunks surrounding a known chunk index within a single ingested document. This is a context-expansion utility, not a search tool: use it after you have already located a target chunk via query_documents or grep, to read the chunks immediately before and after it. It is not a replacement for query_documents and does not improve search accuracy. Provide either filePath (for files ingested via ingest_file) or source (for data ingested via ingest_data), not both. Out-of-range requests are handled leniently: only existing chunks in the requested range are returned, with no error.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        filePath: {
+          type: 'string',
+          description:
+            'Absolute path to the file (for documents ingested via ingest_file). Example: "/Users/user/documents/manual.pdf". Provide either filePath or source, not both.',
+        },
+        source: {
+          type: 'string',
+          description:
+            'Source identifier used in ingest_data (for data ingested via ingest_data). Examples: "https://example.com/page", "clipboard://2024-12-30". Provide either filePath or source, not both.',
+        },
+        chunkIndex: {
+          type: 'number',
+          description: 'Zero-based target chunk index (non-negative integer).',
+        },
+        before: {
+          type: 'number',
+          description: 'Number of chunks before the target to include. Default: 2.',
+        },
+        after: {
+          type: 'number',
+          description: 'Number of chunks after the target to include. Default: 2.',
+        },
+      },
+      required: ['chunkIndex'],
+    },
+  },
 ]

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -130,11 +130,11 @@ export const toolDefinitions: Tool[] = [
         },
         before: {
           type: 'number',
-          description: 'Number of chunks before the target to include. Default: 2.',
+          description: 'Number of chunks to retrieve before the target (0–50, default 2).',
         },
         after: {
           type: 'number',
-          description: 'Number of chunks after the target to include. Default: 2.',
+          description: 'Number of chunks to retrieve after the target (0–50, default 2).',
         },
       },
       required: ['chunkIndex'],

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -135,3 +135,42 @@ export interface QueryResult {
   /** Document title extracted from file content (display-only, not used for scoring) */
   fileTitle: string | null
 }
+
+/**
+ * read_chunk_neighbors tool input.
+ * Exactly one of filePath / source must be provided (XOR).
+ */
+export interface ReadChunkNeighborsInput {
+  /** File path (for files ingested via ingest_file). Absolute path required. */
+  filePath?: string
+  /** Source identifier (for data ingested via ingest_data). */
+  source?: string
+  /** Target chunk index (zero-based, required, non-negative integer) (AC-010). */
+  chunkIndex: number
+  /** Number of chunks before the target to include (default 2, non-negative integer) (AC-009). */
+  before?: number
+  /** Number of chunks after the target to include (default 2, non-negative integer) (AC-009). */
+  after?: number
+}
+
+/**
+ * read_chunk_neighbors tool output item.
+ * Core fields {filePath, chunkIndex, text} per AC-002.
+ * isTarget per AC-019 (exactly one true when target exists; else all false).
+ * source per AC-020 (present on raw-data rows only).
+ * fileTitle mirrors QueryResult for drop-in consistency with query_documents results.
+ */
+export interface ReadChunkNeighborsResultItem {
+  /** File path */
+  filePath: string
+  /** Chunk index */
+  chunkIndex: number
+  /** Text */
+  text: string
+  /** True iff this chunk's chunkIndex matches the requested target (AC-019) */
+  isTarget: boolean
+  /** Original source (only for raw-data files, e.g., URLs ingested via ingest_data) (AC-020) */
+  source?: string
+  /** Document title extracted from file content (display-only, not used for scoring) */
+  fileTitle: string | null
+}

--- a/src/vectordb/__tests__/vectordb.test.ts
+++ b/src/vectordb/__tests__/vectordb.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { type VectorChunk, VectorStore } from '../index.js'
-import { isLanceDBRawResult, toSearchResult } from '../types.js'
+import { type ChunkRow, DatabaseError, isLanceDBRawResult, toSearchResult } from '../types.js'
 
 describe('VectorStore', () => {
   const testDbPath = './tmp/test-vectordb'
@@ -1238,6 +1238,204 @@ describe('VectorStore', () => {
           }
         }
       })
+    })
+  })
+
+  /**
+   * VectorStore.getChunksByRange — range-read primitive for read_chunk_neighbors.
+   *
+   * This describe block is the PROBE GATE for LanceDB numeric-predicate
+   * viability (chunkIndex >= N AND chunkIndex <= M). The first test is
+   * the Design Doc Early Verification Point. If it fails with a LanceDB
+   * SQL error, switch the primitive in src/vectordb/index.ts to the
+   * documented fallback (fetch-all + in-memory filter) and update the
+   * Design Doc Limitation note with the observed error text.
+   */
+  describe('getChunksByRange', () => {
+    it('should return chunks in range [2, 5] in order when seeding 10 contiguous chunks (Early Verification Point)', async () => {
+      const dbPath = './tmp/test-vectordb-range-probe'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        const filePath = '/test/contiguous.md'
+
+        // Seed 10 contiguous chunks with chunkIndex 0..9 in ascending insertion order
+        const chunks: VectorChunk[] = []
+        for (let i = 0; i < 10; i++) {
+          chunks.push(
+            createTestChunk(`Chunk ${i} body`, filePath, i, createNormalizedVector(i + 1))
+          )
+        }
+        await store.insertChunks(chunks)
+
+        const result = await store.getChunksByRange(filePath, 2, 5)
+
+        // Success criteria (Design Doc §Early Verification Point):
+        expect(result).toHaveLength(4)
+        expect(result.map((row) => row.chunkIndex)).toEqual([2, 3, 4, 5])
+        expect(result.every((row) => row.filePath === filePath)).toBe(true)
+
+        // ChunkRow shape: no score, no metadata keys present on any row
+        for (const row of result) {
+          expect(row).not.toHaveProperty('score')
+          expect(row).not.toHaveProperty('metadata')
+          expect(Object.keys(row).sort()).toEqual(['chunkIndex', 'filePath', 'fileTitle', 'text'])
+        }
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
+    })
+
+    it('should sort ascending even when chunks are inserted in descending order (AC-018 contract)', async () => {
+      const dbPath = './tmp/test-vectordb-range-sort'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        const filePath = '/test/descending.md'
+
+        // Insert chunks with chunkIndex 9,8,7,6,5,4,3,2,1,0 in that order
+        // (not ascending) so that ascending sort is a contract, not coincidence.
+        const insertionOrder = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        for (const idx of insertionOrder) {
+          await store.insertChunks([
+            createTestChunk(`Chunk ${idx}`, filePath, idx, createNormalizedVector(idx + 1)),
+          ])
+        }
+
+        const result = await store.getChunksByRange(filePath, 0, 9)
+
+        expect(result).toHaveLength(10)
+        expect(result.map((row) => row.chunkIndex)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
+    })
+
+    it('should return empty array when backing table has not been initialized (lazy-table)', async () => {
+      const dbPath = './tmp/test-vectordb-range-lazy-table'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        // Initialize but do not insert anything; this leaves the table null
+        // (createTable is deferred to first insertChunks call, per index.ts).
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        const result = await store.getChunksByRange('/any/path.md', 0, 10)
+
+        expect(result).toEqual([])
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
+    })
+
+    it('should throw DatabaseError with "Failed to read chunks by range" on simulated LanceDB failure', async () => {
+      const dbPath = './tmp/test-vectordb-range-db-error'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        // Seed a single chunk so the table is created
+        await store.insertChunks([
+          createTestChunk('seed', '/test/error-probe.md', 0, createNormalizedVector(1)),
+        ])
+
+        // Replace the internal table handle with a stub whose query() throws.
+        // Matches the "inject a temporarily corrupted table handle" pattern
+        // referenced in Task 1.3 step 3, consistent with no mocking library
+        // being used elsewhere in this test file.
+        const brokenTable = {
+          query: () => {
+            throw new Error('simulated LanceDB failure')
+          },
+        }
+        ;(store as unknown as { table: typeof brokenTable }).table = brokenTable
+
+        await expect(store.getChunksByRange('/test/error-probe.md', 0, 5)).rejects.toThrow(
+          DatabaseError
+        )
+        await expect(store.getChunksByRange('/test/error-probe.md', 0, 5)).rejects.toThrow(
+          /Failed to read chunks by range/
+        )
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
+    })
+
+    it('should normalize empty-string fileTitle to null and omit score/metadata keys (ChunkRow shape)', async () => {
+      const dbPath = './tmp/test-vectordb-range-chunkrow-shape'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        const filePath = '/test/shape.md'
+
+        // Seed a chunk where fileTitle is empty string (insertChunks stores ''
+        // verbatim when provided; toChunkRow normalizes '' → null on read).
+        const chunk: VectorChunk = {
+          ...createTestChunk('Body text', filePath, 0, createNormalizedVector(1)),
+          fileTitle: '',
+        }
+        await store.insertChunks([chunk])
+
+        const result: ChunkRow[] = await store.getChunksByRange(filePath, 0, 0)
+
+        expect(result).toHaveLength(1)
+        const row = result[0]
+        expect(row).toBeDefined()
+        expect(row!.fileTitle).toBeNull()
+        expect(row).not.toHaveProperty('score')
+        expect(row).not.toHaveProperty('metadata')
+        // The only keys on a ChunkRow are the four Design Doc fields
+        expect(Object.keys(row!).sort()).toEqual(['chunkIndex', 'filePath', 'fileTitle', 'text'])
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
     })
   })
 })

--- a/src/vectordb/__tests__/vectordb.test.ts
+++ b/src/vectordb/__tests__/vectordb.test.ts
@@ -1398,6 +1398,48 @@ describe('VectorStore', () => {
       }
     })
 
+    it('should throw DatabaseError when minIdx is NaN or a float (precondition guard)', async () => {
+      const dbPath = './tmp/test-vectordb-range-precondition'
+      if (fs.existsSync(dbPath)) {
+        fs.rmSync(dbPath, { recursive: true })
+      }
+
+      try {
+        const store = new VectorStore({
+          dbPath,
+          tableName: 'chunks',
+        })
+        await store.initialize()
+
+        // Seed a single chunk so the table is created
+        await store.insertChunks([
+          createTestChunk('seed', '/test/precondition.md', 0, createNormalizedVector(1)),
+        ])
+
+        // NaN minIdx
+        await expect(
+          store.getChunksByRange('/test/precondition.md', Number.NaN, 5)
+        ).rejects.toThrow(DatabaseError)
+        await expect(
+          store.getChunksByRange('/test/precondition.md', Number.NaN, 5)
+        ).rejects.toThrow(/non-negative integer range bounds/)
+
+        // Float minIdx
+        await expect(store.getChunksByRange('/test/precondition.md', 1.5, 5)).rejects.toThrow(
+          DatabaseError
+        )
+
+        // maxIdx < minIdx
+        await expect(store.getChunksByRange('/test/precondition.md', 5, 2)).rejects.toThrow(
+          DatabaseError
+        )
+      } finally {
+        if (fs.existsSync(dbPath)) {
+          fs.rmSync(dbPath, { recursive: true })
+        }
+      }
+    })
+
     it('should normalize empty-string fileTitle to null and omit score/metadata keys (ChunkRow shape)', async () => {
       const dbPath = './tmp/test-vectordb-range-chunkrow-shape'
       if (fs.existsSync(dbPath)) {

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -145,6 +145,12 @@ export class VectorStore {
       return []
     }
 
+    if (!Number.isInteger(minIdx) || !Number.isInteger(maxIdx) || minIdx < 0 || maxIdx < minIdx) {
+      throw new DatabaseError(
+        'getChunksByRange requires non-negative integer range bounds with minIdx <= maxIdx'
+      )
+    }
+
     try {
       // Escape single quotes to prevent SQL injection (mirrors deleteChunks)
       const escapedFilePath = filePath.replace(/'/g, "''")
@@ -157,7 +163,6 @@ export class VectorStore {
       rows.sort((a, b) => a.chunkIndex - b.chunkIndex)
       return rows
     } catch (error) {
-      console.warn('VectorStore: Error reading chunks by range:', error)
       throw new DatabaseError('Failed to read chunks by range', error as Error)
     }
   }

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -3,11 +3,13 @@
 import { type Connection, connect, Index, type Table } from '@lancedb/lancedb'
 import { applyFileFilter, applyGrouping, applyKeywordBoost } from './search-filters.js'
 import {
+  type ChunkRow,
   DatabaseError,
   FTS_CLEANUP_THRESHOLD_MS,
   FTS_INDEX_NAME,
   HYBRID_SEARCH_CANDIDATE_MULTIPLIER,
   type SearchResult,
+  toChunkRow,
   toSearchResult,
   type VectorChunk,
   type VectorStoreConfig,
@@ -110,6 +112,53 @@ export class VectorStore {
       ) {
         throw new DatabaseError(`Failed to delete chunks for file: ${filePath}`, error as Error)
       }
+    }
+  }
+
+  /**
+   * Return chunk rows for a single file whose chunkIndex is within the
+   * inclusive [minIdx, maxIdx] range, sorted ascending by chunkIndex.
+   *
+   * This is a feature-agnostic primitive (ADR-0001 D5): it knows nothing
+   * about before/after/isTarget semantics — those live in the handler.
+   * Ascending sort by chunkIndex is a contract, not incidental storage
+   * order (AC-018).
+   *
+   * Lazy-table null returns [] (mirrors search, listFiles, deleteChunks).
+   * LanceDB errors are wrapped as DatabaseError with the original error
+   * preserved as cause.
+   *
+   * Note: LanceDB numeric predicates (>=, <=) on chunkIndex are not
+   * exercised elsewhere in the repo today. Task 1.3 unit tests act as
+   * the probe for this SQL shape; see Design Doc §Main Components →
+   * VectorStore Limitation note for the fetch-all + in-memory-filter
+   * fallback plan if the probe fails.
+   *
+   * @param filePath - File path (absolute)
+   * @param minIdx - Minimum chunk index (inclusive)
+   * @param maxIdx - Maximum chunk index (inclusive)
+   * @returns Array of chunk rows sorted ascending by chunkIndex
+   */
+  async getChunksByRange(filePath: string, minIdx: number, maxIdx: number): Promise<ChunkRow[]> {
+    if (!this.table) {
+      console.error('VectorStore: Skipping range read as table does not exist')
+      return []
+    }
+
+    try {
+      // Escape single quotes to prevent SQL injection (mirrors deleteChunks)
+      const escapedFilePath = filePath.replace(/'/g, "''")
+      // Backtick-quoted camelCase columns; numeric literals unquoted
+      const predicate = `\`filePath\` = '${escapedFilePath}' AND \`chunkIndex\` >= ${minIdx} AND \`chunkIndex\` <= ${maxIdx}`
+
+      const raw = await this.table.query().where(predicate).toArray()
+      const rows = raw.map((row) => toChunkRow(row))
+      // Contractual ascending sort (AC-018); do not rely on storage order
+      rows.sort((a, b) => a.chunkIndex - b.chunkIndex)
+      return rows
+    } catch (error) {
+      console.warn('VectorStore: Error reading chunks by range:', error)
+      throw new DatabaseError('Failed to read chunks by range', error as Error)
     }
   }
 

--- a/src/vectordb/types.ts
+++ b/src/vectordb/types.ts
@@ -95,6 +95,24 @@ export interface SearchResult {
 }
 
 /**
+ * Row returned by VectorStore.getChunksByRange.
+ * Distinct from SearchResult (see Design Doc §Contract Definitions):
+ * no score (not a ranked result) and no metadata (not needed for
+ * index-adjacent retrieval). Consumed by handleReadChunkNeighbors
+ * and runReadNeighbors (Task 1.2).
+ */
+export interface ChunkRow {
+  /** File path (absolute) */
+  filePath: string
+  /** Chunk index (zero-based) */
+  chunkIndex: number
+  /** Chunk text */
+  text: string
+  /** Document title extracted from file content (display-only, not used for scoring) */
+  fileTitle: string | null
+}
+
+/**
  * Raw result from LanceDB query (internal type)
  */
 export interface LanceDBRawResult {
@@ -154,6 +172,42 @@ export function toSearchResult(raw: unknown): SearchResult {
     score: raw._distance ?? raw._score ?? 0,
     metadata: raw.metadata,
     fileTitle: raw.fileTitle || null,
+  }
+}
+
+/**
+ * Convert LanceDB raw row to ChunkRow with type validation.
+ * Mirrors toSearchResult but returns the minimal shape defined in
+ * Design Doc §Contract Definitions: no score (not ranked) and no
+ * metadata (not needed for index-adjacent retrieval).
+ *
+ * Uses a narrower shape check than isLanceDBRawResult: only
+ * filePath/chunkIndex/text are required because getChunksByRange
+ * does not project metadata. The empty-string-or-missing fileTitle
+ * is normalized to null per §Field Propagation Map.
+ *
+ * @throws DatabaseError if the raw row is missing required fields
+ */
+export function toChunkRow(raw: unknown): ChunkRow {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new DatabaseError('Invalid chunk row shape from LanceDB')
+  }
+  const obj = raw as Record<string, unknown>
+  if (
+    typeof obj['filePath'] !== 'string' ||
+    typeof obj['chunkIndex'] !== 'number' ||
+    typeof obj['text'] !== 'string'
+  ) {
+    throw new DatabaseError('Invalid chunk row shape from LanceDB')
+  }
+  const rawFileTitle = obj['fileTitle']
+  const fileTitle =
+    typeof rawFileTitle === 'string' && rawFileTitle.length > 0 ? rawFileTitle : null
+  return {
+    filePath: obj['filePath'],
+    chunkIndex: obj['chunkIndex'],
+    text: obj['text'],
+    fileTitle,
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `read_chunk_neighbors` MCP tool and `read-neighbors` CLI subcommand for on-demand context expansion around a known chunk (issue #104)
- New `VectorStore.getChunksByRange` primitive for range-based chunk retrieval (non-vector, LanceDB WHERE clause)
- Dual-input support (`filePath` OR `source` URL) mirroring `delete_file` pattern
- Separate `--before` / `--after` flags (default 2 each, max 50) for asymmetric window control
- Lenient out-of-range policy: returns only existing chunks, no error
- Target chunk included in response with `isTarget: true` marker
- Skills docs updated with on-demand trigger conditions, semantic chunking context, and stable tool-name bridging for multi-client compatibility

## Changed files (13 files, +2164/-3)

**VectorStore layer**
- `src/vectordb/types.ts` — `ChunkRow` interface + `toChunkRow` guard
- `src/vectordb/index.ts` — `getChunksByRange(filePath, minIdx, maxIdx)` with precondition guard

**MCP server**
- `src/server/types.ts` — `ReadChunkNeighborsInput` + `ReadChunkNeighborsResultItem`
- `src/server/tool-definitions.ts` — `read_chunk_neighbors` tool schema
- `src/server/index.ts` — `handleReadChunkNeighbors` handler + dispatch

**CLI**
- `src/cli/read-neighbors.ts` — `runReadNeighbors` subcommand
- `src/cli-main.ts` — dispatch wiring
- `src/cli/options.ts` — `ROOT_HELP_TEXT` entry

**Tests (562 total, 37 new)**
- `src/vectordb/__tests__/vectordb.test.ts` — 6 unit tests (range filter, sort, null-table, guard, shape)
- `src/server/__tests__/rag-server.read-neighbors.integration.test.ts` — 14 integration tests (AC coverage + P95 < 100ms + single-call sufficiency)
- `src/__tests__/cli/read-neighbors.test.ts` — 11 CLI unit tests

**Skills docs**
- `skills/mcp-local-rag/SKILL.md` — description with tool names, Context Expansion section, tool-name bridging note
- `skills/mcp-local-rag/references/cli-reference.md` — `read-neighbors` reference block

## Test plan

- [ ] `pnpm run check:all` passes (lint + format + unused exports + circular deps + build + 562 tests)
- [ ] `npx mcp-local-rag read-neighbors --file-path <path> --chunk-index <N>` returns adjacent chunks
- [ ] `npx mcp-local-rag read-neighbors --help` prints usage and exits 0
- [ ] MCP tool `read_chunk_neighbors` returns correct window with `isTarget` marker
- [ ] P95 latency < 100ms on 10k-chunk document (measured in CI, reported below)
- [ ] `before > 50` / `after > 50` rejected with validation error
- [ ] Skills doc correctly triggers on "read around that chunk" intent

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)