### PR TITLE
feat: GPU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,19 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
-    - name: Install Vulkan SDK and SwiftShader (webgpu only)
+    - name: Install Vulkan SDK and Software Rasterizer (webgpu only)
       if: matrix.device == 'webgpu'
       uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
       with:
         install_runtime: true
-        install_swiftshader: true
+        install_swiftshader: ${{ runner.os == 'Windows' }}
+        install_lavapipe: ${{ runner.os == 'Linux' }}
+
+    - name: Install Vulkan Dependencies (Ubuntu, webgpu only)
+      if: matrix.device == 'webgpu' && runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvulkan1 vulkan-tools libwayland-client0 mesa-vulkan-drivers
 
     - name: Verify Vulkan (webgpu only)
       if: matrix.device == 'webgpu'
@@ -79,6 +86,10 @@ jobs:
     - name: Run tests
       env:
         RAG_DEVICE: ${{ matrix.device }}
+        # Direct Dawn to use Vulkan (rather than D3D12) on Windows when running webgpu
+        # mode in CI, so SwiftShader can serve as the adapter.
+        WGPU_BACKEND: ${{ matrix.device == 'webgpu' && 'vulkan' || '' }}
+        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,16 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    # The integration tests use Xenova/all-MiniLM-L6-v2 via @huggingface/transformers,
+    # which is downloaded on first use (~90MB). Caching it across runs avoids a
+    # network round-trip on every CI build and prevents the first-touched beforeAll
+    # from blowing its 30s hook timeout on slower Windows runners.
+    - name: Cache HuggingFace model
+      uses: actions/cache@v4
+      with:
+        path: tmp/models
+        key: hf-model-${{ runner.os }}-Xenova-all-MiniLM-L6-v2
+
     - name: Lint check
       run: pnpm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,14 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
-    - name: Install Vulkan SDK with SwiftShader (Windows, webgpu only)
-      if: matrix.device == 'webgpu' && runner.os == 'Windows'
+    - name: Install Vulkan SDK and Software Rasterizer (webgpu only)
+      if: matrix.device == 'webgpu'
       uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
       with:
         install_runtime: true
-        install_swiftshader: true
+        # install_swiftshader is used on Windows, install_lavapipe on Linux
+        install_swiftshader: ${{ runner.os == 'Windows' }}
+        install_lavapipe: ${{ runner.os == 'Linux' }}
 
     - name: Install Vulkan and Mesa (Ubuntu, webgpu only)
       if: matrix.device == 'webgpu' && runner.os == 'Linux'
@@ -81,9 +83,9 @@ jobs:
       env:
         RAG_DEVICE: ${{ matrix.device }}
         # Direct Dawn to use Vulkan (rather than D3D12) on Windows when running webgpu
-        # mode in CI, so SwiftShader can serve as the adapter.
+        # mode in CI, so SwiftShader/Lavapipe can serve as the adapter.
         WGPU_BACKEND: ${{ matrix.device == 'webgpu' && 'vulkan' || '' }}
-        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
+        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && (runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '/usr/share/vulkan/icd.d/lvp_icd.x86_64.json') || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        # We test the two RAG_DEVICE branches we own the code for:
+        #   cpu     — onnxruntime-node native CPU (default; works everywhere).
+        #   webgpu  — onnxruntime-node's WebGPU EP, exercised via software Vulkan
+        #             (SwiftShader on Windows, Mesa llvmpipe on Linux) since CI
+        #             runners have no real GPU.
+        # Verified locally that the WebGPU EP does compile and dispatch WGSL to
+        # the selected adapter (nvidia-smi shows node.exe on the GPU during a run),
+        # so SwiftShader is a real software substitute, not a CPU-fallback fake.
+        # Native EPs (dml/cuda/coreml) need real hardware and aren't covered here.
+        device: [cpu, webgpu]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -36,23 +46,22 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
-    - name: Install Vulkan SDK (Windows)
-      if: runner.os == 'Windows'
+    - name: Install Vulkan SDK with SwiftShader (Windows, webgpu only)
+      if: matrix.device == 'webgpu' && runner.os == 'Windows'
       uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
       with:
         install_runtime: true
         install_swiftshader: true
 
-    - name: Install Vulkan & SwiftShader (Ubuntu)
-      if: runner.os == 'Linux'
+    - name: Install Vulkan and Mesa (Ubuntu, webgpu only)
+      if: matrix.device == 'webgpu' && runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install -y libvulkan1 mesa-vulkan-drivers vulkan-tools
 
     # The integration tests use Xenova/all-MiniLM-L6-v2 via @huggingface/transformers,
     # which is downloaded on first use (~90MB). Caching it across runs avoids a
-    # network round-trip on every CI build and prevents the first-touched beforeAll
-    # from blowing its 30s hook timeout on slower Windows runners.
+    # network round-trip on every CI build.
     - name: Cache HuggingFace model
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
@@ -70,9 +79,11 @@ jobs:
 
     - name: Run tests
       env:
