### PR TITLE
fix(server.json): declare RAG_DEVICE and RAG_HYBRID_WEIGHT env vars

### DIFF
--- a/server.json
+++ b/server.json
@@ -81,6 +81,20 @@
           "isRequired": false,
           "format": "string",
           "isSecret": false
+        },
+        {
+          "name": "RAG_DEVICE",
+          "description": "Execution device for the embedder (defaults to cpu). Passed straight to ONNX Runtime; see the Transformers.js device source for the supported backend names. If the requested device fails to initialize, the server throws an error.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "RAG_HYBRID_WEIGHT",
+          "description": "Keyword boost factor for hybrid search (0.0-1.0, defaults to 0.6). 0 means semantic similarity only; higher values increase the keyword-match contribution to the final score.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
         }
       ],
       "features": {


### PR DESCRIPTION
## Summary

Two environment variables read by the MCP server at startup were missing from `server.json`'s `environmentVariables` declaration. MCP registry validation rejects env vars the runtime uses that the manifest does not declare, so this would fail on the next publish.

## Added

| Env var | Default | Read at |
|---|---|---|
| `RAG_DEVICE` | `cpu` | `src/server-main.ts` (passed to the embedder; `RAG_DEVICE=webgpu` opts in to GPU) |
| `RAG_HYBRID_WEIGHT` | `0.6` | `src/server-main.ts` (keyword boost factor for hybrid search) |

Both are already documented in `README.md` — this PR only syncs the manifest to match.

## Out of scope

The `$schema` URL (`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`) is the latest version published upstream and is currently reachable (HTTP 200, valid draft-07 schema). The upstream MCP registry's own examples on `main` use the same URL. If VS Code reports "schema can't be loaded", the cause is local (schema cache / proxy / extension conflict), not the manifest.