### PR TITLE
fix: reject CLI flags on bare MCP server launch (closes #124)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ dist/
 # Runtime data
 coverage
 test-output.json
+lancedb/
+models/
 
 # IDE and editor specific files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ For the full list of CLI flags, environment variables, and defaults, see [Config
 
 For CLI-only setups (no MCP server), install [Agent Skills](#agent-skills) so your AI assistant can form better queries and interpret results consistently.
 
-> ⚠️ **`--model-name` must match your MCP server config.** Using a different embedding model against an existing database produces incompatible vectors, silently degrading search quality.
+> ⚠️ **CLI `--model-name` must match the MCP server's `MODEL_NAME` env var.** Using a different embedding model against an existing database produces incompatible vectors, silently degrading search quality.
 
 ## Search Tuning
 
@@ -310,7 +310,7 @@ apply the mcp-local-rag skill for better query formulation and result interpreta
 
 ### Environment Variables and CLI Flags
 
-Both MCP and CLI use the same environment variables. The CLI also accepts equivalent flags.
+The MCP server is configured by environment variables only — pass them through your MCP client's `env` block. The CLI accepts the same env vars plus equivalent flags (priority: CLI flag > env > default). CLI flags are not accepted on the bare `mcp-local-rag` (MCP server) launch.
 
 | Environment Variable | CLI Flag | Default | Description |
 |---------------------|----------|---------|-------------|

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ if (firstArg && SUBCOMMANDS.has(firstArg)) {
     process.exit(1)
   })
 } else {
-  // Default: start MCP server
+  // Default: start MCP server (env-only, no CLI flags)
   process.on('unhandledRejection', (reason, promise) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason)
     process.exit(1)
@@ -42,5 +42,5 @@ if (firstArg && SUBCOMMANDS.has(firstArg)) {
     process.exit(1)
   })
 
-  startServer(globalOptions)
+  startServer()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,15 @@ if (firstArg && SUBCOMMANDS.has(firstArg)) {
     console.error(error)
     process.exit(1)
   })
-} else {
+} else if (remainingArgs.length === 0) {
+  if (Object.keys(globalOptions).length > 0) {
+    console.error('Global CLI options are not supported when launching the MCP server directly.')
+    console.error(
+      'Use environment variables like DB_PATH, CACHE_DIR, MODEL_NAME, BASE_DIR, and MAX_FILE_SIZE instead.'
+    )
+    process.exit(1)
+  }
+
   // Default: start MCP server (env-only, no CLI flags)
   process.on('unhandledRejection', (reason, promise) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason)
@@ -43,4 +51,8 @@ if (firstArg && SUBCOMMANDS.has(firstArg)) {
   })
 
   startServer()
+} else {
+  console.error(`Unknown command: ${firstArg}`)
+  console.error('Available commands: skills, ingest, list, query, status, delete, read-neighbors')
+  process.exit(1)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,5 +42,5 @@ if (firstArg && SUBCOMMANDS.has(firstArg)) {
     process.exit(1)
   })
 