-        WGPU_BACKEND: vulkan
-        # Default SwiftShader location on Windows as per the action:
-        VK_ICD_FILENAMES: ${{ runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
+        RAG_DEVICE: ${{ matrix.device }}
+        # Direct Dawn to use Vulkan (rather than D3D12) on Windows when running webgpu
+        # mode in CI, so SwiftShader can serve as the adapter.
+        WGPU_BACKEND: ${{ matrix.device == 'webgpu' && 'vulkan' || '' }}
+        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,19 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    - name: Install Vulkan SDK (Windows)
+      if: runner.os == 'Windows'
+      uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
+      with:
+        install_runtime: true
+        install_swiftshader: true
+
+    - name: Install Vulkan & SwiftShader (Ubuntu)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libvulkan1 mesa-vulkan-drivers vulkan-tools
+
     # The integration tests use Xenova/all-MiniLM-L6-v2 via @huggingface/transformers,
     # which is downloaded on first use (~90MB). Caching it across runs avoids a
     # network round-trip on every CI build and prevents the first-touched beforeAll
@@ -56,6 +69,10 @@ jobs:
       run: pnpm run build
 
     - name: Run tests
+      env:
+        WGPU_BACKEND: vulkan
+        # Default SwiftShader location on Windows as per the action:
+        VK_ICD_FILENAMES: ${{ runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     # network round-trip on every CI build and prevents the first-touched beforeAll
     # from blowing its 30s hook timeout on slower Windows runners.
     - name: Cache HuggingFace model
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: tmp/models
         key: hf-model-${{ runner.os }}-Xenova-all-MiniLM-L6-v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,48 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  static-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
+      with:
+        version: 10
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Lint check
+      run: pnpm run lint
+
+    - name: Format check
+      run: pnpm run format:check
+
+    - name: Type check
+      run: pnpm run build
+
+    - name: Check production dependencies
+      run: npx report-missing-dependencies
+
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # We test the two RAG_DEVICE branches we own the code for:
-        #   cpu     — onnxruntime-node native CPU (default; works everywhere).
-        #   webgpu  — onnxruntime-node's WebGPU EP, exercised via software Vulkan
-        #             (SwiftShader on Windows, Mesa llvmpipe on Linux) since CI
-        #             runners have no real GPU.
-        # Verified locally that the WebGPU EP does compile and dispatch WGSL to
-        # the selected adapter (nvidia-smi shows node.exe on the GPU during a run),
-        # so SwiftShader is a real software substitute, not a CPU-fallback fake.
-        # Native EPs (dml/cuda/coreml) need real hardware and aren't covered here.
+        # webgpu cells install a software Vulkan adapter (SwiftShader on
+        # Windows, Lavapipe on Linux) because CI runners have no GPU.
         device: [cpu, webgpu]
     runs-on: ${{ matrix.os }}
 
@@ -62,26 +90,18 @@ jobs:
 
     - name: Verify Vulkan (webgpu only)
       if: matrix.device == 'webgpu'
-      run: |
-        vulkaninfo --summary || echo "vulkaninfo failed"
+      run: vulkaninfo --summary
 
     # The integration tests use Xenova/all-MiniLM-L6-v2 via @huggingface/transformers,
-    # which is downloaded on first use (~90MB). Caching it across runs avoids a
-    # network round-trip on every CI build.
-    - name: Cache HuggingFace model
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+    # which is downloaded on first use (~90MB). Both device cells per OS share the
+    # same model artefacts, so we restore on every cell but save only from the cpu
+    # cell to avoid two cells racing to reserve/save the same key.
+    - name: Restore HuggingFace model cache
+      id: hf-cache-restore
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: tmp/models
         key: hf-model-${{ runner.os }}-Xenova-all-MiniLM-L6-v2
-
-    - name: Lint check
-      run: pnpm run lint
-
-    - name: Format check
-      run: pnpm run format:check
-
-    - name: Type check
-      run: pnpm run build
 
     - name: Run tests
       env:
@@ -92,16 +112,20 @@ jobs:
         VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && (runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '/usr/share/vulkan/icd.d/lvp_icd.json') || '' }}
       run: pnpm test
 
-    - name: Check production dependencies
-      run: npx report-missing-dependencies
+    - name: Save HuggingFace model cache
+      if: matrix.device == 'cpu' && steps.hf-cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: tmp/models
+        key: ${{ steps.hf-cache-restore.outputs.cache-primary-key }}
 
   # Stable aggregate check. The `main` ruleset requires a status named `ci`,
   # so this job keeps that name regardless of the test matrix dimensions.
   ci:
-    needs: test
+    needs: [static-checks, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Verify the test matrix succeeded
-      if: needs.test.result != 'success'
+      if: needs.static-checks.result != 'success' || needs.test.result != 'success'
       run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
       env:
         RAG_DEVICE: ${{ matrix.device }}
         # Direct Dawn to use Vulkan (rather than D3D12) on Windows when running webgpu
-        # mode in CI, so SwiftShader can serve as the adapter.
+        # mode in CI, so SwiftShader/Lavapipe can serve as the adapter.
         WGPU_BACKEND: ${{ matrix.device == 'webgpu' && 'vulkan' || '' }}
-        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '' }}
+        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && (runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '/usr/share/vulkan/icd.d/lvp_icd.json') || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,20 +46,17 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
-    - name: Install Vulkan SDK and Software Rasterizer (webgpu only)
+    - name: Install Vulkan SDK and SwiftShader (webgpu only)
       if: matrix.device == 'webgpu'
       uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
       with:
         install_runtime: true
-        # install_swiftshader is used on Windows, install_lavapipe on Linux
-        install_swiftshader: ${{ runner.os == 'Windows' }}
-        install_lavapipe: ${{ runner.os == 'Linux' }}
+        install_swiftshader: true
 
-    - name: Install Vulkan and Mesa (Ubuntu, webgpu only)
-      if: matrix.device == 'webgpu' && runner.os == 'Linux'
+    - name: Verify Vulkan (webgpu only)
+      if: matrix.device == 'webgpu'
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libvulkan1 mesa-vulkan-drivers vulkan-tools
+        vulkaninfo --summary || echo "vulkaninfo failed"
 
     # The integration tests use Xenova/all-MiniLM-L6-v2 via @huggingface/transformers,
     # which is downloaded on first use (~90MB). Caching it across runs avoids a
@@ -82,10 +79,6 @@ jobs:
     - name: Run tests
       env:
         RAG_DEVICE: ${{ matrix.device }}
-        # Direct Dawn to use Vulkan (rather than D3D12) on Windows when running webgpu
-        # mode in CI, so SwiftShader/Lavapipe can serve as the adapter.
-        WGPU_BACKEND: ${{ matrix.device == 'webgpu' && 'vulkan' || '' }}
-        VK_ICD_FILENAMES: ${{ matrix.device == 'webgpu' && (runner.os == 'Windows' && 'C:\SwiftShader\vk_swiftshader_icd.json' || '/usr/share/vulkan/icd.d/lvp_icd.x86_64.json') || '' }}
       run: pnpm test
 
     - name: Check production dependencies

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ PDF, DOCX, TXT, Markdown, and HTML (via `ingest_data`). Not yet: Excel, PowerPoi
 Yes, but you must delete your database and re-ingest all documents. Different models produce incompatible vector dimensions.
 
 **GPU acceleration?**
-Opt-in via `RAG_DEVICE`. `webgpu` works on Windows, macOS, and Linux and offloads compute to the GPU. For maximum throughput pick the platform-native EP: `dml` (Windows), `cuda` (Linux x64 with NVIDIA), `coreml` (macOS). Default is `cpu`. The server throws if the requested device fails — set `RAG_DEVICE=cpu` to revert.
+Opt-in via `RAG_DEVICE`. Verified: `webgpu` offloads compute to the GPU on Windows with a real D3D12-capable adapter (`nvidia-smi` confirms the Node process on the GPU). Linux and macOS WebGPU paths exist but are not verified in this repo. For maximum throughput pick the platform-native EP: `dml` (Windows), `cuda` (Linux x64 NVIDIA), `coreml` (macOS). Default is `cpu`. The server throws if the requested device fails — set `RAG_DEVICE=cpu` to revert.
 
 **Multi-user support?**
 No. Designed for single-user, local access. Multi-user would require authentication/access control.

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ PDF, DOCX, TXT, Markdown, and HTML (via `ingest_data`). Not yet: Excel, PowerPoi
 Yes, but you must delete your database and re-ingest all documents. Different models produce incompatible vector dimensions.
 
 **GPU acceleration?**
-Transformers.js runs on CPU. GPU support is experimental. CPU performance is adequate for most use cases.
+WebGPU is used by default with automatic CPU fallback. No configuration needed — if WebGPU is unavailable the embedder switches to CPU silently.
 
 **Multi-user support?**
 No. Designed for single-user, local access. Multi-user would require authentication/access control.

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ The MCP server is configured by environment variables only — pass them through
 | `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model ID ([available models](https://huggingface.co/models?library=transformers.js&pipeline_tag=feature-extraction)) |
 | `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100MB) | Maximum file size in bytes |
 | `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Minimum chunk length in characters (1–10000) |
+| `RAG_DEVICE` | — | `cpu` | Execution device. Pass straight to ONNX Runtime. Recommended values: `cpu` (default), `webgpu` (cross-platform GPU offload), `dml` (Windows max-perf), `cuda` (Linux x64 NVIDIA), `coreml` (macOS). Also accepts `wasm`, `auto`, `gpu`. |
 
 **Model choice tips:**
 - Multilingual docs → e.g., `onnx-community/embeddinggemma-300m-ONNX` (100+ languages)
@@ -444,7 +445,7 @@ PDF, DOCX, TXT, Markdown, and HTML (via `ingest_data`). Not yet: Excel, PowerPoi
 Yes, but you must delete your database and re-ingest all documents. Different models produce incompatible vector dimensions.
 
 **GPU acceleration?**
-WebGPU is used by default with automatic CPU fallback. No configuration needed — if WebGPU is unavailable the embedder switches to CPU silently.
+Opt-in via `RAG_DEVICE`. `webgpu` works on Windows, macOS, and Linux and offloads compute to the GPU. For maximum throughput pick the platform-native EP: `dml` (Windows), `cuda` (Linux x64 with NVIDIA), `coreml` (macOS). Default is `cpu`. The server throws if the requested device fails — set `RAG_DEVICE=cpu` to revert.
 
 **Multi-user support?**
 No. Designed for single-user, local access. Multi-user would require authentication/access control.

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The MCP server is configured by environment variables only — pass them through
 | `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model ID ([available models](https://huggingface.co/models?library=transformers.js&pipeline_tag=feature-extraction)) |
 | `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100MB) | Maximum file size in bytes |
 | `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Minimum chunk length in characters (1–10000) |
-| `RAG_DEVICE` | — | `cpu` | Execution device. Pass straight to ONNX Runtime. Recommended values: `cpu` (default), `webgpu` (cross-platform GPU offload), `dml` (Windows max-perf), `cuda` (Linux x64 NVIDIA), `coreml` (macOS). Also accepts `wasm`, `auto`, `gpu`. |
+| `RAG_DEVICE` | — | `cpu` | Execution device. Passed straight to ONNX Runtime. See the [Transformers.js device source code](https://github.com/huggingface/transformers.js/blob/main/packages/transformers/src/utils/devices.js) for the live list of supported backend names. If initialization fails, the server throws an error. |
 
 **Model choice tips:**
 - Multilingual docs → e.g., `onnx-community/embeddinggemma-300m-ONNX` (100+ languages)
@@ -445,7 +445,7 @@ PDF, DOCX, TXT, Markdown, and HTML (via `ingest_data`). Not yet: Excel, PowerPoi
 Yes, but you must delete your database and re-ingest all documents. Different models produce incompatible vector dimensions.
 
 **GPU acceleration?**
-Opt-in via `RAG_DEVICE`. Verified: `webgpu` offloads compute to the GPU on Windows with a real D3D12-capable adapter (`nvidia-smi` confirms the Node process on the GPU). Linux and macOS WebGPU paths exist but are not verified in this repo. For maximum throughput pick the platform-native EP: `dml` (Windows), `cuda` (Linux x64 NVIDIA), `coreml` (macOS). Default is `cpu`. The server throws if the requested device fails — set `RAG_DEVICE=cpu` to revert.
+Opt-in via `RAG_DEVICE`. Devices are passed straight to ONNX Runtime. GPU support is highly dependent on your system, Node.js version, and the underlying ONNX backend. See the [Transformers.js device source code](https://github.com/huggingface/transformers.js/blob/main/packages/transformers/src/utils/devices.js) for the live list of supported backend names. If the requested device fails to initialize, the server throws an error — set `RAG_DEVICE=cpu` to revert.
 
 **Multi-user support?**
 No. Designed for single-user, local access. Multi-user would require authentication/access control.

--- a/src/__tests__/cli/common.test.ts
+++ b/src/__tests__/cli/common.test.ts
@@ -62,11 +62,20 @@ describe('createVectorStore', () => {
 })
 
 describe('createEmbedder', () => {
+  const originalDevice = process.env['RAG_DEVICE']
+
   afterEach(() => {
     mocks.Embedder.mockReset()
+    if (originalDevice === undefined) {
+      delete process.env['RAG_DEVICE']
+    } else {
+      process.env['RAG_DEVICE'] = originalDevice
+    }
   })
 
-  it('should map modelName to modelPath in Embedder config', () => {
+  it('defaults device to cpu when RAG_DEVICE is unset', () => {
+    delete process.env['RAG_DEVICE']
+
     createEmbedder(makeConfig({ modelName: 'custom/model', cacheDir: '/custom/cache' }))
 
     expect(mocks.Embedder).toHaveBeenCalledOnce()
@@ -74,6 +83,15 @@ describe('createEmbedder', () => {
       modelPath: 'custom/model',
       batchSize: 16,
       cacheDir: '/custom/cache',
+      device: 'cpu',
     })
+  })
+
+  it('passes RAG_DEVICE through to the Embedder', () => {
+    process.env['RAG_DEVICE'] = 'webgpu'
+
+    createEmbedder(makeConfig({ modelName: 'custom/model', cacheDir: '/custom/cache' }))
+
+    expect(mocks.Embedder).toHaveBeenCalledWith(expect.objectContaining({ device: 'webgpu' }))
   })
 })

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -69,12 +69,14 @@ vi.mock('../../chunker/index.js', () => ({
 vi.mock('../../cli/common.js', () => ({
   createEmbedder: vi.fn().mockImplementation(() => ({
     embedBatch: mocks.embedBatch,
+    dispose: vi.fn(),
   })),
   createVectorStore: vi.fn().mockImplementation(() => ({
     initialize: mocks.initialize,
     deleteChunks: mocks.deleteChunks,
     insertChunks: mocks.insertChunks,
     optimize: mocks.optimize,
+    close: vi.fn(),
   })),
 }))
 

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -23,10 +23,12 @@ const mocks = vi.hoisted(() => {
 vi.mock('../../cli/common.js', () => ({
   createEmbedder: vi.fn().mockImplementation(() => ({
     embedBatch: mocks.embedBatch,
+    dispose: vi.fn(),
   })),
   createVectorStore: vi.fn().mockImplementation(() => ({
     initialize: mocks.initialize,
     search: mocks.search,
+    close: vi.fn(),
   })),
 }))
 

--- a/src/__tests__/e2e/html-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/html-workflow.e2e.test.ts
@@ -34,6 +34,7 @@ describe('HTML Workflow E2E', () => {
   }, 120000) // 2 minutes for model download
 
   afterAll(async () => {
+    await server.close()
     await rm(testDbPath, { recursive: true, force: true })
   })
 

--- a/src/__tests__/e2e/rag-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/rag-workflow.e2e.test.ts
@@ -75,6 +75,7 @@ describe('RAG MCP Server E2E Test', () => {
         }
       } finally {
         // Cleanup
+        await ragServer.close()
         rmSync(testDbPath, { recursive: true, force: true })
         rmSync(testDataDir, { recursive: true, force: true })
       }
@@ -128,6 +129,7 @@ describe('RAG MCP Server E2E Test', () => {
         expect(results[0].filePath).toContain('sample.docx')
       } finally {
         // Cleanup
+        await ragServer.close()
         rmSync(testDbPath, { recursive: true, force: true })
         rmSync(testDataDir, { recursive: true, force: true })
       }
@@ -218,6 +220,7 @@ describe('RAG MCP Server E2E Test', () => {
         expect(targetResult.text).not.toContain('TypeScript is a strongly typed')
       } finally {
         // Cleanup
+        await ragServer.close()
         rmSync(testDbPath, { recursive: true, force: true })
         rmSync(testDataDir, { recursive: true, force: true })
       }

--- a/src/__tests__/embedder/embedder.test.ts
+++ b/src/__tests__/embedder/embedder.test.ts
@@ -1,0 +1,76 @@
+// Embedder unit tests
+// Test Type: Integration Test (uses the real @huggingface/transformers pipeline)
+// Covers the wrapped-error paths and empty-input short-circuits that the
+// maintainer flagged as untested.
+
+import { describe, expect, it } from 'vitest'
+import { Embedder, EmbeddingError } from '../../embedder/index.js'
+
+function makeEmbedder(device?: string): Embedder {
+  return new Embedder({
+    modelPath: 'Xenova/all-MiniLM-L6-v2',
+    batchSize: 16,
+    cacheDir: './tmp/models',
+    ...(device !== undefined ? { device } : {}),
+  })
+}
+
+describe('Embedder', () => {
+  describe('embed() input validation', () => {
+    it('rejects empty string before initializing the model', async () => {
+      // Use a deliberately broken device so init *would* fail if it were attempted.
+      // The empty-text guard must short-circuit before we get there.
+      const embedder = makeEmbedder('definitely-not-a-real-device')
+
+      const err = await embedder.embed('').catch((e) => e as Error)
+      expect(err).toBeInstanceOf(EmbeddingError)
+      expect(err.message).toBe('Cannot generate embedding for empty text')
+    })
+  })
+
+  describe('embedBatch()', () => {
+    it('returns [] for empty input without initializing the model', async () => {
+      const embedder = makeEmbedder('definitely-not-a-real-device')
+
+      // No init attempt → no device error surfaces.
+      await expect(embedder.embedBatch([])).resolves.toEqual([])
+    })
+
+    it('early-rethrows EmbeddingError from embed() instead of re-wrapping with batch guidance', async () => {
+      const embedder = makeEmbedder('cpu')
+
+      const err = await embedder.embedBatch(['valid', '']).catch((e) => e as Error)
+      expect(err).toBeInstanceOf(EmbeddingError)
+      expect(err.message).toBe('Cannot generate embedding for empty text')
+      expect(err.message).not.toMatch(/Failed to generate batch embeddings/)
+    })
+  })
+
+  describe('device validation', () => {
+    it('surfaces transformers.js native error as EmbeddingError when pipeline init fails', async () => {
+      const embedder = makeEmbedder('definitely-not-a-real-device')
+
+      const err = await embedder.embed('hello').catch((e) => e as Error)
+      expect(err).toBeInstanceOf(EmbeddingError)
+      // Underlying message comes through verbatim; we don't add our own prefix.
+      expect(err.message).toMatch(/Unsupported device/)
+      expect(err.message).toMatch(/definitely-not-a-real-device/)
+    })
+
+    it('does not add speculative cache/network guidance to init failures', async () => {
+      const embedder = makeEmbedder('definitely-not-a-real-device')
+
+      const err = await embedder.embed('hello').catch((e) => e as Error)
+      expect(err).toBeInstanceOf(EmbeddingError)
+      expect(err.message).not.toMatch(/Network connectivity/)
+      expect(err.message).not.toMatch(/Insufficient disk space/)
+    })
+  })
+
+  describe('dispose()', () => {
+    it('is safe to call before any embed() invocation', async () => {
+      const embedder = makeEmbedder('cpu')
+      await expect(embedder.dispose()).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/__tests__/security/security.test.ts
+++ b/src/__tests__/security/security.test.ts
@@ -67,6 +67,12 @@ describe('RAG MCP Server Security Test', () => {
     await rm(fixturesDir, { recursive: true, force: true })
   })
 
+  afterEach(async () => {
+    if (server) {
+      await server.close()
+    }
+  })
+
   beforeEach(async () => {
     // Initialize server before each test
     server = new RAGServer(testConfig)
@@ -127,15 +133,19 @@ This approach provides accurate search results for natural language queries.`
     it('No network communication after initial model download on subsequent startups (simulated)', async () => {
       const monitor = createNetworkMonitor()
 
+      let server2: RAGServer | null = null
       try {
         // Second initialization (model already cached)
-        const server2 = new RAGServer(testConfig)
+        server2 = new RAGServer(testConfig)
         await server2.initialize()
 
         // Verify no requests to HuggingFace API
         const huggingfaceRequests = monitor.requests.filter((url) => url.includes('huggingface.co'))
         expect(huggingfaceRequests.length).toBe(0)
       } finally {
+        if (server2) {
+          await server2.close()
+        }
         monitor.restore()
       }
     })

--- a/src/__tests__/server/config-warnings.test.ts
+++ b/src/__tests__/server/config-warnings.test.ts
@@ -297,6 +297,10 @@ describe('Config warning delivery via MCP annotations', () => {
       await server.initialize()
     })
 
+    afterAll(async () => {
+      await server.close()
+    })
+
     it('combines multiple warnings into a single content block', async () => {
       const result = await server.handleStatus()
       const warningBlock = result.content[1]

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -34,6 +34,7 @@ describe('ingest_data Tool', () => {
   }, 120000) // 2 minutes for model download
 
   afterAll(async () => {
+    await server.close()
     await rm(testDbPath, { recursive: true, force: true })
   })
 

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -42,6 +42,7 @@ describe('ingest_data Tool', () => {
   // Text Format Ingestion
   // --------------------------------------------
   describe('Text Format Ingestion', () => {
+    // First test in this file to call embed() — pays cold-cache model download.
     it('ingests plain text content', async () => {
       const content =
         'This is plain text content for testing the ingest_data tool. ' +
@@ -61,7 +62,7 @@ describe('ingest_data Tool', () => {
       expect(parsed.chunkCount).toBeGreaterThan(0)
       expect(parsed.filePath).toContain('raw-data')
       expect(parsed.filePath).toMatch(/\.md$/) // All formats use .md extension
-    })
+    }, 60000)
 
     it('saves raw text to raw-data directory', async () => {
       const content =

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -24,5 +24,6 @@ export function createEmbedder(config: ResolvedGlobalConfig): Embedder {
     modelPath: config.modelName,
     batchSize: 16,
     cacheDir: config.cacheDir,
+    device: process.env['RAG_DEVICE']?.trim() || 'cpu',
   })
 }

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -436,30 +436,35 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
   // Process each file
   const summary: IngestSummary = { succeeded: 0, failed: 0, totalChunks: 0 }
 
-  for (let i = 0; i < files.length; i++) {
-    const filePath = files[i]!
-    const label = `[${i + 1}/${files.length}]`
+  try {
+    for (let i = 0; i < files.length; i++) {
+      const filePath = files[i]!
+      const label = `[${i + 1}/${files.length}]`
 
-    try {
-      const chunkCount = await ingestSingleFile(filePath, parser, chunker, embedder, vectorStore)
-      if (chunkCount === 0) {
-        // 0 chunks is a skip/warning, not a failure
-        console.error(`${label} ${filePath} ... SKIPPED (0 chunks)`)
-        summary.succeeded++
-      } else {
-        console.error(`${label} ${filePath} ... OK (${chunkCount} chunks)`)
-        summary.succeeded++
-        summary.totalChunks += chunkCount
+      try {
+        const chunkCount = await ingestSingleFile(filePath, parser, chunker, embedder, vectorStore)
+        if (chunkCount === 0) {
+          // 0 chunks is a skip/warning, not a failure
+          console.error(`${label} ${filePath} ... SKIPPED (0 chunks)`)
+          summary.succeeded++
+        } else {
+          console.error(`${label} ${filePath} ... OK (${chunkCount} chunks)`)
+          summary.succeeded++
+          summary.totalChunks += chunkCount
+        }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        console.error(`${label} ${filePath} ... FAILED: ${reason}`)
+        summary.failed++
       }
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
-      console.error(`${label} ${filePath} ... FAILED: ${reason}`)
-      summary.failed++
     }
-  }
 
-  // Optimize once at end (not per-file)
-  await vectorStore.optimize()
+    // Optimize once at end (not per-file)
+    await vectorStore.optimize()
+  } finally {
+    await embedder.dispose()
+    await vectorStore.close()
+  }
 
   // Print summary
   console.error('')

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -203,5 +203,8 @@ export async function runQuery(args: string[], globalOptions: GlobalOptions = {}
     const reason = error instanceof Error ? error.message : String(error)
     console.error(`Error: ${reason}`)
     process.exit(1)
+  } finally {
+    await embedder.dispose()
+    await vectorStore.close()
   }
 }

--- a/src/embedder/__tests__/lazy-initialization.test.ts
+++ b/src/embedder/__tests__/lazy-initialization.test.ts
@@ -87,28 +87,16 @@ describe('Embedder - Lazy Initialization', () => {
     expect(result.length).toBe(384)
   }, 180000)
 
-  // Test 5: Error message should provide detailed guidance
-  it('should provide detailed error message with guidance on initialization failure', async () => {
+  // Test 5: Init failure surfaces transformers.js' own message as an EmbeddingError.
+  it('should surface the underlying transformers.js message as an EmbeddingError on init failure', async () => {
     const embedderWithInvalidPath = new Embedder({
       ...testConfig,
       modelPath: 'invalid/nonexistent-model',
     })
 
-    try {
-      await embedderWithInvalidPath.embed('test')
-      // Should not reach here
-      expect.fail('Expected embed() to throw an error')
-    } catch (error) {
-      expect(error).toBeInstanceOf(EmbeddingError)
-      const errorMessage = (error as EmbeddingError).message
-
-      // Verify error message contains helpful guidance
-      expect(errorMessage).toContain('Possible causes')
-      expect(errorMessage).toContain('Recommended actions')
-      expect(errorMessage).toContain(testConfig.cacheDir)
-      expect(errorMessage).toContain('Check your internet connection')
-      expect(errorMessage).toContain('delete cache')
-    }
+    const error = await embedderWithInvalidPath.embed('test').catch((e) => e as Error)
+    expect(error).toBeInstanceOf(EmbeddingError)
+    expect((error as EmbeddingError).message).toMatch(/invalid\/nonexistent-model/)
   }, 30000)
 
   // Test 6: Explicit initialize() should still work (backward compatibility)

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -88,7 +88,19 @@ export class Embedder {
         const gpuTimeout = new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('WebGPU init timed out')), 3_000)
         )
-        this.model = await Promise.race([gpuLoad, gpuTimeout])
+        const candidate = await Promise.race([gpuLoad, gpuTimeout])
+        // Init "succeeded" but on CI Windows runners WebGPU sometimes returns a
+        // pipeline that runs inference via slow software emulation. A single
+        // warmup call on a real GPU is ~50ms; if it takes >2s we treat this as
+        // a broken GPU and fall back to CPU.
+        const warmup = (
+          candidate as (text: string, options: unknown) => Promise<{ data: Float32Array }>
+        )('warmup', { pooling: 'mean', normalize: true })
+        const warmupTimeout = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('GPU warmup too slow (>2s)')), 2_000)
+        )
+        await Promise.race([warmup, warmupTimeout])
+        this.model = candidate
         gpuAvailable = true
         console.error('Embedder: Model loaded successfully (GPU)')
         return

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -1,6 +1,28 @@
 // Embedder implementation with Transformers.js
 
-import { env, pipeline } from '@huggingface/transformers'
+import { type DeviceType, env, pipeline } from '@huggingface/transformers'
+
+const VALID_DEVICES: readonly DeviceType[] = [
+  'auto',
+  'gpu',
+  'cpu',
+  'wasm',
+  'webgpu',
+  'cuda',
+  'dml',
+  'coreml',
+  'webnn',
+  'webnn-npu',
+  'webnn-gpu',
+  'webnn-cpu',
+] as const
+
+function resolveDevice(): DeviceType {
+  const raw = process.env['RAG_DEVICE']?.trim()
+  if (!raw) return 'cpu'
+  if ((VALID_DEVICES as readonly string[]).includes(raw)) return raw as DeviceType
+  throw new Error(`RAG_DEVICE="${raw}" is not a valid device. Valid: ${VALID_DEVICES.join(', ')}`)
+}
 
 // ============================================
 // Type Definitions
@@ -34,10 +56,6 @@ export class EmbeddingError extends Error {
     this.name = 'EmbeddingError'
   }
 }
-
-// Cached across all Embedder instances in the process: once WebGPU fails (e.g. no GPU on CI),
-// subsequent instances skip the 3s timeout probe and go straight to CPU.
-let gpuAvailable: boolean | null = null
 
 // ============================================
 // Embedder Class
@@ -73,59 +91,25 @@ export class Embedder {
     // Set cache directory BEFORE creating pipeline
     env.cacheDir = this.config.cacheDir
 
-    console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
-    console.error(`Embedder: Loading model "${this.config.modelPath}"...`)
+    // RAG_DEVICE selects the execution provider. Default 'cpu' is safe everywhere.
+    // The user picks from the transformers.js device list (cpu, webgpu, dml, cuda,
+    // coreml, wasm, auto, gpu, etc.) — we validate the string and pass it through.
+    // No fallback — if the requested device fails, init throws.
+    const device = resolveDevice()
 
-    if (gpuAvailable !== false) {
-      try {
-        // Wrap WebGPU init in a timeout: on environments without WebGPU (e.g. Node.js on CI),
-        // the pipeline call hangs indefinitely instead of throwing. Race against a short
-        // deadline so we fall through to the CPU path without blocking the process.
-        const gpuLoad = pipeline('feature-extraction', this.config.modelPath, {
-          dtype: 'fp32',
-          device: 'webgpu',
-        })
-        const gpuTimeoutMs = process.env['CI'] ? 30_000 : 3_000
-        const gpuTimeout = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('WebGPU init timed out')), gpuTimeoutMs)
-        )
-        const candidate = await Promise.race([gpuLoad, gpuTimeout])
-        // Init "succeeded" but on CI Windows runners WebGPU sometimes returns a
-        // pipeline that runs inference via slow software emulation. A single
-        // warmup call on a real GPU is ~50ms; if it takes >2s we treat this as
-        // a broken GPU and fall back to CPU.
-        const warmup = (
-          candidate as (text: string, options: unknown) => Promise<{ data: Float32Array }>
-        )('warmup', { pooling: 'mean', normalize: true })
-        const warmupTimeoutMs = process.env['CI'] ? 30_000 : 2_000
-        const warmupTimeout = new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error(`GPU warmup too slow (>${warmupTimeoutMs}ms)`)),
-            warmupTimeoutMs
-          )
-        )
-        await Promise.race([warmup, warmupTimeout])
-        this.model = candidate
-        gpuAvailable = true
-        console.error('Embedder: Model loaded successfully (GPU)')
-        return
-      } catch (gpuError) {
-        gpuAvailable = false
-        console.error(
-          `Embedder: GPU unavailable (${(gpuError as Error).message}), falling back to CPU...`
-        )
-      }
-    }
+    console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
+    console.error(`Embedder: Loading model "${this.config.modelPath}" on device "${device}"...`)
 
     try {
       this.model = await pipeline('feature-extraction', this.config.modelPath, {
         dtype: 'fp32',
-        device: 'cpu',
+        device,
       })
-      console.error('Embedder: Model loaded successfully (CPU fallback)')
+      console.error(`Embedder: Model loaded successfully (device=${device})`)
     } catch (error) {
       throw new EmbeddingError(
-        `Failed to initialize Embedder: ${(error as Error).message}`,
+        `Failed to initialize Embedder on device "${device}": ${(error as Error).message}\n\n` +
+          'Set RAG_DEVICE=cpu to force CPU. Other values: gpu (auto per platform), dml, cuda, coreml, webgpu, wasm, auto.',
         error as Error
       )
     }

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -21,7 +21,9 @@ function resolveDevice(): DeviceType {
   const raw = process.env['RAG_DEVICE']?.trim()
   if (!raw) return 'cpu'
   if ((VALID_DEVICES as readonly string[]).includes(raw)) return raw as DeviceType
-  throw new Error(`RAG_DEVICE="${raw}" is not a valid device. Valid: ${VALID_DEVICES.join(', ')}`)
+  throw new EmbeddingError(
+    `RAG_DEVICE="${raw}" is not a valid device. Valid: ${VALID_DEVICES.join(', ')}`
+  )
 }
 
 // ============================================
@@ -91,9 +93,6 @@ export class Embedder {
     // Set cache directory BEFORE creating pipeline
     env.cacheDir = this.config.cacheDir
 
-    // RAG_DEVICE selects the execution provider. Default 'cpu' is safe everywhere.
-    // The user picks from the transformers.js device list (cpu, webgpu, dml, cuda,
-    // coreml, wasm, auto, gpu, etc.) — we validate the string and pass it through.
     // No fallback — if the requested device fails, init throws.
     const device = resolveDevice()
 

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -85,8 +85,9 @@ export class Embedder {
           dtype: 'fp32',
           device: 'webgpu',
         })
+        const gpuTimeoutMs = process.env['CI'] ? 30_000 : 3_000
         const gpuTimeout = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('WebGPU init timed out')), 3_000)
+          setTimeout(() => reject(new Error('WebGPU init timed out')), gpuTimeoutMs)
         )
         const candidate = await Promise.race([gpuLoad, gpuTimeout])
         // Init "succeeded" but on CI Windows runners WebGPU sometimes returns a
@@ -96,8 +97,12 @@ export class Embedder {
         const warmup = (
           candidate as (text: string, options: unknown) => Promise<{ data: Float32Array }>
         )('warmup', { pooling: 'mean', normalize: true })
+        const warmupTimeoutMs = process.env['CI'] ? 30_000 : 2_000
         const warmupTimeout = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('GPU warmup too slow (>2s)')), 2_000)
+          setTimeout(
+            () => reject(new Error(`GPU warmup too slow (>${warmupTimeoutMs}ms)`)),
+            warmupTimeoutMs
+          )
         )
         await Promise.race([warmup, warmupTimeout])
         this.model = candidate

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -72,15 +72,21 @@ export class Embedder {
 
       console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
       console.error(`Embedder: Loading model "${this.config.modelPath}"...`)
-      // Use type assertion to avoid TS2590 (union type too complex with @types/jsdom)
-      this.model = await pipeline('feature-extraction', this.config.modelPath, {
+      // Wrap WebGPU init in a timeout: on environments without WebGPU (e.g. Node.js on CI),
+      // the pipeline call hangs indefinitely instead of throwing. Race against a short
+      // deadline so we fall through to the CPU path without blocking the process.
+      const gpuLoad = pipeline('feature-extraction', this.config.modelPath, {
         dtype: 'fp32',
         device: 'webgpu',
       })
+      const gpuTimeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('WebGPU init timed out')), 3_000)
+      )
+      this.model = await Promise.race([gpuLoad, gpuTimeout])
       console.error('Embedder: Model loaded successfully (GPU)')
     } catch (gpuError) {
       console.error(
-        `Embedder: GPU initialization failed (${(gpuError as Error).message}), falling back to CPU...`
+        `Embedder: GPU unavailable (${(gpuError as Error).message}), falling back to CPU...`
       )
       try {
         this.model = await pipeline('feature-extraction', this.config.modelPath, {

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -75,13 +75,25 @@ export class Embedder {
       // Use type assertion to avoid TS2590 (union type too complex with @types/jsdom)
       this.model = await pipeline('feature-extraction', this.config.modelPath, {
         dtype: 'fp32',
+        device: 'webgpu',
       })
-      console.error('Embedder: Model loaded successfully')
-    } catch (error) {
-      throw new EmbeddingError(
-        `Failed to initialize Embedder: ${(error as Error).message}`,
-        error as Error
+      console.error('Embedder: Model loaded successfully (GPU)')
+    } catch (gpuError) {
+      console.error(
+        `Embedder: GPU initialization failed (${(gpuError as Error).message}), falling back to CPU...`
       )
+      try {
+        this.model = await pipeline('feature-extraction', this.config.modelPath, {
+          dtype: 'fp32',
+          device: 'cpu',
+        })
+        console.error('Embedder: Model loaded successfully (CPU fallback)')
+      } catch (error) {
+        throw new EmbeddingError(
+          `Failed to initialize Embedder: ${(error as Error).message}`,
+          error as Error
+        )
+      }
     }
   }
 

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -2,30 +2,6 @@
 
 import { type DeviceType, env, pipeline } from '@huggingface/transformers'
 
-const VALID_DEVICES: readonly DeviceType[] = [
-  'auto',
-  'gpu',
-  'cpu',
-  'wasm',
-  'webgpu',
-  'cuda',
-  'dml',
-  'coreml',
-  'webnn',
-  'webnn-npu',
-  'webnn-gpu',
-  'webnn-cpu',
-] as const
-
-function resolveDevice(): DeviceType {
-  const raw = process.env['RAG_DEVICE']?.trim()
-  if (!raw) return 'cpu'
-  if ((VALID_DEVICES as readonly string[]).includes(raw)) return raw as DeviceType
-  throw new EmbeddingError(
-    `RAG_DEVICE="${raw}" is not a valid device. Valid: ${VALID_DEVICES.join(', ')}`
-  )
-}
-
 // ============================================
 // Type Definitions
 // ============================================
@@ -40,6 +16,8 @@ export interface EmbedderConfig {
   batchSize: number
   /** Model cache directory */
   cacheDir: string
+  /** Device type */
+  device?: string
 }
 
 // ============================================
@@ -82,6 +60,22 @@ export class Embedder {
   }
 
   /**
+   * Release resources held by the Embedder pipeline
+   */
+  async dispose(): Promise<void> {
+    const model = this.model as { dispose?: () => Promise<void> } | null
+    if (model && typeof model.dispose === 'function') {
+      try {
+        await model.dispose()
+      } catch (error) {
+        console.error('Error disposing embedder model:', error)
+      }
+    }
+    this.model = null
+    this.initPromise = null
+  }
+
+  /**
    * Initialize Transformers.js model
    */
   async initialize(): Promise<void> {
@@ -94,7 +88,7 @@ export class Embedder {
     env.cacheDir = this.config.cacheDir
 
     // No fallback — if the requested device fails, init throws.
-    const device = resolveDevice()
+    const device = this.config.device || 'cpu'
 
     console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
     console.error(`Embedder: Loading model "${this.config.modelPath}" on device "${device}"...`)
@@ -102,15 +96,14 @@ export class Embedder {
     try {
       this.model = await pipeline('feature-extraction', this.config.modelPath, {
         dtype: 'fp32',
-        device,
+        device: device as DeviceType,
       })
       console.error(`Embedder: Model loaded successfully (device=${device})`)
     } catch (error) {
-      throw new EmbeddingError(
-        `Failed to initialize Embedder on device "${device}": ${(error as Error).message}\n\n` +
-          'Set RAG_DEVICE=cpu to force CPU. Other values: gpu (auto per platform), dml, cuda, coreml, webgpu, wasm, auto.',
-        error as Error
-      )
+      // Don't prepend "device=X" — the prior stderr line already says which
+      // device was attempted, and transformers.js' own errors typically
+      // include the device name. Just re-type the error.
+      throw new EmbeddingError((error as Error).message, error as Error)
     }
   }
 
@@ -130,20 +123,14 @@ export class Embedder {
       return
     }
 
-    // Start initialization
     console.error(
       'Embedder: First use detected. Initializing model (downloading ~90MB, may take 1-2 minutes)...'
     )
 
     this.initPromise = this.initialize().catch((error) => {
-      // Clear initPromise on failure to allow retry
+      // Clear initPromise on failure to allow retry on the next call.
       this.initPromise = null
-
-      // Enhance error message with detailed guidance
-      throw new EmbeddingError(
-        `Failed to initialize embedder on first use: ${(error as Error).message}\n\nPossible causes:\n  • Network connectivity issues during model download\n  • Insufficient disk space (need ~90MB)\n  • Corrupted model cache\n\nRecommended actions:\n  1. Check your internet connection and try again\n  2. Ensure sufficient disk space is available\n  3. If problem persists, delete cache: ${this.config.cacheDir}\n  4. Then retry your query\n`,
-        error as Error
-      )
+      throw error
     })
 
     await this.initPromise
@@ -156,17 +143,15 @@ export class Embedder {
    * @returns Embedding vector (dimension depends on model)
    */
   async embed(text: string): Promise<number[]> {
+    // Reject empty input before paying for model init.
+    if (text.length === 0) {
+      throw new EmbeddingError('Cannot generate embedding for empty text')
+    }
+
     // Lazy initialization: initialize on first use if not already initialized
     await this.ensureInitialized()
 
     try {
-      // Fail-fast for empty string: cannot generate meaningful embedding
-      if (text.length === 0) {
-        throw new EmbeddingError('Cannot generate embedding for empty text')
-      }
-
-      // Use type assertion to avoid complex Transformers.js type definitions
-      // This is due to external library type definition constraints, runtime behavior is guaranteed
       const options = { pooling: 'mean', normalize: true }
       const modelCall = this.model as (
         text: string,
@@ -195,12 +180,13 @@ export class Embedder {
    * @returns Array of embedding vectors (dimension depends on model)
    */
   async embedBatch(texts: string[]): Promise<number[][]> {
-    // Lazy initialization: initialize on first use if not already initialized
-    await this.ensureInitialized()
-
+    // Nothing to embed → skip model init entirely.
     if (texts.length === 0) {
       return []
     }
+
+    // Lazy initialization: initialize on first use if not already initialized
+    await this.ensureInitialized()
 
     try {
       const embeddings: number[][] = []
@@ -214,6 +200,9 @@ export class Embedder {
 
       return embeddings
     } catch (error) {
+      if (error instanceof EmbeddingError) {
+        throw error
+      }
       throw new EmbeddingError(
         `Failed to generate batch embeddings: ${(error as Error).message}`,
         error as Error

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -35,6 +35,10 @@ export class EmbeddingError extends Error {
   }
 }
 
+// Cached across all Embedder instances in the process: once WebGPU fails (e.g. no GPU on CI),
+// subsequent instances skip the 3s timeout probe and go straight to CPU.
+let gpuAvailable: boolean | null = null
+
 // ============================================
 // Embedder Class
 // ============================================
@@ -66,40 +70,47 @@ export class Embedder {
       return
     }
 
-    try {
-      // Set cache directory BEFORE creating pipeline
-      env.cacheDir = this.config.cacheDir
+    // Set cache directory BEFORE creating pipeline
+    env.cacheDir = this.config.cacheDir
 
-      console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
-      console.error(`Embedder: Loading model "${this.config.modelPath}"...`)
-      // Wrap WebGPU init in a timeout: on environments without WebGPU (e.g. Node.js on CI),
-      // the pipeline call hangs indefinitely instead of throwing. Race against a short
-      // deadline so we fall through to the CPU path without blocking the process.
-      const gpuLoad = pipeline('feature-extraction', this.config.modelPath, {
-        dtype: 'fp32',
-        device: 'webgpu',
-      })
-      const gpuTimeout = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('WebGPU init timed out')), 3_000)
-      )
-      this.model = await Promise.race([gpuLoad, gpuTimeout])
-      console.error('Embedder: Model loaded successfully (GPU)')
-    } catch (gpuError) {
-      console.error(
-        `Embedder: GPU unavailable (${(gpuError as Error).message}), falling back to CPU...`
-      )
+    console.error(`Embedder: Setting cache directory to "${this.config.cacheDir}"`)
+    console.error(`Embedder: Loading model "${this.config.modelPath}"...`)
+
+    if (gpuAvailable !== false) {
       try {
-        this.model = await pipeline('feature-extraction', this.config.modelPath, {
+        // Wrap WebGPU init in a timeout: on environments without WebGPU (e.g. Node.js on CI),
+        // the pipeline call hangs indefinitely instead of throwing. Race against a short
+        // deadline so we fall through to the CPU path without blocking the process.
+        const gpuLoad = pipeline('feature-extraction', this.config.modelPath, {
           dtype: 'fp32',
-          device: 'cpu',
+          device: 'webgpu',
         })
-        console.error('Embedder: Model loaded successfully (CPU fallback)')
-      } catch (error) {
-        throw new EmbeddingError(
-          `Failed to initialize Embedder: ${(error as Error).message}`,
-          error as Error
+        const gpuTimeout = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('WebGPU init timed out')), 3_000)
+        )
+        this.model = await Promise.race([gpuLoad, gpuTimeout])
+        gpuAvailable = true
+        console.error('Embedder: Model loaded successfully (GPU)')
+        return
+      } catch (gpuError) {
+        gpuAvailable = false
+        console.error(
+          `Embedder: GPU unavailable (${(gpuError as Error).message}), falling back to CPU...`
         )
       }
+    }
+
+    try {
+      this.model = await pipeline('feature-extraction', this.config.modelPath, {
+        dtype: 'fp32',
+        device: 'cpu',
+      })
+      console.error('Embedder: Model loaded successfully (CPU fallback)')
+    } catch (error) {
+      throw new EmbeddingError(
+        `Failed to initialize Embedder: ${(error as Error).message}`,
+        error as Error
+      )
     }
   }
 

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -77,6 +77,15 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
   return { value: parsed }
 }
 
+/**
+ * Resolve RAG_DEVICE. The value is passed through to transformers.js — no
+ * allowlist is maintained here. Whitespace-only is treated as unset.
+ */
+export function parseDevice(value: string | undefined): ParseResult<string> {
+  if (!value || value.trim() === '') return { value: 'cpu' }
+  return { value: value.trim() }
+}
+
 // ============================================
 // Server Startup
 // ============================================
@@ -89,12 +98,14 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
 export async function startServer(): Promise<void> {
   try {
     // RAGServer configuration (env-only for MCP client compatibility)
+    const device = parseDevice(process.env['RAG_DEVICE']).value as string
     const config: ConstructorParameters<typeof RAGServer>[0] = {
       dbPath: process.env['DB_PATH'] || './lancedb/',
       modelName: process.env['MODEL_NAME'] || 'Xenova/all-MiniLM-L6-v2',
       cacheDir: process.env['CACHE_DIR'] || './models/',
       baseDir: process.env['BASE_DIR'] || process.cwd(),
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
+      device,
     }
 
     // Collect configuration warnings

--- a/src/server/__tests__/ingest-rollback.test.ts
+++ b/src/server/__tests__/ingest-rollback.test.ts
@@ -27,8 +27,9 @@ describe('Ingest Rollback', () => {
     await ragServer.initialize()
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     vi.restoreAllMocks()
+    await ragServer.close()
     rmSync(testDbPath, { recursive: true, force: true })
     rmSync(testDataDir, { recursive: true, force: true })
   })

--- a/src/server/__tests__/rag-server.delete.integration.test.ts
+++ b/src/server/__tests__/rag-server.delete.integration.test.ts
@@ -27,6 +27,7 @@ describe('AC-010: File Deletion', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })

--- a/src/server/__tests__/rag-server.files.integration.test.ts
+++ b/src/server/__tests__/rag-server.files.integration.test.ts
@@ -29,6 +29,7 @@ describe('AC-006: Additional Format Support (Phase 2)', () => {
   }, 60000)
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })
@@ -141,6 +142,7 @@ describe('AC-007: File Management', () => {
   }, 120000)
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })
@@ -317,8 +319,9 @@ describe('AC-007: File Management', () => {
 
       writeFileSync(resolve(siblingData, 'sibling-file.txt'), 'File in sibling baseDir')
 
+      let siblingServer: RAGServer | null = null
       try {
-        const siblingServer = new RAGServer({
+        siblingServer = new RAGServer({
           dbPath: siblingDb,
           modelName: 'Xenova/all-MiniLM-L6-v2',
           cacheDir: siblingCache,
@@ -336,6 +339,9 @@ describe('AC-007: File Management', () => {
         expect(filePaths).toContain(resolve(siblingData, 'sibling-file.txt'))
         expect(parsed.files.length).toBe(1)
       } finally {
+        if (siblingServer) {
+          await siblingServer.close()
+        }
         rmSync(siblingBase, { recursive: true, force: true })
       }
     })

--- a/src/server/__tests__/rag-server.ingest.integration.test.ts
+++ b/src/server/__tests__/rag-server.ingest.integration.test.ts
@@ -27,6 +27,7 @@ describe('AC-008: File Re-ingestion', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })
@@ -100,6 +101,7 @@ describe('AC-009: Error Handling (Complete)', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })

--- a/src/server/__tests__/rag-server.metadata.integration.test.ts
+++ b/src/server/__tests__/rag-server.metadata.integration.test.ts
@@ -29,6 +29,7 @@ describe('File Title Extraction Pipeline', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })
@@ -100,6 +101,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })

--- a/src/server/__tests__/rag-server.protocol.integration.test.ts
+++ b/src/server/__tests__/rag-server.protocol.integration.test.ts
@@ -27,8 +27,9 @@ describe('AC-001: MCP Protocol Integration', () => {
   })
 
   afterAll(async () => {
-    rmSync(testDbPath, { recursive: true, force: true })
-    rmSync(testDataDir, { recursive: true, force: true })
+    await ragServer.close()
+    rmSync(localTestDbPath, { recursive: true, force: true })
+    rmSync(localTestDataDir, { recursive: true, force: true })
   })
 
   // AC interpretation: [Error handling] Appropriate MCP error response returned when error occurs
@@ -82,8 +83,9 @@ describe('AC-005: Error Handling (Basic)', () => {
   })
 
   afterAll(async () => {
-    rmSync(testDbPath, { recursive: true, force: true })
-    rmSync(testDataDir, { recursive: true, force: true })
+    await ragServer.close()
+    rmSync(localTestDbPath, { recursive: true, force: true })
+    rmSync(localTestDataDir, { recursive: true, force: true })
   })
 
   // AC interpretation: [Error handling] Error message returned for non-existent file path
@@ -126,6 +128,8 @@ describe('AC-005: Error Handling (Basic)', () => {
     } catch (error) {
       // Error during initialization is also OK
       expect(error).toBeDefined()
+    } finally {
+      await invalidServer.close()
     }
   })
 })

--- a/src/server/__tests__/rag-server.protocol.integration.test.ts
+++ b/src/server/__tests__/rag-server.protocol.integration.test.ts
@@ -28,8 +28,8 @@ describe('AC-001: MCP Protocol Integration', () => {
 
   afterAll(async () => {
     await ragServer.close()
-    rmSync(localTestDbPath, { recursive: true, force: true })
-    rmSync(localTestDataDir, { recursive: true, force: true })
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
   })
 
   // AC interpretation: [Error handling] Appropriate MCP error response returned when error occurs
@@ -84,8 +84,8 @@ describe('AC-005: Error Handling (Basic)', () => {
 
   afterAll(async () => {
     await ragServer.close()
-    rmSync(localTestDbPath, { recursive: true, force: true })
-    rmSync(localTestDataDir, { recursive: true, force: true })
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
   })
 
   // AC interpretation: [Error handling] Error message returned for non-existent file path

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -115,8 +115,6 @@ describe('read_chunk_neighbors integration', () => {
       const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(7)
-      // 60s, not 30s: this is the first beforeAll in the file and may pay the
-      // cold-cache ~90MB model download on Windows CI (~30s by itself).
     }, 60000)
 
     afterAll(() => {
@@ -211,8 +209,6 @@ describe('read_chunk_neighbors integration', () => {
         'Distinctive marker ZZQWERTY12345 appears in this document. '.repeat(60)
       )
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-      // 60s for the same reason as Test 1: this hook can be the first to load
-      // the embedder model from a cold disk cache on slower Windows CI.
     }, 60000)
 
     afterAll(() => {
@@ -310,7 +306,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(4)
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -404,7 +400,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingest = JSON.parse(ingestRes.content[0].text)
       chunkCount = ingest.chunkCount
       expect(chunkCount).toBeGreaterThanOrEqual(3)
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -501,7 +497,7 @@ describe('read_chunk_neighbors integration', () => {
       })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(3)
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -592,7 +588,7 @@ describe('read_chunk_neighbors integration', () => {
       fileBackedPath = resolve(testDataDir, 'file-backed.txt')
       writeFileSync(fileBackedPath, 'File backed document content. '.repeat(100))
       await ragServer.handleIngestFile({ filePath: fileBackedPath })
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -826,7 +822,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingest = JSON.parse(ingestRes.content[0].text)
       chunkCount = ingest.chunkCount
       expect(chunkCount).toBeGreaterThan(0)
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -890,7 +886,7 @@ describe('read_chunk_neighbors integration', () => {
       ingestedFilePath = resolve(testDataDir, 'validation-doc.txt')
       writeFileSync(ingestedFilePath, 'Validation boundary test content. '.repeat(60))
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -958,7 +954,7 @@ describe('read_chunk_neighbors integration', () => {
       ingestedFilePath = resolve(testDataDir, 'validation-chunk-index.txt')
       writeFileSync(ingestedFilePath, 'chunkIndex validation test content. '.repeat(60))
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -1046,7 +1042,7 @@ describe('read_chunk_neighbors integration', () => {
         ).content[0].text
       )
       expect(dataIngest.chunkCount).toBeGreaterThanOrEqual(3)
-    }, 30000)
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -115,7 +115,9 @@ describe('read_chunk_neighbors integration', () => {
       const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(7)
-    }, 30000)
+      // 60s, not 30s: this is the first beforeAll in the file and may pay the
+      // cold-cache ~90MB model download on Windows CI (~30s by itself).
+    }, 60000)
 
     afterAll(() => {
       rmSync(testDbPath, { recursive: true, force: true })
@@ -209,7 +211,9 @@ describe('read_chunk_neighbors integration', () => {
         'Distinctive marker ZZQWERTY12345 appears in this document. '.repeat(60)
       )
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 30000)
+      // 60s for the same reason as Test 1: this hook can be the first to load
+      // the embedder model from a cold disk cache on slower Windows CI.
+    }, 60000)
 
     afterAll(() => {
       vi.restoreAllMocks()

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -115,7 +115,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(7)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -210,10 +210,11 @@ describe('read_chunk_neighbors integration', () => {
         'Distinctive marker ZZQWERTY12345 appears in this document. '.repeat(60)
       )
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 60000)
+    })
 
-    afterAll(() => {
+    afterAll(async () => {
       vi.restoreAllMocks()
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -307,7 +308,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingestRes = await ragServer.handleIngestFile({ filePath: ingestedFilePath })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(4)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -402,7 +403,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingest = JSON.parse(ingestRes.content[0].text)
       chunkCount = ingest.chunkCount
       expect(chunkCount).toBeGreaterThanOrEqual(3)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -500,7 +501,7 @@ describe('read_chunk_neighbors integration', () => {
       })
       const ingest = JSON.parse(ingestRes.content[0].text)
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(3)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -592,7 +593,7 @@ describe('read_chunk_neighbors integration', () => {
       fileBackedPath = resolve(testDataDir, 'file-backed.txt')
       writeFileSync(fileBackedPath, 'File backed document content. '.repeat(100))
       await ragServer.handleIngestFile({ filePath: fileBackedPath })
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -787,7 +788,7 @@ describe('read_chunk_neighbors integration', () => {
         p95,
         `P95 latency ${p95.toFixed(2)} ms exceeds 100 ms threshold. Timings: ${JSON.stringify(timings)}`
       ).toBeLessThan(100)
-    }, 60000)
+    })
   })
 
   // =============================================================================
@@ -828,7 +829,7 @@ describe('read_chunk_neighbors integration', () => {
       const ingest = JSON.parse(ingestRes.content[0].text)
       chunkCount = ingest.chunkCount
       expect(chunkCount).toBeGreaterThan(0)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -893,7 +894,7 @@ describe('read_chunk_neighbors integration', () => {
       ingestedFilePath = resolve(testDataDir, 'validation-doc.txt')
       writeFileSync(ingestedFilePath, 'Validation boundary test content. '.repeat(60))
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -962,7 +963,7 @@ describe('read_chunk_neighbors integration', () => {
       ingestedFilePath = resolve(testDataDir, 'validation-chunk-index.txt')
       writeFileSync(ingestedFilePath, 'chunkIndex validation test content. '.repeat(60))
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()
@@ -1051,7 +1052,7 @@ describe('read_chunk_neighbors integration', () => {
         ).content[0].text
       )
       expect(dataIngest.chunkCount).toBeGreaterThanOrEqual(3)
-    }, 60000)
+    })
 
     afterAll(async () => {
       await ragServer.close()

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -117,7 +117,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(7)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -308,7 +309,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(4)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -402,7 +404,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(chunkCount).toBeGreaterThanOrEqual(3)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -499,7 +502,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(ingest.chunkCount).toBeGreaterThanOrEqual(3)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -590,7 +594,8 @@ describe('read_chunk_neighbors integration', () => {
       await ragServer.handleIngestFile({ filePath: fileBackedPath })
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -738,7 +743,8 @@ describe('read_chunk_neighbors integration', () => {
       await vectorStore.optimize()
     }, 120000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -824,7 +830,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(chunkCount).toBeGreaterThan(0)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -888,7 +895,8 @@ describe('read_chunk_neighbors integration', () => {
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -956,7 +964,8 @@ describe('read_chunk_neighbors integration', () => {
       await ragServer.handleIngestFile({ filePath: ingestedFilePath })
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })
@@ -1044,7 +1053,8 @@ describe('read_chunk_neighbors integration', () => {
       expect(dataIngest.chunkCount).toBeGreaterThanOrEqual(3)
     }, 60000)
 
-    afterAll(() => {
+    afterAll(async () => {
+      await ragServer.close()
       rmSync(testDbPath, { recursive: true, force: true })
       rmSync(testDataDir, { recursive: true, force: true })
     })

--- a/src/server/__tests__/rag-server.search.integration.test.ts
+++ b/src/server/__tests__/rag-server.search.integration.test.ts
@@ -41,6 +41,7 @@ describe('AC-004: Vector Search', () => {
   })
 
   afterAll(async () => {
+    await localRagServer.close()
     rmSync(localTestDbPath, { recursive: true, force: true })
     rmSync(localTestDataDir, { recursive: true, force: true })
   })
@@ -117,17 +118,20 @@ describe('AC-004: Vector Search', () => {
       maxFileSize: 100 * 1024 * 1024,
     })
 
-    await emptyServer.initialize()
+    try {
+      await emptyServer.initialize()
 
-    const result = await emptyServer.handleQueryDocuments({
-      query: 'xyzabc123randomstring',
-    })
+      const result = await emptyServer.handleQueryDocuments({
+        query: 'xyzabc123randomstring',
+      })
 
-    const results = JSON.parse(result.content[0].text)
-    expect(Array.isArray(results)).toBe(true)
-    expect(results.length).toBe(0)
-
-    rmSync(emptyDbPath, { recursive: true, force: true })
+      const results = JSON.parse(result.content[0].text)
+      expect(Array.isArray(results)).toBe(true)
+      expect(results.length).toBe(0)
+    } finally {
+      await emptyServer.close()
+      rmSync(emptyDbPath, { recursive: true, force: true })
+    }
   })
 
   // Edge Case: limit boundary values

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -741,4 +741,12 @@ export class RAGServer {
     await this.server.connect(transport)
     console.error('RAGServer running on stdio transport')
   }
+
+  /**
+   * Stop the server and release resources
+   */
+  async close(): Promise<void> {
+    await this.vectorStore.close()
+    console.error('RAGServer stopped')
+  }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -91,11 +91,15 @@ export class RAGServer {
       vectorStoreConfig.maxFiles = config.maxFiles
     }
     this.vectorStore = new VectorStore(vectorStoreConfig)
-    this.embedder = new Embedder({
+    const embedderConfig: ConstructorParameters<typeof Embedder>[0] = {
       modelPath: config.modelName,
       batchSize: 16,
       cacheDir: config.cacheDir,
-    })
+    }
+    if (config.device !== undefined) {
+      embedderConfig.device = config.device
+    }
+    this.embedder = new Embedder(embedderConfig)
     this.chunker = new SemanticChunker(
       config.chunkMinLength !== undefined ? { minChunkLength: config.chunkMinLength } : {}
     )
@@ -746,7 +750,9 @@ export class RAGServer {
    * Stop the server and release resources
    */
   async close(): Promise<void> {
+    await this.server.close()
     await this.vectorStore.close()
+    await this.embedder.dispose()
     console.error('RAGServer stopped')
   }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -17,6 +17,8 @@ export interface RAGServerConfig {
   baseDir: string
   /** Maximum file size (100MB) */
   maxFileSize: number
+  /** Compute device (cpu, webgpu, dml, etc) */
+  device?: string
   /** Maximum distance threshold for quality filtering (optional) */
   maxDistance?: number
   /** Grouping mode for quality filtering (optional) */

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -476,4 +476,17 @@ export class VectorStore {
       throw new DatabaseError('Failed to get status', error as Error)
     }
   }
+
+  /**
+   * Close the database connection
+   */
+  async close(): Promise<void> {
+    if (this.db) {
+      // LanceDB Connections should be closed to release file handles
+      await this.db.close()
+      this.db = null
+      this.table = null
+      console.error('VectorStore connection closed')
+    }
+  }
 }

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -486,6 +486,7 @@ export class VectorStore {
       await this.db.close()
       this.db = null
       this.table = null
+      this.ftsEnabled = false
       console.error('VectorStore connection closed')
     }
   }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -10,8 +10,8 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     // Process management improvements
-    testTimeout: 10000,        // 10 second timeout
-    hookTimeout: 10000,        // Hook processing timeout 10 seconds
+    testTimeout: 60000,        // 60 second timeout
+    hookTimeout: 120000,       // Hook processing timeout 120 seconds
     teardownTimeout: 5000,     // Teardown timeout 5 seconds
     pool: 'forks',             // Use forks instead of threads for onnxruntime-node compatibility
     maxWorkers: 1,             // Single process execution to avoid onnxruntime-node threading issues

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -10,8 +10,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     // Process management improvements
-    testTimeout: 60000,        // 60 second timeout
-    hookTimeout: 120000,       // Hook processing timeout 120 seconds
+    testTimeout: 10000,
     teardownTimeout: 5000,     // Teardown timeout 5 seconds
     pool: 'forks',             // Use forks instead of threads for onnxruntime-node compatibility
     maxWorkers: 1,             // Single process execution to avoid onnxruntime-node threading issues
@@ -20,6 +19,7 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '**/.claude/**',
+      '**/tmp/**',
     ],
   },
   resolve: {


### PR DESCRIPTION
Closes #127

## What this changes

Adds an optional `RAG_DEVICE` environment variable.

- When unset or `cpu`, the embedder calls `pipeline(..., { device: 'cpu' })` (current default).
- When set to any other string, that string is passed through to transformers.js.
- If `pipeline()` rejects the device, the embedder throws `EmbeddingError` on first use and the underlying transformers.js error message reaches the caller.

No allowlist is maintained in this repo; the list of accepted device names is whatever the linked `@huggingface/transformers` version accepts.

## CI

Matrix expanded to `[ubuntu-latest, windows-latest] × [cpu, webgpu]`.

The `webgpu` cells install a software Vulkan adapter (SwiftShader on Windows, Lavapipe on Linux) and set `WGPU_BACKEND=vulkan` plus `VK_ICD_FILENAMES` so Dawn binds to it. CI runners have no GPU. Native EPs (`dml`/`cuda`/`coreml`) require hardware that GitHub-hosted runners don't provide.

Lint, format, and type-check were moved into a separate `static-checks` job so they run once per OS instead of once per (OS, device) cell.

## Test plan

- [ ] `static-checks` and both `test` matrix dimensions pass on Ubuntu and Windows
- [ ] `RAG_DEVICE` unset → server logs `device=cpu`
- [ ] `RAG_DEVICE=<unsupported>` → first embed throws `EmbeddingError` with the transformers.js message