### PR TITLE
Improve validation for filePath and source

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -667,8 +667,10 @@ export class RAGServer {
       if (after > 50) {
         throw new McpError(ErrorCode.InvalidParams, `after must be between 0 and 50 (got ${after})`)
       }
-      const hasFilePath = args.filePath !== undefined
-      const hasSource = args.source !== undefined
+
+      const hasFilePath = typeof args.filePath === 'string' && args.filePath.trim().length > 0
+      const hasSource = typeof args.source === 'string' && args.source.trim().length > 0
+      
       if (hasFilePath === hasSource) {
         throw new McpError(
           ErrorCode.InvalidParams,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -667,10 +667,8 @@ export class RAGServer {
       if (after > 50) {
         throw new McpError(ErrorCode.InvalidParams, `after must be between 0 and 50 (got ${after})`)
       }
-
       const hasFilePath = typeof args.filePath === 'string' && args.filePath.trim().length > 0
       const hasSource = typeof args.source === 'string' && args.source.trim().length > 0
-      
       if (hasFilePath === hasSource) {
         throw new McpError(
           ErrorCode.InvalidParams,


### PR DESCRIPTION
## Handle empty `source` correctly in `read_chunk_neighbors` validation

This PR tightens input validation for `read_chunk_neighbors` by treating empty string values as missing input instead of as provided values. It prevents false `"Either filePath or source must be provided, not both"` errors when callers send `source: ""` alongside a valid `filePath`.

I get a lot of these errors

<img width="415" height="372" alt="{583E87E2-1D91-4A84-A6F0-878C6957E7D0}" src="https://github.com/user-attachments/assets/146d036d-0c47-4672-8ff2-f4f3cb23cda0" />