-  startServer()
+  startServer(globalOptions)
 }

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -88,16 +88,11 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
  */
 export async function startServer(): Promise<void> {
   try {
-    // Read config from environment variables only (for MCP client compatibility)
-    const dbPath = process.env['DB_PATH'] ?? './lancedb/'
-    const modelName = process.env['MODEL_NAME'] ?? 'Xenova/all-MiniLM-L6-v2'
-    const cacheDir = process.env['CACHE_DIR'] ?? './models/'
-
-    // RAGServer configuration
+    // RAGServer configuration (env-only for MCP client compatibility)
     const config: ConstructorParameters<typeof RAGServer>[0] = {
-      dbPath,
-      modelName,
-      cacheDir,
+      dbPath: process.env['DB_PATH'] || './lancedb/',
+      modelName: process.env['MODEL_NAME'] || 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: process.env['CACHE_DIR'] || './models/',
       baseDir: process.env['BASE_DIR'] || process.cwd(),
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
     }

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,5 +1,4 @@
 // MCP Server entry point
-import type { GlobalOptions } from './cli/options.js'
 import { RAGServer } from './server/index.js'
 import type { GroupingMode } from './vectordb/index.js'
 
@@ -84,13 +83,15 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
 
 /**
  * Start the RAG MCP Server
+ * Configuration is read from environment variables only (no CLI flags).
+ * This ensures the bare `mcp-local-rag` launch is suitable for MCP clients.
  */
-export async function startServer(cliOptions: GlobalOptions = {}): Promise<void> {
+export async function startServer(): Promise<void> {
   try {
-    // Priority: CLI flag > env var > default
-    const dbPath = cliOptions.dbPath ?? process.env['DB_PATH'] ?? './lancedb/'
-    const modelName = cliOptions.modelName ?? process.env['MODEL_NAME'] ?? 'Xenova/all-MiniLM-L6-v2'
-    const cacheDir = cliOptions.cacheDir ?? process.env['CACHE_DIR'] ?? './models/'
+    // Read config from environment variables only (for MCP client compatibility)
+    const dbPath = process.env['DB_PATH'] ?? './lancedb/'
+    const modelName = process.env['MODEL_NAME'] ?? 'Xenova/all-MiniLM-L6-v2'
+    const cacheDir = process.env['CACHE_DIR'] ?? './models/'
 
     // RAGServer configuration
     const config: ConstructorParameters<typeof RAGServer>[0] = {

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,4 +1,5 @@
 // MCP Server entry point
+import type { GlobalOptions } from './cli/options.js'
 import { RAGServer } from './server/index.js'
 import type { GroupingMode } from './vectordb/index.js'
 
@@ -84,13 +85,18 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
 /**
  * Start the RAG MCP Server
  */
-export async function startServer(): Promise<void> {
+export async function startServer(cliOptions: GlobalOptions = {}): Promise<void> {
   try {
+    // Priority: CLI flag > env var > default
+    const dbPath = cliOptions.dbPath ?? process.env['DB_PATH'] ?? './lancedb/'
+    const modelName = cliOptions.modelName ?? process.env['MODEL_NAME'] ?? 'Xenova/all-MiniLM-L6-v2'
+    const cacheDir = cliOptions.cacheDir ?? process.env['CACHE_DIR'] ?? './models/'
+
     // RAGServer configuration
     const config: ConstructorParameters<typeof RAGServer>[0] = {
-      dbPath: process.env['DB_PATH'] || './lancedb/',
-      modelName: process.env['MODEL_NAME'] || 'Xenova/all-MiniLM-L6-v2',
-      cacheDir: process.env['CACHE_DIR'] || './models/',
+      dbPath,
+      modelName,
+      cacheDir,
       baseDir: process.env['BASE_DIR'] || process.cwd(),
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
     }


### PR DESCRIPTION
Closes #124

## Summary

`mcp-local-rag` (no subcommand) starts the MCP server. MCP clients launch it via an `env` block in their config, so `startServer()` reads from env vars only. But global CLI flags passed before the bare launch (`mcp-local-rag --db-path X`) were silently ignored, which #124 flagged as confusing.

This PR makes the env-only contract explicit instead of wiring flag-parsing into a launch path MCP clients don't use:

- Bare form fails fast with a clear message if global flags are passed, pointing users at the env vars
- Unknown subcommands error out with the available-commands list
- JSDoc on `startServer()` documents the env-only contract
- README clarifies that CLI flags apply to subcommands only, and the `--model-name` warning now points at the MCP server's `MODEL_NAME` env var explicitly
- CLI flags continue to work on subcommands (`ingest`, `query`, ...) — unchanged

Also adds `lancedb/` and `models/` to `.gitignore` so runtime-generated directories are not tracked.

## Test plan

- [ ] `pnpm test` passes
- [ ] `pnpm dev --db-path /foo` exits 1 with a helpful message
- [ ] `pnpm dev fooble` exits 1 with "Unknown command"
- [ ] `pnpm dev` (no args) starts the MCP server using env vars
- [ ] `pnpm dev ingest /path` still works (subcommand CLI flags unaffected)