### PR TITLE
Add opt-in visual-quality profile (fast / quality) for PDF visual ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Re-ingesting the same file replaces the old version automatically.
 
 ##### Ingesting PDFs with figures (visual mode)
 
-PDFs with charts, tables, or diagrams can optionally add local VLM-generated captions to the related text chunks, giving visual content some searchable representation in the same vector + FTS pipeline.
+PDFs with charts, tables, or diagrams can optionally add local VLM-generated captions to the document index, giving visual content some searchable representation in the same vector + FTS pipeline.
 
 **Via MCP**:
 ```
@@ -133,9 +133,34 @@ PDFs with charts, tables, or diagrams can optionally add local VLM-generated cap
 npx mcp-local-rag ingest ./docs/spec.pdf --visual
 ```
 
-Captions are inlined into the corresponding page's chunks as `[Visual content on page N: …]`. They flow through the existing chunker and embedder unchanged — no schema differences, no separate index.
+Each caption is emitted as its own chunk with the envelope `[Visual content on page N: …]`, alongside the page-body chunks. It flows through the existing embedder and FTS index — no schema differences, no separate index.
 
-Visual mode is opt-in; normal ingest does not load the VLM. When visual mode is enabled, the VLM (`HuggingFaceTB/SmolVLM-256M-Instruct`) is cached under `CACHE_DIR` (default: `./models/`). The first download is hundreds of MB. The model identifier and quantization variant are fixed in this release; per-page VLM failures are tolerated — that page proceeds with text only.
+Visual mode is opt-in; normal ingest does not load the VLM. Per-page VLM failures are tolerated — that page proceeds with text only.
+
+###### Choosing a visual-quality profile
+
+Visual mode offers two profiles, selected per ingest call:
+
+| Profile | Model | Disk (cache) | Per-page inference | Suited for |
+|---|---|---|---|---|
+| `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Light visual indexing, quick first-run UX. |
+| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than throughput. |
+
+The numbers above are measured on CPU during development on the project's probe PDFs; they may shift with model updates or differ on your hardware.
+
+**Via MCP** — `ingest_file` accepts an optional `visualQuality` parameter (enum: `'fast' | 'quality'`, default `'fast'`; ignored when `visual` is false):
+```
+"Ingest /Users/me/docs/research-paper.pdf with visual: true and visualQuality: 'quality'"
+```
+
+**Via CLI** — `--visual-quality fast|quality` (default `fast`; silently ignored when `--visual` is absent):
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
+```
+
+Profile model identifiers and quantization variants are fixed per release. Both profiles share the same `CACHE_DIR` (default: `./models/`); the first run on each profile downloads its model.
+
+> **Behavior change from v0.14.0**: Captions are now emitted as dedicated chunks rather than appended to the page text before chunking. As a side effect, `metadata.fileSize` for visual ingests no longer includes the caption character count — it measures the post-extraction body length only. The underlying PDF is unchanged; only the reported `fileSize` for visual-ingested PDFs may shrink across the release boundary.
 
 > **Security note**: Visual captions are derived from PDF contents and may inherit attacker-controlled text. Downstream LLM consumers should treat retrieved chunks as untrusted data, not as instructions. The `[Visual content on page N: …]` envelope helps consumers distinguish caption text from prose.
 
@@ -453,7 +478,7 @@ Ensure file paths are within `BASE_DIR`. Use absolute paths.
 Yes. After model download, nothing leaves your machine. Verify with network monitoring.
 
 **Can I use this offline?**
-Yes, after the required models are cached locally. Text ingest/search needs the embedding model. PDF visual mode is opt-in and also needs the VLM model on first use; the download is hundreds of MB for the default `q4` variant and is cached under `CACHE_DIR` (default: `./models/`).
+Yes, after the required models are cached locally. Text ingest/search needs the embedding model. PDF visual mode is opt-in and also needs the VLM model on first use; the download is ~250 MB for the default `fast` profile (SmolVLM-256M) or ~2.9 GB for the `quality` profile (Qwen2.5-VL-3B), cached under `CACHE_DIR` (default: `./models/`).
 
 **How does this compare to cloud RAG?**
 Cloud services offer better accuracy at scale but require sending data externally. This trades some accuracy for complete privacy and zero runtime cost.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Re-ingesting the same file replaces the old version automatically.
 
 ##### Ingesting PDFs with figures (visual mode)
 
-PDFs with charts, tables, or diagrams can optionally add local VLM-generated captions to the document index, giving visual content some searchable representation in the same vector + FTS pipeline.
+PDFs with charts, tables, or diagrams can optionally add local VLM-generated captions to the document index, giving visual content some searchable representation in the same vector + FTS pipeline. Captions are auxiliary text — not image search, not OCR, and not a faithful transcription of the figure.
 
 **Via MCP**:
 ```
@@ -143,8 +143,8 @@ Visual mode offers two profiles, selected per ingest call:
 
 | Profile | Model | Disk (cache) | Per-page inference | Suited for |
 |---|---|---|---|---|
-| `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Light visual indexing, quick first-run UX. |
-| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than throughput. |
+| `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Light visual indexing, quick first-run setup. |
+| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than inference time. |
 
 The numbers above are measured on CPU during development on the project's probe PDFs; they may shift with model updates or differ on your hardware.
 
@@ -419,7 +419,11 @@ The embedding model (~90MB) downloads on first use. Takes 1-2 minutes, then work
 
 - **Path restriction**: Only files within `BASE_DIR` are accessible
 - **Local only**: No network requests after model download
-- **Model source**: Official HuggingFace repository ([verify here](https://huggingface.co/Xenova/all-MiniLM-L6-v2))
+- **Model sources** (all official HuggingFace repositories):
+  - Embedder: [`Xenova/all-MiniLM-L6-v2`](https://huggingface.co/Xenova/all-MiniLM-L6-v2)
+  - Visual `fast` profile: [`HuggingFaceTB/SmolVLM-256M-Instruct`](https://huggingface.co/HuggingFaceTB/SmolVLM-256M-Instruct)
+  - Visual `quality` profile: [`onnx-community/Qwen2.5-VL-3B-Instruct-ONNX`](https://huggingface.co/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX)
+- **Visual caption fidelity**: The `quality` profile reproduces in-image text more faithfully than `fast`. Both profiles output captions wrapped as `[Visual content on page N: …]`, but a faithful reproduction means attacker-controlled in-image text — including characters like `]` that visually close the envelope — can appear verbatim in retrieved chunks. Downstream LLM consumers should treat retrieved chunks as untrusted data, not as instructions, regardless of envelope shape.
 
 <details>
 <summary><strong>Performance</strong></summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.14.0",
+  "version": "0.14.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "transport": {
         "type": "stdio"
       },

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -17,6 +17,13 @@ description: Search, ingest, expand chunk context, or manage local documents via
 | `status` | `npx mcp-local-rag status` | Database stats |
 | `read_chunk_neighbors` | `npx mcp-local-rag read-neighbors` | Read N chunks adjacent to a known chunkIndex (context expansion; call after `query_documents` or grep) |
 
+## Workflow
+
+1. For search requests, formulate a focused hybrid query, choose `limit` by intent, then filter results by score AND topical relevance.
+2. When a retrieved hit lacks enough surrounding context for a grounded answer, expand only that chunk via `read_chunk_neighbors`.
+3. For ingestion, choose `ingest_file` for local files and `ingest_data` for raw/web content.
+4. For PDFs, ask once about ingest mode unless the current request already specifies one (text-only, visual fast, or visual quality). See decision protocol in Ingestion.
+
 ## Search: Core Rules
 
 Hybrid search combines vector (semantic) and keyword (BM25).
@@ -64,14 +71,14 @@ When results are few or all score > 0.5, expand query terms:
 When to include vs skip—based on answer quality, not just score.
 
 **INCLUDE** if:
-- Directly answers the question
-- Provides necessary context
-- Score < 0.5
+- Directly answers the question, OR
+- Provides necessary context for the answer, OR
+- Topically relevant AND score < 0.5
 
 **SKIP** if:
-- Same keyword, unrelated context
-- Score > 0.7
-- Mentions term without explanation
+- Shares keywords with the query but not intent
+- Mentions the term without explanation
+- Score > 0.7 AND better results exist
 
 ### fileTitle
 
@@ -89,11 +96,11 @@ Each result includes `fileTitle` (document title extracted from content). Null w
 
 Each `query_documents` result item includes `chunkIndex` plus either `filePath` or `source`. Pass `filePath` for files ingested with `ingest_file`, or `source` for content ingested with `ingest_data`.
 
-Trigger this tool only when one of these signals is present:
+Use this tool when one of these signals is present:
 - **Insufficient context for your answer**: during response generation, the target chunk alone is not enough to reach a grounded conclusion (e.g., it references "this approach" or "as shown above" without the referent).
 - **Explicit user request for more context**: the user asks for surrounding detail ("what comes before that?", "read more around that section", "show me the full explanation").
 
-If neither signal is present, stop at the `query_documents` results.
+Otherwise, answer from the existing `query_documents` results.
 
 Typical workflow when triggered:
 1. Identify the specific chunk to expand (from a prior `query_documents` hit or `grep`).
@@ -110,10 +117,39 @@ ingest_file({ filePath: "/absolute/path/to/document.pdf" })
 ```
 
 **PDF visual-mode decision:**
-- If the user explicitly asks for visual content, figures, charts, tables, diagrams, screenshots, or scanned page content to be searchable, use `visual: true`.
-- If the user asks to ingest a PDF and does not explicitly mention figures, charts, tables, diagrams, screenshots, or scanned content, ask one short question before ingesting: "Should figures, charts, tables, diagrams, or screenshots in this PDF be made searchable too? Visual ingest may take longer when the PDF has many visual pages."
-- If the user confirms visual content matters, use `visual: true`. If the user wants the fastest text-only ingest or says visual content is not important, use the default text-only ingest.
-- For non-PDF files, use normal `ingest_file`; visual mode has no effect.
+
+For non-PDF files (`.md`, `.docx`, `.txt`), use normal `ingest_file`; `visual` and `visualQuality` have no effect.
+
+For PDFs, the decision has two factors: whether the document needs visual ingest, and which VLM profile to use if so. Both are cost trade-offs along two axes:
+- **Disk**: enabling `visual` downloads a local VLM. `quality` downloads a materially larger model than `fast`.
+- **Machine load**: per-visual-page inference. `quality` is materially heavier per page than `fast`.
+
+Pick by these rules:
+
+1. **Current request already specifies an ingest mode** — follow it without asking:
+   - User explicitly mentions visual content to be searchable (figures, charts, tables, diagrams, screenshots, captions, labels, annotations, faithful captions): use `visual: true`. Select the profile per "Profile signals" below.
+   - User explicitly picks a profile (e.g., "use quality profile", "visual quality"): use that profile.
+   - User explicitly opts out of visual (e.g., "text only", "no images needed", "skip figures"): use text-only ingest.
+
+2. **Current request does not specify a mode**: ask the user before ingesting, in one consolidated question:
+
+   > "Is this PDF image-heavy (figures, charts, tables, or diagrams that should be searchable)?
+   >
+   > If **no** — text-only ingest (fastest; no VLM download, no per-page inference).
+   >
+   > If **yes** — choose a VLM profile:
+   > - **fast** — captures figure titles and broad figure types; detailed in-image text (axis labels, annotations) is less reliable. Downloads a local VLM (extra disk) and runs inference per visual page (machine load). Relatively lightweight.
+   > - **quality** — captures in-image text (axis labels, panel sub-labels, flowchart nodes) more reliably. Materially heavier than 'fast' on both disk and machine load.
+   >
+   > Which fits?"
+
+   Map the reply: no / text-only → text-only ingest. yes + fast / lightweight → `visual: true` (omit `visualQuality`). yes + quality / faithful / labels / accurate captions → `visual: true, visualQuality: 'quality'`.
+
+**Profile signals** (used when `visual: true` and the user did not explicitly pick a profile):
+
+- Default: omit `visualQuality` → server uses `'fast'`.
+- Use `visualQuality: 'quality'` when the user signals in-image text fidelity matters: axis labels, panel sub-labels, annotations, faithful captions, research paper figures, technical diagrams with embedded labels (manuals, architecture diagrams), dense dashboards.
+- If unsure between `fast` and `quality`, ask: "Use the 'quality' profile? It captures in-image text (axis labels, annotations) more reliably but is materially heavier on disk and machine load than 'fast'."
 
 ### ingest_data
 ```
@@ -145,30 +181,33 @@ Re-ingest same source to update. Use same source in `delete_file` to remove.
 
 ### Visual content (PDFs)
 
-Opt-in visual ingest enriches PDF chunks with text descriptions of figures, charts, tables, and diagrams produced by a local Vision Language Model (VLM). Use the decision protocol in `ingest_file` to choose visual mode; otherwise use the default text-only ingest.
+Opt-in visual ingest emits dedicated caption chunks for figures, charts, tables, and diagrams produced by a local Vision Language Model (VLM). Use the decision protocol in `ingest_file` to choose visual mode and select between the `fast` (lightweight) and `quality` (more faithful, heavier) profiles.
 
-Captions are appended to the originating page's text before chunking, so they flow through the same embedder/search pipeline as regular text — no schema change, no separate retrieval path.
+Each caption is its own chunk wrapped as `[Visual content on page <N>: <caption>]`, flowing through the same embedder/search pipeline as page-body chunks — no schema change, no separate retrieval path.
 
 ```
 ingest_file({ filePath: "/absolute/path/to/figures.pdf", visual: true })
+ingest_file({ filePath: "/absolute/path/to/research-paper.pdf", visual: true, visualQuality: "quality" })
 ```
 
 ```
 npx mcp-local-rag ingest /absolute/path/to/figures.pdf --visual
+npx mcp-local-rag ingest /absolute/path/to/research-paper.pdf --visual --visual-quality quality
 ```
 
 - `visual` defaults to `false`. Without it, ingest behavior is identical to before; no VLM is loaded and no model is downloaded.
 - `visual: true` only takes effect for `.pdf` files. For non-PDFs (`.md`, `.docx`, `.txt`), the flag is silently ignored.
-- Captioned content is embedded inline as `[Visual content on page <N>: <caption>]` within the same page's chunks — searchable via `query_documents` like any other text.
+- `visualQuality` selects the VLM profile (`'fast'` default, `'quality'` for higher in-image text fidelity). Selection criteria live in the `ingest_file` protocol above. Silently ignored when `visual` is false. The MCP boundary also accepts `""` as a synonym for omitted.
+- Caption chunks are searchable via `query_documents` like any other text.
 - VLM failures use text-only fallback; see Retry on failure below.
 
 **Environment variables:**
 
 | Env | Default | Purpose |
 |-----|---------|---------|
-| `CACHE_DIR` | `./models/` | Shared model cache directory for the embedder and VLM |
+| `CACHE_DIR` | `./models/` | Shared model cache directory for the embedder and VLM (both profiles) |
 
-**First-time model download:** The VLM is downloaded on the first visual ingest and cached under `CACHE_DIR` (shared with the embedder). The download is hundreds of MB.
+**First-time model download:** Each profile's VLM is downloaded on the first visual ingest that uses it, cached under `CACHE_DIR`. The `quality` profile's model is materially larger than `fast`'s; each profile downloads its own model on first use. See [cli-reference.md](references/cli-reference.md#ingest) for current approximate sizes.
 
 **Retry on failure:** Per-page VLM failures degrade gracefully (the page is ingested as text-only) and the file ingest completes. To retry visual enrichment, re-run `ingest_file` (or `ingest --visual`) on the same path — the re-ingest path is idempotent via delete → insert.
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -28,6 +28,7 @@ npx mcp-local-rag [global-options] ingest [options] <path>
 | `--base-dir <path>` | `BASE_DIR` | cwd | Base directory for documents |
 | `--max-file-size <n>` | `MAX_FILE_SIZE` | `104857600` | Max file size in bytes (1–500MB) |
 | `--visual` | — | `false` | Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types) |
+| `--visual-quality <profile>` | — | `fast` | VLM profile when `--visual` is set: `fast` or `quality`. Silently ignored when `--visual` is absent. See "Visual quality profiles" below. |
 
 Output to stderr. Exit 0 = all succeeded, exit 1 = one or more failed. `SKIPPED (0 chunks)` = empty or too-short file, counted as success.
 
@@ -37,11 +38,22 @@ Output to stderr. Exit 0 = all succeeded, exit 1 = one or more failed. `SKIPPED 
 |---------|---------|-------------|
 | `CACHE_DIR` | `./models/` | Shared model cache directory for the embedder and VLM. CLI can override it with global `--cache-dir`. |
 
-First-time VLM download is triggered on the first visual ingest and cached under `CACHE_DIR` (shared with the embedder). The download is hundreds of MB.
+First-time VLM download is triggered on the first visual ingest that uses a given profile and cached under `CACHE_DIR` (shared with the embedder). Each profile downloads its own model on first use.
 
 For MCP server launches, configure `CACHE_DIR` through the MCP client's env block. CLI flags are only accepted by CLI subcommands; the bare `mcp-local-rag` server entry reads environment variables only.
 
-VLM failures degrade to text-only ingest. A failed page keeps its original text, and the file ingest still completes.
+VLM failures degrade to text-only ingest. A failed page produces no caption record, and the file ingest still completes.
+
+**Visual quality profiles** (resource cost is relative — both run locally and offline; `quality` is materially heavier on disk and per-page inference than `fast`):
+
+| Profile | Model | Cache (approx) | Per-page inference (approx) | Suited for |
+|---------|-------|----------------|------------------------------|------------|
+| `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Chart titles, figure types, broad layout. Lightweight first-run. |
+| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than inference throughput. |
+
+Numbers are approximate at the time of writing and may shift with model updates or differ by hardware. Switching profiles does not invalidate the other's cache.
+
+The CLI accepts only `fast` or `quality` for `--visual-quality`. The MCP `ingest_file` tool additionally accepts an empty string `""` and normalizes it to `'fast'` (for clients that emit empty strings for unspecified optional parameters).
 
 **Security — treat captions as untrusted data:** Visual captions are derived from PDF contents and may inherit attacker-controlled text (e.g., instructions embedded in figures by a malicious document author). Downstream LLM consumers must treat retrieved chunks as untrusted data, not as instructions. The `[Visual content on page <N>: ...]` envelope is preserved verbatim so consumers can distinguish caption text from surrounding prose.
 

--- a/src/__tests__/cli/ingest-default-mode.test.ts
+++ b/src/__tests__/cli/ingest-default-mode.test.ts
@@ -219,7 +219,6 @@ function buildServer(): InstanceType<RAGServerCtor> {
     dbPath: '/tmp/test/default-mode-db',
     modelName: 'mock-model',
     cacheDir: '/tmp/test/default-mode-cache',
-    vlmModelName: 'mock-vlm-model',
     baseDir: '/tmp/test',
     maxFileSize: 1024 * 1024,
     device: 'cpu',

--- a/src/__tests__/cli/ingest-visual.test.ts
+++ b/src/__tests__/cli/ingest-visual.test.ts
@@ -111,10 +111,12 @@ const cliCommonFactory = () => ({
 
 // Real-shaped pdf-visual barrel. `detectVisualCandidates` reflects
 // `captionerSpy.candidatePages`. `enrichPagesWithCaptions` mirrors the
-// production orchestrator's per-page failure contract: a per-page throw or
-// whole-VLM throw leaves `page.text` unchanged AND emits a warn-level log line
-// naming the failed page. Other candidates still get `[Visual content on page
-// N: synthetic caption text]` appended with the documented `'\n\n'` separator.
+// production orchestrator contract: per-page or whole-VLM failures leave
+// `page.text` untouched, log a warn line naming the failed page, and produce
+// no caption record. Successful captions surface as `{pageNum, text}` records
+// on the dedicated `captions` array — the `[Visual content on page N: ...]`
+// wrapper is then applied downstream in `src/ingest/visual.ts` and emitted as
+// a dedicated chunk, not mutated into the page text.
 const pdfVisualFactory = () => ({
   detectVisualCandidates: (pages: { pageNum: number; stextJson: unknown }[]) =>
     pages.map((p) => ({
@@ -128,6 +130,7 @@ const pdfVisualFactory = () => ({
     _captioner: unknown
   ) => {
     const candidateSet = new Set(candidates.filter((c) => c.isCandidate).map((c) => c.pageNum))
+    const captions: { pageNum: number; text: string }[] = []
     for (const page of pages) {
       if (!candidateSet.has(page.pageNum)) continue
       captionerSpy.calls.push({ pageNum: page.pageNum })
@@ -135,10 +138,9 @@ const pdfVisualFactory = () => ({
         console.warn(`VLM caption failed for page ${page.pageNum}: simulated failure`)
         continue
       }
-      const separator = page.text ? '\n\n' : ''
-      page.text = `${page.text}${separator}[Visual content on page ${page.pageNum}: synthetic caption text]`
+      captions.push({ pageNum: page.pageNum, text: 'synthetic caption text' })
     }
-    return pages
+    return { pages, captions }
   },
   createCaptioner: () => ({
     caption: async () => 'synthetic caption text',
@@ -508,16 +510,20 @@ describe('VLM PDF Enrichment - Visual Mode', () => {
   //         plain text — no control characters that would break downstream
   //         processing.)"
   // ROI: 35 (BV:7 × Freq:5 + Legal:0 + Defect:0)
-  // Behavior: Caption appended → chunker + embedder complete without throwing
+  // Behavior: Caption emitted as a dedicated chunk → embedder consumes it
+  //           without throwing; body text passes through the chunker cleanly.
   // Verification items:
-  //   - chunker.chunkText resolves (not rejects) when given enriched text
-  //   - embedder.embedBatch resolves (not rejects) on the chunked output
-  //   - Final inserted chunks have non-empty `vector` arrays
+  //   - chunker.chunkText resolves on body text (captions are NOT in the
+  //     chunker input under the dedicated-chunk contract)
+  //   - embedder.embedBatch resolves on caption text array (called explicitly
+  //     for caption chunks in `prepareVisualPdfChunks`)
+  //   - Final inserted chunks include the caption marker AND have non-empty
+  //     `vector` arrays
   // @category: integration
   // @lane: integration
   // @dependency: ingestSingleFile, real chunker + real embedder (or shape-checked stubs)
   // @complexity: low
-  it('AC-007: enriched page text passes through chunker and embedder without error', async () => {
+  it('AC-007: caption chunk passes through embedder without error; chunker sees body-only text', async () => {
     // Arrange: same setup as AC-002 — page 2 is the only candidate.
     const filePath = resolve('/tmp/test/ac007.pdf')
     mocks.stat.mockResolvedValue(mockFileStat())
@@ -529,18 +535,26 @@ describe('VLM PDF Enrichment - Visual Mode', () => {
     expect(error).toBeUndefined()
     expect(process.exitCode).toBeUndefined()
 
-    // Assert: chunker.chunkText was called on the enriched joined text. The
-    // first argument carries the caption marker — i.e. the enriched text
-    // actually entered the chunker, not the pre-enrichment text.
+    // Assert: chunker.chunkText was called once on the body-only joined text;
+    // the caption marker MUST NOT appear in the chunker input (it lives in a
+    // dedicated chunk emitted after chunking).
     expect(mocks.chunkText).toHaveBeenCalledTimes(1)
     const chunkTextArg = mocks.chunkText.mock.calls[0]?.[0] as string
-    expect(chunkTextArg).toContain('[Visual content on page 2: synthetic caption text]')
+    expect(chunkTextArg).not.toContain('[Visual content on page')
 
-    // Assert: embedder.embedBatch was called on the chunker output (chunk texts).
-    expect(mocks.embedBatch).toHaveBeenCalledTimes(1)
-    const embedBatchArg = mocks.embedBatch.mock.calls[0]?.[0] as string[]
-    expect(Array.isArray(embedBatchArg)).toBe(true)
-    expect(embedBatchArg.length).toBeGreaterThan(0)
+    // Assert: embedder.embedBatch was called for the body chunks AND a
+    // separate explicit call for the caption chunk texts. The caption call
+    // carries the visual marker — proving the caption string survived the
+    // downstream embedder boundary without throwing.
+    expect(mocks.embedBatch.mock.calls.length).toBeGreaterThanOrEqual(2)
+    const allEmbedBatchTexts = mocks.embedBatch.mock.calls.flatMap(
+      (call) => (call[0] as string[]) ?? []
+    )
+    expect(
+      allEmbedBatchTexts.some((t) =>
+        t.includes('[Visual content on page 2: synthetic caption text]')
+      )
+    ).toBe(true)
 
     // Assert: every inserted chunk has a non-empty vector.
     expect(inserted.length).toBeGreaterThan(0)

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -945,6 +945,44 @@ describe('CLI ingest', () => {
         errorSpy.mockRestore()
       }
     })
+
+    it('should parse --visual-quality fast', () => {
+      const result = parseArgs(['--visual', '--visual-quality', 'fast', '/target'])
+      expect(result.positional).toBe('/target')
+      expect(result.options.visual).toBe(true)
+      expect(result.options.visualQuality).toBe('fast')
+    })
+
+    it('should parse --visual-quality quality', () => {
+      const result = parseArgs(['--visual', '--visual-quality', 'quality', '/target'])
+      expect(result.options.visualQuality).toBe('quality')
+    })
+
+    it('should reject --visual-quality with an invalid value', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--visual', '--visual-quality', 'extreme', '/target'])).toThrow(
+          'process.exit(1)'
+        )
+        expect(
+          errorSpy.mock.calls.some((call) =>
+            String(call[0]).includes('Invalid value for --visual-quality')
+          )
+        ).toBe(true)
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
+    it('should error when --visual-quality value is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--visual-quality'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('Missing value for --visual-quality')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
   })
 
   // --------------------------------------------

--- a/src/__tests__/cli/options.test.ts
+++ b/src/__tests__/cli/options.test.ts
@@ -205,7 +205,6 @@ describe('CLI global options', () => {
         dbPath: GLOBAL_DEFAULTS.dbPath,
         cacheDir: GLOBAL_DEFAULTS.cacheDir,
         modelName: GLOBAL_DEFAULTS.modelName,
-        vlmModelName: GLOBAL_DEFAULTS.vlmModelName,
       })
     })
 
@@ -219,7 +218,6 @@ describe('CLI global options', () => {
         dbPath: '/cli/db',
         cacheDir: '/cli/cache',
         modelName: 'cli/model',
-        vlmModelName: GLOBAL_DEFAULTS.vlmModelName,
       })
     })
 
@@ -233,7 +231,6 @@ describe('CLI global options', () => {
         dbPath: '/env/db',
         cacheDir: '/env/cache',
         modelName: 'env/model',
-        vlmModelName: GLOBAL_DEFAULTS.vlmModelName,
       })
     })
 
@@ -251,7 +248,6 @@ describe('CLI global options', () => {
         dbPath: '/cli/db',
         cacheDir: '/cli/cache',
         modelName: 'cli/model',
-        vlmModelName: GLOBAL_DEFAULTS.vlmModelName,
       })
     })
 

--- a/src/__tests__/server/handleIngestFile-side-effects.test.ts
+++ b/src/__tests__/server/handleIngestFile-side-effects.test.ts
@@ -166,7 +166,6 @@ function buildServer(): RAGServer {
     dbPath: '/tmp/test/side-effects-db',
     modelName: 'mock-model',
     cacheDir: '/tmp/test/side-effects-cache',
-    vlmModelName: 'mock-vlm-model',
     baseDir: '/tmp/test',
     maxFileSize: 1024 * 1024,
     device: 'cpu',

--- a/src/__tests__/server/handleIngestFile-visual-validation.test.ts
+++ b/src/__tests__/server/handleIngestFile-visual-validation.test.ts
@@ -163,7 +163,6 @@ function buildServer(): InstanceType<RAGServerCtor> {
     dbPath: '/tmp/test/visual-validation-db',
     modelName: 'mock-model',
     cacheDir: '/tmp/test/visual-validation-cache',
-    vlmModelName: 'mock-vlm-model',
     baseDir: '/tmp/test',
     maxFileSize: 1024 * 1024,
     device: 'cpu',
@@ -410,5 +409,133 @@ describe('handleIngestFile - `visual` Runtime Validation (AC-012)', () => {
     expect(mocks.createCaptioner).toHaveBeenCalledTimes(1)
     expect(mocks.detectVisualCandidates).toHaveBeenCalledTimes(1)
     expect(mocks.enrichPagesWithCaptions).toHaveBeenCalledTimes(1)
+  })
+})
+
+// =============================================================================
+// `visualQuality` boundary validation + normalization
+// =============================================================================
+//
+// The MCP boundary receives `unknown`, so the JSON Schema enum is necessary
+// but not sufficient. Accepted inputs at the boundary: undefined, "", "fast",
+// "quality" (with undefined and "" normalized to "fast"); any other value
+// fails fast with McpError(InvalidParams) before reaching the captioner.
+const QUALITY_INVALID_MESSAGE = "'visualQuality' must be 'fast' or 'quality' if provided"
+
+describe('handleIngestFile - `visualQuality` Runtime Validation', () => {
+  beforeAll(async () => {
+    vi.resetModules()
+    vi.doMock('../../parser/index.js', parserFactory)
+    vi.doMock('../../chunker/index.js', chunkerFactory)
+    vi.doMock('../../embedder/index.js', embedderFactory)
+    vi.doMock('../../vectordb/index.js', vectordbFactory)
+    vi.doMock('../../pdf-visual/index.js', pdfVisualFactory)
+    const mod = await import('../../server/index.js')
+    RAGServer = mod.RAGServer as RAGServerCtor
+  })
+
+  afterAll(() => {
+    for (const p of MOCKED_PATHS) vi.doUnmock(p)
+    vi.resetModules()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.initialize.mockResolvedValue(undefined)
+    mocks.deleteChunks.mockResolvedValue(undefined)
+    mocks.optimize.mockResolvedValue(undefined)
+    mocks.listFiles.mockResolvedValue([])
+    mocks.search.mockResolvedValue([])
+    mocks.embedInitialize.mockResolvedValue(undefined)
+    mocks.embed.mockResolvedValue([0.1, 0.2])
+    mocks.embedBatch.mockResolvedValue([[0.1, 0.2]])
+    mocks.validateFilePath.mockResolvedValue(undefined)
+    mocks.parseFile.mockResolvedValue({ content: 'plain content', title: 'plain title' })
+    mocks.parsePdf.mockResolvedValue({ content: 'pdf content', title: 'pdf title' })
+    mocks.parsePdfPages.mockResolvedValue({
+      doc: { destroy: vi.fn() },
+      metadataTitle: undefined,
+      pages: [{ pageNum: 1, text: 'page 1 text', stextJson: { blocks: [] } }],
+    })
+    mocks.enrichPagesWithCaptions.mockImplementation(async (pages: unknown) => ({
+      pages,
+      captions: [],
+    }))
+    mocks.detectVisualCandidates.mockReturnValue([])
+    mocks.createCaptioner.mockReturnValue({ caption: vi.fn().mockResolvedValue(null) })
+    mocks.chunkText.mockResolvedValue([{ text: 'chunk 0 text', index: 0 }])
+  })
+
+  it("rejects visualQuality === 'high' with McpError(InvalidParams)", async () => {
+    const server = buildServer()
+    let caught: unknown
+    try {
+      await server.handleIngestFile({
+        filePath: FIXTURE_PDF_PATH,
+        visual: true,
+        visualQuality: 'high',
+      } as unknown as { filePath: string })
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(McpError)
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams)
+    expect((caught as McpError).message).toContain(QUALITY_INVALID_MESSAGE)
+    // Validation short-circuited before any downstream work.
+    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
+    expect(mocks.createCaptioner).toHaveBeenCalledTimes(0)
+  })
+
+  it('rejects non-string visualQuality (number) with McpError(InvalidParams)', async () => {
+    const server = buildServer()
+    let caught: unknown
+    try {
+      await server.handleIngestFile({
+        filePath: FIXTURE_PDF_PATH,
+        visual: true,
+        visualQuality: 1,
+      } as unknown as { filePath: string })
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(McpError)
+    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams)
+  })
+
+  it('normalizes visualQuality === "" to "fast" without throwing (empty-string MCP convention)', async () => {
+    const server = buildServer()
+    await server.handleIngestFile({
+      filePath: FIXTURE_PDF_PATH,
+      visual: true,
+      visualQuality: '',
+    } as unknown as { filePath: string })
+    // Reached the visual dispatch path → captioner constructed with the
+    // normalized 'fast' profile (empty string did NOT propagate).
+    expect(mocks.createCaptioner).toHaveBeenCalledTimes(1)
+    const captionerConfig = mocks.createCaptioner.mock.calls[0]?.[0] as { profile?: unknown }
+    expect(captionerConfig?.profile).toBe('fast')
+  })
+
+  it("forwards visualQuality === 'quality' to createCaptioner", async () => {
+    const server = buildServer()
+    await server.handleIngestFile({
+      filePath: FIXTURE_PDF_PATH,
+      visual: true,
+      visualQuality: 'quality',
+    } as unknown as { filePath: string })
+    expect(mocks.createCaptioner).toHaveBeenCalledTimes(1)
+    const captionerConfig = mocks.createCaptioner.mock.calls[0]?.[0] as { profile?: unknown }
+    expect(captionerConfig?.profile).toBe('quality')
+  })
+
+  it("defaults to 'fast' when visualQuality is absent (undefined)", async () => {
+    const server = buildServer()
+    await server.handleIngestFile({
+      filePath: FIXTURE_PDF_PATH,
+      visual: true,
+    } as unknown as { filePath: string })
+    expect(mocks.createCaptioner).toHaveBeenCalledTimes(1)
+    const captionerConfig = mocks.createCaptioner.mock.calls[0]?.[0] as { profile?: unknown }
+    expect(captionerConfig?.profile).toBe('fast')
   })
 })

--- a/src/__tests__/server/handleIngestFile-visual-validation.test.ts
+++ b/src/__tests__/server/handleIngestFile-visual-validation.test.ts
@@ -215,7 +215,10 @@ describe('handleIngestFile - `visual` Runtime Validation (AC-012)', () => {
       metadataTitle: undefined,
       pages: [{ pageNum: 1, text: 'page 1 text', stextJson: { blocks: [] } }],
     })
-    mocks.enrichPagesWithCaptions.mockImplementation(async (pages: unknown) => pages)
+    mocks.enrichPagesWithCaptions.mockImplementation(async (pages: unknown) => ({
+      pages,
+      captions: [],
+    }))
     mocks.detectVisualCandidates.mockReturnValue([])
     mocks.createCaptioner.mockReturnValue({ caption: vi.fn().mockResolvedValue(null) })
     // Default chunker behavior — return a single chunk so the handler does NOT

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -9,6 +9,7 @@ import type { Embedder } from '../embedder/index.js'
 import { buildChunksAndEmbeddings } from '../ingest/compute.js'
 import { prepareVisualPdfChunks } from '../ingest/visual.js'
 import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
+import type { QualityProfile } from '../pdf-visual/types.js'
 import type { VectorChunk, VectorStore } from '../vectordb/index.js'
 import { createEmbedder, createVectorStore } from './common.js'
 import type { GlobalOptions, ResolvedGlobalConfig } from './options.js'
@@ -50,6 +51,12 @@ interface IngestCliOptions {
   maxFileSize?: number | undefined
   chunkMinLength?: number | undefined
   visual?: boolean | undefined
+  /**
+   * Visual-quality profile selector. Only meaningful when `visual` is true;
+   * silently ignored otherwise (mirrors the existing `--visual` precedent
+   * of silently coercing for non-PDF files). Defaults to `'fast'`.
+   */
+  visualQuality?: QualityProfile | undefined
 }
 
 interface ParsedArgs {
@@ -75,11 +82,12 @@ const HELP_TEXT = `Usage: mcp-local-rag [global-options] ingest [options] <path>
 Ingest a single file or all supported files under a directory.
 
 Options:
-  --base-dir <path>        Base directory for documents (default: cwd)
-  --max-file-size <n>      Max file size in bytes (default: ${INGEST_DEFAULTS.maxFileSize})
-  --chunk-min-length <n>   Minimum chunk length in characters (default: 50, range: 1-10000)
-  --visual                 Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types)
-  -h, --help               Show this help
+  --base-dir <path>          Base directory for documents (default: cwd)
+  --max-file-size <n>        Max file size in bytes (default: ${INGEST_DEFAULTS.maxFileSize})
+  --chunk-min-length <n>     Minimum chunk length in characters (default: 50, range: 1-10000)
+  --visual                   Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types)
+  --visual-quality <profile> VLM profile when --visual is set: fast (default, lightweight) or quality (Qwen2.5-VL-3B, ~10x cache, ~2x inference)
+  -h, --help                 Show this help
 
 Global options (must appear before "ingest"):
   --db-path <path>         LanceDB database path
@@ -154,6 +162,22 @@ export function parseArgs(args: string[]): ParsedArgs {
         options.visual = true
         i++
         break
+      case '--visual-quality': {
+        const value = args[++i]
+        if (value === undefined || value.startsWith('-')) {
+          console.error('Missing value for --visual-quality')
+          process.exit(1)
+        }
+        if (value !== 'fast' && value !== 'quality') {
+          console.error(
+            `Invalid value for --visual-quality: "${value.slice(0, 100)}". Expected "fast" or "quality".`
+          )
+          process.exit(1)
+        }
+        options.visualQuality = value
+        i++
+        break
+      }
       default:
         if (arg.startsWith('-')) {
           console.error(`Unknown option: ${arg}`)
@@ -314,22 +338,22 @@ async function collectFiles(targetPath: string, excludePaths: string[]): Promise
 // ============================================
 
 /**
- * Options for `ingestSingleFile`. Discriminated on `visual` so the visual path
- * is type-only callable with the VLM config it actually needs:
+ * Options for `ingestSingleFile`. Discriminated on `visual` so the visual
+ * path is type-only callable with the VLM config it actually needs:
  *  - `visual` absent or `false` → no VLM fields required (and not accepted).
- *  - `visual: true` → `vlmModelName` and `cacheDir` required; `device` optional.
+ *  - `visual: true` → `profile` and `cacheDir` required; `device` optional.
  *
- * Why a union rather than always-required fields: making `vlmModelName` /
- * `cacheDir` unconditionally required forces non-visual callers (default-mode
- * tests, future direct-import callers that only ingest non-PDF files) to
- * fabricate VLM config they will never use. The visual-true variant still
- * catches accidental misuse at compile time, which was the original goal.
+ * Why a union rather than always-required fields: making the VLM fields
+ * unconditionally required forces non-visual callers (default-mode tests,
+ * future direct-import callers that only ingest non-PDF files) to fabricate
+ * VLM config they will never use. The visual-true variant still catches
+ * accidental misuse at compile time, which was the original goal.
  */
 export type IngestSingleFileOptions =
   | { visual?: false | undefined }
   | {
       visual: true
-      vlmModelName: string
+      profile: QualityProfile
       cacheDir: string
       device?: string | undefined
     }
@@ -367,11 +391,12 @@ export async function ingestSingleFile(
     // inside that helper, not here). This branch keeps the CLI persistence
     // model (delete + insert; bulk-loop optimize at the end of `runIngest`).
     //
-    // `vlmModelName` and `cacheDir` are required by `prepareVisualPdfChunks`;
-    // the CLI bulk-loop always supplies them via the resolved `globalConfig`
-    // (see `resolveGlobalConfig` in `cli/options.ts`).
+    // `profile` and `cacheDir` are required by `prepareVisualPdfChunks`;
+    // the CLI bulk-loop always supplies them from the resolved CLI options
+    // (`runIngest` defaults `visualQuality` to `'fast'` when `--visual` is
+    // set without `--visual-quality`).
     const visualResult = await prepareVisualPdfChunks(filePath, parser, chunker, embedder, {
-      modelName: options.vlmModelName,
+      profile: options.profile,
       cacheDir: options.cacheDir,
       device: options.device,
     })
@@ -542,7 +567,11 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
         const ingestOptions: IngestSingleFileOptions = options.visual
           ? {
               visual: true,
-              vlmModelName: globalConfig.vlmModelName,
+              // Default the profile to `'fast'` when `--visual-quality` was
+              // not provided. The flag is silently ignored when `--visual`
+              // itself is absent (mirrors the existing `--visual` precedent
+              // of silently coercing for non-PDF files).
+              profile: options.visualQuality ?? 'fast',
               cacheDir: globalConfig.cacheDir,
               device: resolveDevice(process.env['RAG_DEVICE']),
             }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -85,7 +85,6 @@ export interface GlobalOptions {
   dbPath?: string | undefined
   cacheDir?: string | undefined
   modelName?: string | undefined
-  vlmModelName?: string | undefined
 }
 
 export interface ParsedGlobalResult {
@@ -97,7 +96,6 @@ export interface ResolvedGlobalConfig {
   dbPath: string
   cacheDir: string
   modelName: string
-  vlmModelName: string
 }
 
 // ============================================
@@ -108,7 +106,6 @@ export const GLOBAL_DEFAULTS = {
   dbPath: './lancedb/',
   cacheDir: './models/',
   modelName: 'Xenova/all-MiniLM-L6-v2',
-  vlmModelName: 'HuggingFaceTB/SmolVLM-256M-Instruct',
 } as const
 
 // ============================================
@@ -226,11 +223,6 @@ export function resolveGlobalConfig(options: GlobalOptions): ResolvedGlobalConfi
   const dbPath = options.dbPath ?? process.env['DB_PATH'] ?? GLOBAL_DEFAULTS.dbPath
   const cacheDir = options.cacheDir ?? process.env['CACHE_DIR'] ?? GLOBAL_DEFAULTS.cacheDir
   const modelName = options.modelName ?? process.env['MODEL_NAME'] ?? GLOBAL_DEFAULTS.modelName
-  // VLM model identifier and ONNX quantization variant are fixed for v1 — see
-  // server-main.ts for the rationale. `vlmModelName` is retained in the
-  // resolved config for the future model-family adapter; it is not
-  // user-tunable on the CLI surface yet.
-  const vlmModelName = GLOBAL_DEFAULTS.vlmModelName
 
   // Validate paths
   const dbPathError = validatePath(dbPath, '--db-path')
@@ -252,7 +244,7 @@ export function resolveGlobalConfig(options: GlobalOptions): ResolvedGlobalConfi
     process.exit(1)
   }
 
-  return { dbPath, cacheDir, modelName, vlmModelName }
+  return { dbPath, cacheDir, modelName }
 }
 
 /**

--- a/src/ingest/visual.ts
+++ b/src/ingest/visual.ts
@@ -39,11 +39,16 @@ export interface VisualPdfParser {
 }
 
 /**
- * Captioner configuration forwarded verbatim to `pdf-visual.createCaptioner`.
- * Mirrors `CaptionerConfig` from `src/pdf-visual/types.ts` without taking a
- * direct dependency on the dynamically-imported module (NFR-1).
+ * Captioner configuration forwarded to `pdf-visual.createCaptioner`. Mirrors
+ * the legacy shape used by `cli/ingest.ts` and `server/index.ts`; the
+ * `modelName` field is currently passed through but ignored — the dispatcher
+ * resolves the model from `profile` (hardcoded to `'fast'` in Phase 1, made
+ * caller-selectable in Phase 3). Kept on the interface so upstream callers
+ * compile against the same shape; Phase 3 removes `modelName` here and adds
+ * `profile`.
  */
 export interface CaptionerConfig {
+  /** Ignored in Phase 1. Removed and replaced by `profile` in Phase 3. */
   modelName: string
   cacheDir: string
   /** Execution device passed through to the captioner model. */
@@ -113,7 +118,17 @@ export async function prepareVisualPdfChunks(
   // invariant while removing the duplication.
   const pdfVisual = await import('../pdf-visual/index.js')
 
-  const captioner = pdfVisual.createCaptioner(captionerConfig)
+  // Bridge to the dispatcher-based captioner contract introduced in this
+  // refactor. `captionerConfig.modelName` is no longer the captioner's tuning
+  // knob — the model is resolved inside the selected profile. Phase 1 hard-
+  // codes `profile: 'fast'` so default behavior matches v0.14.0; Phase 3
+  // wires the profile through `IngestSingleFileOptions` / CLI flag / MCP
+  // tool parameter and drops `modelName` from this interface.
+  const captioner = pdfVisual.createCaptioner({
+    profile: 'fast',
+    cacheDir: captionerConfig.cacheDir,
+    ...(captionerConfig.device !== undefined ? { device: captionerConfig.device } : {}),
+  })
 
   const { doc, metadataTitle, pages } = await parser.parsePdfPages(filePath, embedder)
   try {
@@ -121,7 +136,7 @@ export async function prepareVisualPdfChunks(
       pages.map((p) => ({ pageNum: p.pageNum, stextJson: p.stextJson })),
       doc as Parameters<typeof pdfVisual.detectVisualCandidates>[1]
     )
-    const enrichedPages = await pdfVisual.enrichPagesWithCaptions(
+    const { pages: enrichedPages, captions } = await pdfVisual.enrichPagesWithCaptions(
       pages,
       candidates,
       // The dynamic import widens the doc type at the boundary; the parser
@@ -134,8 +149,10 @@ export async function prepareVisualPdfChunks(
       .filter((t) => t.length > 0)
       .join('\n\n')
 
-    // Chunk + embed once on the joined visual+text content. Title is derived
-    // AFTER chunking from `chunks[0]?.text` (DD §Title resolution).
+    // Chunk + embed the page text WITHOUT captions inline. Captions are
+    // emitted as dedicated chunks below so the semantic chunker cannot split
+    // their internal Summary / Keywords structure on sentence-boundary
+    // vocabulary shifts.
     const { chunks, embeddings } = await buildChunksAndEmbeddings(text, null, chunker, embedder)
 
     const titleResult = extractPdfTitle(
@@ -145,6 +162,20 @@ export async function prepareVisualPdfChunks(
       pages[0]?.page1FontHint
     )
     const title = titleResult.title || null
+
+    // Append one dedicated chunk per caption. The `[Visual content on page N:
+    // …]` wrapper is applied here (previously applied in the orchestrator)
+    // so the caption chunk text matches the historical marker format used by
+    // downstream search.
+    if (captions.length > 0) {
+      const captionChunks = captions.map((c, i) => ({
+        text: `[Visual content on page ${c.pageNum}: ${c.text}]`,
+        index: chunks.length + i,
+      }))
+      const captionEmbeddings = await embedder.embedBatch(captionChunks.map((c) => c.text))
+      chunks.push(...captionChunks)
+      embeddings.push(...captionEmbeddings)
+    }
 
     return { chunks, embeddings, title, text }
   } finally {

--- a/src/ingest/visual.ts
+++ b/src/ingest/visual.ts
@@ -24,6 +24,7 @@ import type { SemanticChunker, TextChunk } from '../chunker/index.js'
 import type { EmbedderInterface } from '../chunker/semantic-chunker.js'
 import type { DocumentParser } from '../parser/index.js'
 import { extractPdfTitle } from '../parser/title-extractor.js'
+import type { QualityProfile } from '../pdf-visual/types.js'
 import { buildChunksAndEmbeddings } from './compute.js'
 
 /**
@@ -39,17 +40,13 @@ export interface VisualPdfParser {
 }
 
 /**
- * Captioner configuration forwarded to `pdf-visual.createCaptioner`. Mirrors
- * the legacy shape used by `cli/ingest.ts` and `server/index.ts`; the
- * `modelName` field is currently passed through but ignored — the dispatcher
- * resolves the model from `profile` (hardcoded to `'fast'` in Phase 1, made
- * caller-selectable in Phase 3). Kept on the interface so upstream callers
- * compile against the same shape; Phase 3 removes `modelName` here and adds
- * `profile`.
+ * Captioner configuration forwarded to `pdf-visual.createCaptioner`. The
+ * `profile` selects the underlying VLM family (`fast` = SmolVLM-256M,
+ * `quality` = Qwen2.5-VL-3B); the actual model identifier lives inside the
+ * profile module.
  */
 export interface CaptionerConfig {
-  /** Ignored in Phase 1. Removed and replaced by `profile` in Phase 3. */
-  modelName: string
+  profile: QualityProfile
   cacheDir: string
   /** Execution device passed through to the captioner model. */
   device?: string | undefined
@@ -118,17 +115,7 @@ export async function prepareVisualPdfChunks(
   // invariant while removing the duplication.
   const pdfVisual = await import('../pdf-visual/index.js')
 
-  // Bridge to the dispatcher-based captioner contract introduced in this
-  // refactor. `captionerConfig.modelName` is no longer the captioner's tuning
-  // knob — the model is resolved inside the selected profile. Phase 1 hard-
-  // codes `profile: 'fast'` so default behavior matches v0.14.0; Phase 3
-  // wires the profile through `IngestSingleFileOptions` / CLI flag / MCP
-  // tool parameter and drops `modelName` from this interface.
-  const captioner = pdfVisual.createCaptioner({
-    profile: 'fast',
-    cacheDir: captionerConfig.cacheDir,
-    ...(captionerConfig.device !== undefined ? { device: captionerConfig.device } : {}),
-  })
+  const captioner = pdfVisual.createCaptioner(captionerConfig)
 
   const { doc, metadataTitle, pages } = await parser.parsePdfPages(filePath, embedder)
   try {

--- a/src/pdf-visual/__tests__/captioner-quality.test.ts
+++ b/src/pdf-visual/__tests__/captioner-quality.test.ts
@@ -1,0 +1,292 @@
+// `createCaptioner` (`quality` profile dispatch) unit test.
+//
+// Asserts the Qwen2.5-VL-3B-Instruct-ONNX surface contract owned by
+// `src/pdf-visual/captioners/quality.ts`:
+//
+//   - Model loaded via the explicit `Qwen2_5_VLForConditionalGeneration`
+//     class (not the architecture-agnostic `AutoModelForImageTextToText`).
+//   - Processor invoked with a SINGLE image argument (not the array form
+//     used by the IDEFICS3-based `fast` profile).
+//   - Image is resized to 448x448 client-side before being handed to the
+//     processor.
+//   - `model.generate` is called with `max_new_tokens` ONLY — the
+//     `repetition_penalty` / `no_repeat_ngram_size` options used by `fast`
+//     MUST NOT be present (they produce forced variant generation on Qwen).
+//   - `inputs.input_ids.dims.at(-1)` is the value used to slice prompt
+//     tokens from the generated output.
+//   - Load failure surfaces the resolved Qwen model identifier in the
+//     wrapper message.
+//
+// Cross-file mock isolation
+// -------------------------
+// `@huggingface/transformers` is also mocked by `captioner.test.ts`. Per the
+// project-context skill rule for `isolate: false` + `pool: forks`, this file
+// installs its factory via `vi.doMock` in `beforeAll` and removes it via
+// `vi.doUnmock` + `vi.resetModules` in `afterAll`. The shared module
+// registry is reset on both sides of the lifecycle so the two test files'
+// mock surfaces do not leak across.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ============================================
+// Mocks (vi.hoisted — required for `@huggingface/transformers`)
+// ============================================
+
+const mocks = vi.hoisted(() => {
+  const state: {
+    decodedText: string
+    fromPretrainedThrows: Error | null
+    generateThrows: Error | null
+    fromBlobThrows: Error | null
+    resizeThrows: Error | null
+  } = {
+    decodedText: 'a valid quality caption',
+    fromPretrainedThrows: null,
+    generateThrows: null,
+    fromBlobThrows: null,
+    resizeThrows: null,
+  }
+
+  const mockProcessorFromPretrained = vi.fn(async (_modelName: string, _options: unknown) => {
+    if (state.fromPretrainedThrows) throw state.fromPretrainedThrows
+    return mockProcessorInstance
+  })
+
+  const mockModelFromPretrained = vi.fn(async (_modelName: string, _options: unknown) => {
+    if (state.fromPretrainedThrows) throw state.fromPretrainedThrows
+    return mockModelInstance
+  })
+
+  // The Qwen2.5-VL processor takes the image directly (not as an array). The
+  // input_ids tensor's last dimension is the input length read via
+  // `dims.at(-1)`. We model the dim list with a leading batch dim so the
+  // selector hits the intended index.
+  const mockProcessorInstance = Object.assign(
+    vi.fn(async (_chatPrompt: string, _image: unknown) => ({
+      input_ids: { dims: [1, 7] },
+      attention_mask: {},
+      pixel_values: {},
+    })),
+    {
+      apply_chat_template: vi.fn((_messages: unknown, _opts: unknown) => 'CHAT_PROMPT_QUALITY'),
+      batch_decode: vi.fn((_tokens: unknown, _opts: unknown) => [state.decodedText]),
+    }
+  )
+
+  const mockGenerate = vi.fn(async (_inputs: unknown) => {
+    if (state.generateThrows) throw state.generateThrows
+    return {
+      slice: (_axis: null, _range: [number, number | null]) => ({ _isSlicedTokens: true }),
+    }
+  })
+
+  const mockModelInstance = { generate: mockGenerate }
+
+  // RawImage.fromBlob resolves to an object with a `.resize()` method; the
+  // production code chains `.resize(448, 448)` and we assert on the args.
+  const mockResize = vi.fn((_w: number, _h: number) => {
+    if (state.resizeThrows) throw state.resizeThrows
+    return { width: 448, height: 448, channels: 3, data: new Uint8ClampedArray(0) }
+  })
+
+  const mockFromBlob = vi.fn(async (_blob: Blob) => {
+    if (state.fromBlobThrows) throw state.fromBlobThrows
+    return { resize: mockResize }
+  })
+
+  const env = { cacheDir: '' as string }
+
+  return {
+    state,
+    env,
+    AutoProcessor: { from_pretrained: mockProcessorFromPretrained },
+    // The captioner-fast spec also imports `AutoModelForImageTextToText` from
+    // this module. We expose a no-op stub so dynamic imports of fast.ts during
+    // module resolution do not crash — the `quality`-profile tests in this
+    // file never construct a fast captioner.
+    AutoModelForImageTextToText: { from_pretrained: vi.fn() },
+    Qwen2_5_VLForConditionalGeneration: { from_pretrained: mockModelFromPretrained },
+    RawImage: { fromBlob: mockFromBlob },
+    mockGenerate,
+    mockProcessorFromPretrained,
+    mockModelFromPretrained,
+    mockProcessorInstance,
+    mockFromBlob,
+    mockResize,
+  }
+})
+
+const transformersFactory = () => ({
+  AutoProcessor: mocks.AutoProcessor,
+  AutoModelForImageTextToText: mocks.AutoModelForImageTextToText,
+  Qwen2_5_VLForConditionalGeneration: mocks.Qwen2_5_VLForConditionalGeneration,
+  RawImage: mocks.RawImage,
+  env: mocks.env,
+})
+
+const MOCKED_PATHS = ['@huggingface/transformers'] as const
+
+// ============================================
+// Test suite
+// ============================================
+
+let createCaptioner: typeof import('../captioner').createCaptioner
+let VlmError: typeof import('../types').VlmError
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+const QUALITY_MODEL_ID = 'onnx-community/Qwen2.5-VL-3B-Instruct-ONNX'
+
+const BASE_CONFIG = {
+  profile: 'quality' as const,
+  cacheDir: '/tmp/cache-quality',
+}
+
+describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-ONNX)', () => {
+  beforeAll(async () => {
+    vi.resetModules()
+    vi.doMock('@huggingface/transformers', transformersFactory)
+    ;({ createCaptioner } = await import('../captioner'))
+    ;({ VlmError } = await import('../types'))
+  })
+
+  afterAll(() => {
+    for (const p of MOCKED_PATHS) vi.doUnmock(p)
+    vi.resetModules()
+  })
+
+  beforeEach(() => {
+    mocks.state.decodedText = 'a valid quality caption'
+    mocks.state.fromPretrainedThrows = null
+    mocks.state.generateThrows = null
+    mocks.state.fromBlobThrows = null
+    mocks.state.resizeThrows = null
+    mocks.mockGenerate.mockClear()
+    mocks.mockProcessorFromPretrained.mockClear()
+    mocks.mockModelFromPretrained.mockClear()
+    mocks.mockFromBlob.mockClear()
+    mocks.mockResize.mockClear()
+    mocks.mockProcessorInstance.mockClear()
+    mocks.env.cacheDir = ''
+  })
+
+  it('forwards the quality-profile Qwen model identifier to both from_pretrained calls', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
+    expect(mocks.mockProcessorFromPretrained).toHaveBeenCalledTimes(1)
+    expect(mocks.mockProcessorFromPretrained.mock.calls[0]?.[0]).toBe(QUALITY_MODEL_ID)
+    expect(mocks.mockModelFromPretrained).toHaveBeenCalledTimes(1)
+    expect(mocks.mockModelFromPretrained.mock.calls[0]?.[0]).toBe(QUALITY_MODEL_ID)
+  })
+
+  it('loads via Qwen2_5_VLForConditionalGeneration (not the auto entry point)', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
+    // The auto entry point MUST NOT have been used — its stub is only kept
+    // alive so a sibling-file dynamic import of fast.ts would not crash.
+    expect(mocks.AutoModelForImageTextToText.from_pretrained).not.toHaveBeenCalled()
+    // Whereas the explicit Qwen class WAS used.
+    expect(mocks.mockModelFromPretrained).toHaveBeenCalledTimes(1)
+  })
+
+  it('resizes the decoded image to 448x448 before invoking the processor', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
+    expect(mocks.mockFromBlob).toHaveBeenCalledTimes(1)
+    expect(mocks.mockResize).toHaveBeenCalledTimes(1)
+    expect(mocks.mockResize.mock.calls[0]).toEqual([448, 448])
+  })
+
+  it('invokes the processor with a SINGLE image (Qwen) — not an array (IDEFICS3)', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
+    // The processor instance itself is the callable that consumes
+    // (prompt, image). It must have been invoked once with the image as the
+    // second argument — and that second argument MUST NOT be an array.
+    expect(mocks.mockProcessorInstance).toHaveBeenCalledTimes(1)
+    const [promptArg, imageArg] = mocks.mockProcessorInstance.mock.calls[0] as unknown as [
+      string,
+      unknown,
+    ]
+    expect(promptArg).toBe('CHAT_PROMPT_QUALITY')
+    expect(Array.isArray(imageArg)).toBe(false)
+  })
+
+  it('calls model.generate with max_new_tokens only — no repetition_penalty / no_repeat_ngram_size', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
+    expect(mocks.mockGenerate).toHaveBeenCalledTimes(1)
+    const arg = mocks.mockGenerate.mock.calls[0]?.[0] as {
+      max_new_tokens?: number
+      repetition_penalty?: number
+      no_repeat_ngram_size?: number
+    }
+    expect(arg?.max_new_tokens).toBe(128)
+    // These two options exist on `fast` but are explicitly absent on `quality`
+    // because they cause forced variant generation on Qwen2.5-VL.
+    expect(arg?.repetition_penalty).toBeUndefined()
+    expect(arg?.no_repeat_ngram_size).toBeUndefined()
+  })
+
+  it('returns the decoded caption verbatim when post-processing leaves it unchanged', async () => {
+    mocks.state.decodedText = 'Summary: a figure.\n\nKeywords: alpha; beta'
+    const captioner = createCaptioner(BASE_CONFIG)
+
+    const result = await captioner.caption(PNG_BYTES, 1)
+
+    expect(result).toBe('Summary: a figure.\n\nKeywords: alpha; beta')
+  })
+
+  it('returns null when decoded output is whitespace-only (shared postProcess applies)', async () => {
+    mocks.state.decodedText = '   \n\t  '
+    const captioner = createCaptioner(BASE_CONFIG)
+
+    const result = await captioner.caption(PNG_BYTES, 1)
+
+    expect(result).toBeNull()
+  })
+
+  it('wraps model-load failure in VlmError with pageNum + Qwen model identifier in the cause', async () => {
+    const originalErr = new Error('boom-quality-load')
+    mocks.state.fromPretrainedThrows = originalErr
+    const captioner = createCaptioner(BASE_CONFIG)
+
+    let captured: unknown
+    try {
+      await captioner.caption(PNG_BYTES, 5)
+    } catch (err) {
+      captured = err
+    }
+
+    expect(captured).toBeInstanceOf(VlmError)
+    expect((captured as VlmError).pageNum).toBe(5)
+    expect((captured as VlmError).message).toBe('Captioning failed for page 5')
+
+    const cause = (captured as VlmError).cause as Error
+    expect(cause.message).toContain('Captioner load failed')
+    expect(cause.message).toContain(`modelName=${QUALITY_MODEL_ID}`)
+    expect(cause.message).toContain('boom-quality-load')
+    expect((cause as Error & { cause?: unknown }).cause).toBe(originalErr)
+  })
+
+  it('wraps generation failure in VlmError with pageNum + cause', async () => {
+    const originalErr = new Error('boom-quality-generate')
+    mocks.state.generateThrows = originalErr
+    const captioner = createCaptioner(BASE_CONFIG)
+
+    let captured: unknown
+    try {
+      await captioner.caption(PNG_BYTES, 9)
+    } catch (err) {
+      captured = err
+    }
+
+    expect(captured).toBeInstanceOf(VlmError)
+    expect((captured as VlmError).pageNum).toBe(9)
+    expect((captured as VlmError).cause).toBe(originalErr)
+  })
+})

--- a/src/pdf-visual/__tests__/captioner.test.ts
+++ b/src/pdf-visual/__tests__/captioner.test.ts
@@ -189,14 +189,6 @@ describe('createCaptioner — fast profile dispatch (CaptionerConfig flow + AC-0
     expect(mocks.mockModelFromPretrained.mock.calls[0]?.[0]).toBe(FAST_MODEL_ID)
   })
 
-  // ----- dispatcher rejects unimplemented profiles -----
-
-  it("throws synchronously when profile is 'quality' (Phase 2 placeholder)", () => {
-    expect(() => createCaptioner({ ...BASE_CONFIG, profile: 'quality' as const })).toThrow(
-      /quality.*not yet implemented/i
-    )
-  })
-
   // ----- VLM_DTYPE pinned -----
 
   it('forwards the pinned VLM_DTYPE to both processor and model from_pretrained', async () => {

--- a/src/pdf-visual/__tests__/captioner.test.ts
+++ b/src/pdf-visual/__tests__/captioner.test.ts
@@ -1,15 +1,23 @@
-// `createCaptioner` unit test.
+// `createCaptioner` (`fast` profile dispatch) unit test.
 //
-// Asserts the captioner's public contract documented in
-// docs/design/vlm-pdf-enrichment-design.md §Component → pdf-visual/captioner.ts:
+// Phase 1 of the visual-quality-mode refactor routes the dispatcher's `fast`
+// profile to `captioners/fast.ts`, which is a verbatim port of the v0.14.0
+// captioner. The mock surface and assertions in this file were authored
+// against that port and continue to apply: the model class is still
+// `AutoModelForImageTextToText`, the processor is still called with an array-
+// form image list, generation options are still
+// `{max_new_tokens:128, repetition_penalty:1.15, no_repeat_ngram_size:3}`.
 //
-//   createCaptioner(config: CaptionerConfig): Captioner
-//   Captioner.caption(pngBytes: Uint8Array, pageNum: number): Promise<string | null>
+// What changed at the dispatcher boundary:
+//   - `CaptionerConfig` no longer carries `modelName`. The model identifier
+//     (`HuggingFaceTB/SmolVLM-256M-Instruct`) lives inside `captioners/fast.ts`.
+//   - Construction is `createCaptioner({ profile: 'fast', cacheDir, device? })`.
 //
 // Verification points:
-//   - `from_pretrained` receives `config.modelName` and `{ dtype: VLM_DTYPE }`;
-//     model loading also receives the resolved device.
-//   - `model.generate` receives the pinned decoding options
+//   - `from_pretrained` receives the `fast`-profile model identifier and the
+//     dispatcher-exposed `VLM_DTYPE`; model loading also receives the
+//     resolved device.
+//   - `model.generate` receives the `fast`-profile decoding options
 //     (`max_new_tokens`, `repetition_penalty`, `no_repeat_ngram_size`).
 //   - Post-decode boundary cases: 1000 chars passes through unchanged, 1001
 //     chars truncated to 1000 + `…` (final length 1001), empty/whitespace-only/
@@ -130,12 +138,14 @@ let VlmError: typeof import('../types').VlmError
 
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
 
+const FAST_MODEL_ID = 'HuggingFaceTB/SmolVLM-256M-Instruct'
+
 const BASE_CONFIG = {
-  modelName: 'sentinel-default-model',
+  profile: 'fast' as const,
   cacheDir: '/tmp/cache',
 }
 
-describe('createCaptioner (CaptionerConfig flow + AC-011 length / emptiness)', () => {
+describe('createCaptioner — fast profile dispatch (CaptionerConfig flow + AC-011 length / emptiness)', () => {
   beforeAll(async () => {
     vi.resetModules()
     vi.doMock('@huggingface/transformers', transformersFactory)
@@ -161,20 +171,30 @@ describe('createCaptioner (CaptionerConfig flow + AC-011 length / emptiness)', (
     mocks.env.cacheDir = ''
   })
 
-  // ----- config.modelName flow -----
+  // ----- fast profile resolves its own model identifier -----
 
-  it('forwards config.modelName as the first argument to from_pretrained', async () => {
-    // Arrange
-    const captioner = createCaptioner({ ...BASE_CONFIG, modelName: 'sentinel-model-name' })
+  it('forwards the fast-profile model identifier as the first argument to from_pretrained', async () => {
+    // Arrange: model identifier is owned by `captioners/fast.ts`, not the
+    // caller. Pinning it here makes accidental changes loud.
+    const captioner = createCaptioner(BASE_CONFIG)
 
     // Act
     await captioner.caption(PNG_BYTES, 1)
 
-    // Assert: both AutoProcessor and AutoModel from_pretrained get the model name.
+    // Assert: both AutoProcessor and AutoModel from_pretrained receive the
+    // fast-profile literal.
     expect(mocks.mockProcessorFromPretrained).toHaveBeenCalledTimes(1)
-    expect(mocks.mockProcessorFromPretrained.mock.calls[0]?.[0]).toBe('sentinel-model-name')
+    expect(mocks.mockProcessorFromPretrained.mock.calls[0]?.[0]).toBe(FAST_MODEL_ID)
     expect(mocks.mockModelFromPretrained).toHaveBeenCalledTimes(1)
-    expect(mocks.mockModelFromPretrained.mock.calls[0]?.[0]).toBe('sentinel-model-name')
+    expect(mocks.mockModelFromPretrained.mock.calls[0]?.[0]).toBe(FAST_MODEL_ID)
+  })
+
+  // ----- dispatcher rejects unimplemented profiles -----
+
+  it("throws synchronously when profile is 'quality' (Phase 2 placeholder)", () => {
+    expect(() => createCaptioner({ ...BASE_CONFIG, profile: 'quality' as const })).toThrow(
+      /quality.*not yet implemented/i
+    )
   })
 
   // ----- VLM_DTYPE pinned -----
@@ -345,7 +365,7 @@ describe('createCaptioner (CaptionerConfig flow + AC-011 length / emptiness)', (
     const cause = (captured as VlmError).cause as Error
     expect(cause).toBeInstanceOf(Error)
     expect(cause.message).toContain('Captioner load failed')
-    expect(cause.message).toContain('modelName=sentinel-default-model')
+    expect(cause.message).toContain(`modelName=${FAST_MODEL_ID}`)
     expect(cause.message).toContain('device=cpu')
     expect(cause.message).toContain('boom-load')
 

--- a/src/pdf-visual/__tests__/orchestrator.test.ts
+++ b/src/pdf-visual/__tests__/orchestrator.test.ts
@@ -1,29 +1,33 @@
-// T3.4 — `enrichPagesWithCaptions` unit tests (AC-003, AC-004).
+// `enrichPagesWithCaptions` unit tests (AC-003, AC-004).
 //
-// Asserts the orchestrator's public contract documented in
-// docs/design/vlm-pdf-enrichment-design.md §Component → pdf-visual/index.ts
-// — `enrichPagesWithCaptions` orchestrator:
+// Asserts the orchestrator's public contract:
 //
 //   enrichPagesWithCaptions(
 //     pages: Array<{ pageNum, text, stextJson }>,
 //     candidates: Array<{ pageNum, isCandidate }>,
 //     doc: MupdfDocument,
 //     captioner: Captioner
-//   ): Promise<Array<{ pageNum, text, stextJson }>>
+//   ): Promise<{ pages, captions: Array<{ pageNum, text }> }>
 //
-// Verification points (per task file Red Phase):
+// Per the visual-quality-mode refactor, captions are no longer mutated into
+// `page.text`. The orchestrator returns the unchanged `pages` array plus a
+// dedicated `captions` array; the `[Visual content on page N: ...]` wrapper
+// and chunk emission live in `src/ingest/visual.ts`.
+//
+// Verification points:
 //   - AC-003: when no candidate has `isCandidate === true`, the captioner is
-//     never invoked (call count 0). Also implies the renderer is never invoked.
-//   - AC-004: per-page captioner failures are swallowed. The failing page's
-//     text is left unchanged (no `[Visual content on page N: ` substring),
-//     while subsequent candidate pages receive their caption normally. A
-//     warn/error-level log line names the failed page.
-//   - null caption: when the captioner returns `null`, the page text is left
-//     unchanged AND a warn log line names the page (DD: null → warn log,
+//     never invoked (call count 0), the renderer is never invoked, and the
+//     returned `captions` array is empty.
+//   - AC-004: per-page captioner failures are swallowed — the failing page
+//     produces no `captions[]` entry, while subsequent candidate pages do.
+//     A warn/error-level log line names the failed page.
+//   - null caption: when the captioner returns `null`, the page produces no
+//     `captions[]` entry AND a warn log line names the page (null → warn log,
 //     same effect as failure but distinct log channel).
-//   - Happy path: a candidate page receives
-//     `[Visual content on page N: <caption>]` appended to its text (joined
-//     with `\n\n` when prior text is non-empty).
+//   - Happy path: a candidate page produces a `{ pageNum, text }` record on
+//     `captions[]` with the raw caption string (no `[Visual content ...]`
+//     wrapper — wrapping is applied by `ingest/visual.ts`). `page.text` is
+//     never mutated.
 //
 // Renderer and captioner are mocked via `vi.hoisted` per the project-wide
 // constraint (`vitest.config.mjs` sets `isolate: false`, so mock factories
@@ -176,7 +180,13 @@ describe('enrichPagesWithCaptions', () => {
     expect(mocks.captionSpy).toHaveBeenCalledTimes(0)
     expect(mocks.renderSpy).toHaveBeenCalledTimes(0)
     // Texts pass through unchanged.
-    expect(result.map((p) => p.text)).toEqual(['page one body', 'page two body', 'page three body'])
+    expect(result.pages.map((p) => p.text)).toEqual([
+      'page one body',
+      'page two body',
+      'page three body',
+    ])
+    // No captions produced.
+    expect(result.captions).toEqual([])
   })
 
   it('AC-004: a single page captioner failure is swallowed; other pages still get captions', async () => {
@@ -199,12 +209,14 @@ describe('enrichPagesWithCaptions', () => {
     const result = await enrichPagesWithCaptions(pages, candidates, fakeDoc, captioner)
 
     // Assert
-    const byPage = new Map(result.map((p) => [p.pageNum, p.text]))
-    // Page 2 failure was swallowed — no caption bracket appended.
+    // Page texts are never mutated — both pages pass through verbatim.
+    const byPage = new Map(result.pages.map((p) => [p.pageNum, p.text]))
     expect(byPage.get(2)).toBe('page two body')
-    expect(byPage.get(2)).not.toContain('[Visual content on page 2:')
-    // Page 3 happy path — caption appended in the documented format.
-    expect(byPage.get(3)).toContain('[Visual content on page 3: bar chart with X axis labels]')
+    expect(byPage.get(3)).toBe('page three body')
+    // Page 2 failure swallowed → no caption record.
+    // Page 3 happy path → one caption record with the raw caption string
+    // (no `[Visual content ...]` wrapper — wrapping happens in ingest/visual.ts).
+    expect(result.captions).toEqual([{ pageNum: 3, text: 'bar chart with X axis labels' }])
     // A log line names page 2. The DD specifies error-level for throw paths
     // and warn-level for null paths; either log channel is acceptable for the
     // throw path so long as the page number is captured.
@@ -231,9 +243,10 @@ describe('enrichPagesWithCaptions', () => {
     const result = await enrichPagesWithCaptions(pages, candidates, fakeDoc, captioner)
 
     // Assert
-    const byPage = new Map(result.map((p) => [p.pageNum, p.text]))
+    const byPage = new Map(result.pages.map((p) => [p.pageNum, p.text]))
     expect(byPage.get(2)).toBe('page two body')
-    expect(byPage.get(2)).not.toContain('[Visual content on page 2:')
+    // No caption record was produced for the null page.
+    expect(result.captions).toEqual([])
     // The null path must be warn-level, not error-level (it is not a failure).
     const warnMessages = warnSpy.mock.calls
       .flat()
@@ -244,7 +257,7 @@ describe('enrichPagesWithCaptions', () => {
     expect(errorSpy).toHaveBeenCalledTimes(0)
   })
 
-  it('happy path: appends [Visual content on page N: <caption>] to candidate page text', async () => {
+  it('happy path: emits a {pageNum, text} caption record without mutating page.text', async () => {
     // Arrange: page 2 is the sole candidate.
     const pages = makePages([
       { pageNum: 1, text: 'page one body' },
@@ -259,13 +272,13 @@ describe('enrichPagesWithCaptions', () => {
     // Act
     const result = await enrichPagesWithCaptions(pages, candidates, fakeDoc, captioner)
 
-    // Assert: exact bracket format per DD line 736.
-    const byPage = new Map(result.map((p) => [p.pageNum, p.text]))
-    expect(byPage.get(2)).toBe(
-      'page two body\n\n[Visual content on page 2: pie chart 40 / 35 / 25 percent]'
-    )
-    // Page 1 (non-candidate) untouched.
+    // Assert: pages pass through unchanged; caption surfaces only via the
+    // dedicated `captions` array. The `[Visual content on page N: ...]`
+    // wrapper is applied downstream in `src/ingest/visual.ts`, not here.
+    const byPage = new Map(result.pages.map((p) => [p.pageNum, p.text]))
     expect(byPage.get(1)).toBe('page one body')
+    expect(byPage.get(2)).toBe('page two body')
+    expect(result.captions).toEqual([{ pageNum: 2, text: 'pie chart 40 / 35 / 25 percent' }])
     // The candidate page invoked the renderer and the captioner exactly once.
     expect(mocks.renderSpy).toHaveBeenCalledTimes(1)
     expect(mocks.renderSpy).toHaveBeenCalledWith(fakeDoc, 2, [1, 2, 3, 4])

--- a/src/pdf-visual/captioner.ts
+++ b/src/pdf-visual/captioner.ts
@@ -58,10 +58,20 @@ export function createCaptioner(config: CaptionerConfig): Captioner {
     case 'fast':
       return createFastCaptioner(resolvedDevice)
     case 'quality':
-      // Load failures from the heavier Qwen2.5-VL model propagate as the
-      // wrapped Error (later re-thrown per-page as `VlmError`) — there is
-      // deliberately no silent fallback to `fast` so a misconfigured
-      // `quality` install surfaces immediately.
+      // No silent fallback to `fast` on load failure. The heavier Qwen2.5-VL
+      // model surfaces its load error as a wrapped `VlmError` per page (see
+      // `enrichPagesWithCaptions` in `./index.ts`); per FR-3 the file ingest
+      // as a whole still completes text-only, so a misconfigured install
+      // degrades each candidate page rather than masking the misconfig by
+      // switching to `fast`. Operators see one warn line per candidate page.
       return createQualityCaptioner(resolvedDevice)
+    default: {
+      // Exhaustiveness guard. `QualityProfile` is statically narrow at the
+      // call sites (CLI + MCP both validate before reaching here) so this
+      // branch is unreachable today; the throw is defensive for future
+      // ProfileType additions that forget to extend this switch.
+      const _exhaustive: never = config.profile
+      throw new Error(`Unknown QualityProfile: ${_exhaustive as string}`)
+    }
   }
 }

--- a/src/pdf-visual/captioner.ts
+++ b/src/pdf-visual/captioner.ts
@@ -23,6 +23,7 @@
 import { env } from '@huggingface/transformers'
 
 import { createFastCaptioner } from './captioners/fast.js'
+import { createQualityCaptioner } from './captioners/quality.js'
 import type { Captioner, CaptionerConfig } from './types.js'
 
 /**
@@ -57,9 +58,10 @@ export function createCaptioner(config: CaptionerConfig): Captioner {
     case 'fast':
       return createFastCaptioner(resolvedDevice)
     case 'quality':
-      // Phase 2 wires up `captioners/quality.ts`. Until then the dispatcher
-      // refuses the profile so callers fail fast rather than silently falling
-      // back to `fast`.
-      throw new Error("Captioner profile 'quality' is not yet implemented (scheduled for Phase 2)")
+      // Load failures from the heavier Qwen2.5-VL model propagate as the
+      // wrapped Error (later re-thrown per-page as `VlmError`) — there is
+      // deliberately no silent fallback to `fast` so a misconfigured
+      // `quality` install surfaces immediately.
+      return createQualityCaptioner(resolvedDevice)
   }
 }

--- a/src/pdf-visual/captioner.ts
+++ b/src/pdf-visual/captioner.ts
@@ -1,109 +1,48 @@
-// Thin VLM wrapper for the visual ingest path.
+// Captioner dispatcher for the visual ingest path.
 //
-// Wraps `@huggingface/transformers` direct model instantiation
-// (`AutoProcessor.from_pretrained` + `AutoModelForImageTextToText.from_pretrained`)
-// behind a small `Captioner` interface. Lazy-loads the processor and model
-// on the first `caption()` call to keep the default (`visual: false`) path
-// zero-overhead.
+// `createCaptioner(config)` selects the underlying VLM family based on the
+// `QualityProfile` and returns a `Captioner`. Each profile is implemented as a
+// self-contained module under `./captioners/` so that prompt, chat template,
+// processor signature, generation options, and model class stay coherent per
+// profile.
 //
-// Implementation contract:
-//   1. Set `env.cacheDir = config.cacheDir` BEFORE any `from_pretrained` call
-//      (defensive ordering — does not depend on `Embedder.initialize()`).
-//   2. Lazy-load processor + model on first `caption()` call with the pinned
-//      `VLM_DTYPE` and the resolved device.
-//   3. Decode PNG bytes via `RawImage.fromBlob(new Blob([pngBytes], { type: 'image/png' }))`.
-//   4. Build chat-style input via `processor.apply_chat_template(messages,
-//      { add_generation_prompt: true })` with the IDEFICS3 conversation shape
-//      (probe-verified). The shape is hard-coded against the v1 captioner
-//      family; swapping in a non-IDEFICS3 model requires an adapter.
-//   5. Call `model.generate({ ...inputs, max_new_tokens, repetition_penalty,
-//      no_repeat_ngram_size })` with the pinned decoding options below.
-//   6. Decode via `processor.batch_decode(newTokens, { skip_special_tokens: true })`
-//      where `newTokens = outputs.slice(null, [inputs.input_ids.dims[1], null])`.
-//   7. Post-processing (single source of truth, in this order):
-//        - Strip C0 / C1 control chars except `\n` and `\t`.
-//        - Trim surrounding whitespace.
-//        - Empty → return `null`.
-//        - length > 1000 → truncate to 1000 + `…` (final length 1001).
-//   8. On model load / image decode / generation failure throw `VlmError`
-//      with `pageNum` + `cause`. The empty-caption `null` return is NOT a
-//      failure.
+// Profiles:
+//   - `fast`    → `captioners/fast.ts`    (SmolVLM-256M-Instruct, IDEFICS3).
+//                 Lightweight default; ~250 MB cache.
+//   - `quality` → `captioners/quality.ts` (Qwen2.5-VL-3B-Instruct-ONNX).
+//                 Higher fidelity on figures with in-image text; ~2.9 GB cache,
+//                 ~2× per-page inference relative to `fast`.
 //
-// `VLM_DTYPE = 'q4'` pins the ONNX quantization variant for v1. Exported so
-// tests can assert against the literal without re-declaring it; production has
-// no user-facing knob.
+// `env.cacheDir` is set once here (not inside the per-profile modules) so the
+// shared global is configured before either profile's `from_pretrained` runs
+// and the per-profile modules stay free of the global side effect.
+//
+// `VLM_DTYPE` is exported for legacy test compatibility — it reflects the
+// quantization variant currently used by both profiles.
 
-import {
-  AutoModelForImageTextToText,
-  AutoProcessor,
-  type DeviceType,
-  env,
-  RawImage,
-} from '@huggingface/transformers'
+import { env } from '@huggingface/transformers'
 
+import { createFastCaptioner } from './captioners/fast.js'
 import type { Captioner, CaptionerConfig } from './types.js'
-import { VlmError } from './types.js'
 
 /**
- * ONNX quantization variant. Pinned to the smallest viable variant for the v1
- * captioner. Exposed for tests only — production has no user-facing knob.
+ * ONNX quantization variant. Pinned to the smallest viable variant for both
+ * profiles. Exposed for tests only — production has no user-facing knob.
  */
 export const VLM_DTYPE = 'q4'
 
 /**
- * Static prompt — tuned for "describe for search retrieval" not "describe for
- * a blind reader". It asks for retrieval-relevant detail rather than a short
- * summary, while keeping claims grounded in visible evidence.
- */
-const PROMPT =
-  'Write search text for this PDF page image. Include visible section names, visual titles, ' +
-  'headings, labels, legends, axes, row or column names, UI text, metric names, identifiers, ' +
-  'proper nouns, and flow or diagram step names. Prefer exact readable words from the image. ' +
-  'Cover the main visual regions across the page. Use short searchable phrases separated by ' +
-  'commas or semicolons. Use only readable or visually evident details. Use each phrase once.'
-
-/**
- * Strip C0 (U+0000–U+001F) and C1 (U+007F–U+009F) control characters from the
- * input, except `\n` (U+000A) and `\t` (U+0009) which are kept verbatim.
- */
-function stripControlChars(input: string): string {
-  let out = ''
-  for (let i = 0; i < input.length; i++) {
-    const code = input.charCodeAt(i)
-    if (code === 0x09 || code === 0x0a) {
-      out += input[i]
-      continue
-    }
-    if (code <= 0x1f) continue
-    if (code >= 0x7f && code <= 0x9f) continue
-    out += input[i]
-  }
-  return out
-}
-
-/**
- * Apply the post-generation processing rules (DD § Captioner contract step 6).
- * Returns the final caption or `null` when the result is empty after stripping.
- */
-function postProcess(decoded: string): string | null {
-  const stripped = stripControlChars(decoded).trim()
-  if (stripped.length === 0) return null
-  if (stripped.length > 1000) return `${stripped.slice(0, 1000)}…`
-  return stripped
-}
-
-/**
- * Create a captioner backed by the configured VLM. Sets `env.cacheDir`
- * immediately so the global is correct even if the captioner is constructed
- * before any embedder initializes.
+ * Create a captioner for the requested visual-quality profile. Sets
+ * `env.cacheDir` immediately so the global is correct even if the captioner
+ * is constructed before any embedder initializes.
  *
  * Concurrency assumption: `env.cacheDir` is a process-global from
  * `@huggingface/transformers`. Setting it here at construction time is safe
  * for the current single-instance usage (one captioner per ingest run). If
- * the codebase ever constructs multiple captioners with DIFFERENT
- * `cacheDir` values in parallel, the last writer wins and the first
- * captioner's `from_pretrained` may resolve against the wrong cache. Avoid
- * concurrent construction with differing cacheDirs.
+ * the codebase ever constructs multiple captioners with DIFFERENT `cacheDir`
+ * values in parallel, the last writer wins and the first captioner's
+ * `from_pretrained` may resolve against the wrong cache. Avoid concurrent
+ * construction with differing cacheDirs.
  */
 export function createCaptioner(config: CaptionerConfig): Captioner {
   // Defensive ordering: set the global cacheDir at construction so the very
@@ -114,104 +53,13 @@ export function createCaptioner(config: CaptionerConfig): Captioner {
 
   const resolvedDevice = config.device || 'cpu'
 
-  // Lazy-loaded singletons. `unknown` is used to keep the surface small and
-  // avoid pulling private types from `@huggingface/transformers`.
-  let processor: unknown = null
-  let model: unknown = null
-
-  // Cache the load outcome so a transient failure (network, mis-cached model
-  // file) does not trigger one `from_pretrained` retry per candidate page.
-  // Per-page `caption()` is the single wrapping site that adds `pageNum` and
-  // the user-facing `Captioning failed for page N` message, so this fast-fail
-  // path produces observationally-equivalent errors to a hypothetical
-  // re-load attempt.
-  type LoadState = { kind: 'pending' } | { kind: 'ok' } | { kind: 'failed'; cause: Error }
-  let loadState: LoadState = { kind: 'pending' }
-
-  async function ensureLoaded(): Promise<void> {
-    if (loadState.kind === 'ok') return
-    if (loadState.kind === 'failed') throw loadState.cause
-    try {
-      // Both classes accept `{ dtype }` (probe-verified). They load in sequence
-      // because the second resolves the runtime class
-      // (`Idefics3ForConditionalGeneration` for the default model) via the
-      // architecture-agnostic `AutoModelForImageTextToText` entry point. The
-      // transformers.js declared `dtype` is a literal union; cast through
-      // `unknown` to widen-to-string-then-back.
-      const dtypeOpt = { dtype: VLM_DTYPE } as unknown as { dtype: 'q4' }
-      const modelOpt = { dtype: VLM_DTYPE, device: resolvedDevice } as unknown as {
-        dtype: 'q4'
-        device: DeviceType
-      }
-      processor = await AutoProcessor.from_pretrained(config.modelName, dtypeOpt)
-      model = await AutoModelForImageTextToText.from_pretrained(config.modelName, modelOpt)
-      loadState = { kind: 'ok' }
-    } catch (err) {
-      const original = err instanceof Error ? err : new Error(String(err))
-      const wrapped = new Error(
-        `Captioner load failed (modelName=${config.modelName}, device=${resolvedDevice}): ${original.message}`,
-        { cause: original }
-      )
-      loadState = { kind: 'failed', cause: wrapped }
-      throw wrapped
-    }
-  }
-
-  return {
-    async caption(pngBytes: Uint8Array, pageNum: number): Promise<string | null> {
-      try {
-        await ensureLoaded()
-
-        // Decode PNG → RawImage. `Blob` accepts `Uint8Array` directly (the
-        // renderer returns `Uint8Array` from `Pixmap.asPNG()`, not `Buffer`).
-        // The `BlobPart` type does not include `Uint8Array<ArrayBufferLike>`
-        // due to SharedArrayBuffer subtyping; cast through unknown.
-        const blob = new Blob([pngBytes as unknown as ArrayBuffer], { type: 'image/png' })
-        const rawImage = await RawImage.fromBlob(blob)
-
-        // Build chat-style input. The IDEFICS3 conversation shape is
-        // probe-verified for `Idefics3Processor.apply_chat_template`.
-        const messages = [
-          {
-            role: 'user',
-            content: [{ type: 'image' }, { type: 'text', text: PROMPT }],
-          },
-        ]
-        // The processor and model are dynamic in type at the boundary;
-        // narrow to a minimal callable / generate-able shape here.
-        const proc = processor as {
-          apply_chat_template: (m: unknown, o: { add_generation_prompt: boolean }) => string
-          batch_decode: (t: unknown, o: { skip_special_tokens: boolean }) => string[]
-        } & ((prompt: string, images: unknown[]) => Promise<{ input_ids: { dims: number[] } }>)
-        const mdl = model as {
-          generate: (inputs: unknown) => Promise<{
-            slice: (axis: null, range: [number, number | null]) => unknown
-          }>
-        }
-
-        const chatPrompt = proc.apply_chat_template(messages, { add_generation_prompt: true })
-        const inputs = await proc(chatPrompt, [rawImage])
-
-        const outputs = await mdl.generate({
-          ...inputs,
-          max_new_tokens: 128,
-          repetition_penalty: 1.15,
-          no_repeat_ngram_size: 3,
-        })
-
-        // `outputs.slice(null, [inputLen, null])` strips the prompt tokens.
-        const inputLen = inputs.input_ids.dims[1] as number
-        const newTokens = outputs.slice(null, [inputLen, null])
-
-        const decoded = proc.batch_decode(newTokens, { skip_special_tokens: true })
-        const text = decoded[0] ?? ''
-
-        return postProcess(text)
-      } catch (err) {
-        if (err instanceof VlmError) throw err
-        const cause = err instanceof Error ? err : new Error(String(err))
-        throw new VlmError(`Captioning failed for page ${pageNum}`, { cause, pageNum })
-      }
-    },
+  switch (config.profile) {
+    case 'fast':
+      return createFastCaptioner(resolvedDevice)
+    case 'quality':
+      // Phase 2 wires up `captioners/quality.ts`. Until then the dispatcher
+      // refuses the profile so callers fail fast rather than silently falling
+      // back to `fast`.
+      throw new Error("Captioner profile 'quality' is not yet implemented (scheduled for Phase 2)")
   }
 }

--- a/src/pdf-visual/captioners/fast.ts
+++ b/src/pdf-visual/captioners/fast.ts
@@ -1,0 +1,160 @@
+// `fast` visual-quality profile — SmolVLM-256M-Instruct / IDEFICS3.
+//
+// Verbatim port of the v0.14.0 (HEAD) captioner implementation. Kept as a
+// self-contained module so the `quality` profile (Qwen2.5-VL-3B-Instruct-ONNX)
+// can evolve independently without risking subtle behavior drift in the
+// default profile.
+//
+// Implementation contract (matches HEAD captioner contract steps 2–8):
+//   1. Lazy-load processor + model on first `caption()` call with the pinned
+//      `VLM_DTYPE` and the resolved device. `env.cacheDir` is set by the
+//      dispatcher (`captioner.ts`) before this profile is constructed.
+//   2. Decode PNG bytes via `RawImage.fromBlob(new Blob([pngBytes], { type:
+//      'image/png' }))`. SmolVLM-256M is NOT resized client-side — IDEFICS3's
+//      processor handles its own preprocessing.
+//   3. Build chat-style input via `processor.apply_chat_template(messages,
+//      { add_generation_prompt: true })` with the IDEFICS3 conversation shape
+//      `[{role:'user', content:[{type:'image'},{type:'text',text:...}]}]`.
+//      Probe-verified.
+//   4. Call `model.generate({ ...inputs, max_new_tokens: 128,
+//      repetition_penalty: 1.15, no_repeat_ngram_size: 3 })` — these
+//      generation options are tuned for SmolVLM-256M and MUST stay on the
+//      `fast` profile (they cause forced variant generation on Qwen2.5-VL,
+//      which is why the `quality` profile drops them).
+//   5. Decode via `processor.batch_decode(newTokens, { skip_special_tokens: true })`
+//      where `newTokens = outputs.slice(null, [inputs.input_ids.dims[1], null])`.
+//   6. Post-processing via `shared.postProcess` (control-char strip, trim,
+//      empty → `null`, length > 1000 → truncate + `…`).
+//   7. On model load / image decode / generation failure throw `VlmError`
+//      with `pageNum` + `cause`.
+
+import {
+  AutoModelForImageTextToText,
+  AutoProcessor,
+  type DeviceType,
+  RawImage,
+} from '@huggingface/transformers'
+
+import type { Captioner } from '../types.js'
+import { VlmError } from '../types.js'
+import { postProcess } from './shared.js'
+
+const MODEL_NAME = 'HuggingFaceTB/SmolVLM-256M-Instruct'
+
+/**
+ * ONNX quantization variant — smallest viable variant for SmolVLM-256M. Local
+ * to this profile so `quality.ts` can pin its own variant independently.
+ */
+const DTYPE = 'q4'
+
+/**
+ * Static prompt — tuned for "describe for search retrieval" not "describe for
+ * a blind reader". It asks for retrieval-relevant detail rather than a short
+ * summary, while keeping claims grounded in visible evidence.
+ */
+const PROMPT =
+  'Write search text for this PDF page image. Include visible section names, visual titles, ' +
+  'headings, labels, legends, axes, row or column names, UI text, metric names, identifiers, ' +
+  'proper nouns, and flow or diagram step names. Prefer exact readable words from the image. ' +
+  'Cover the main visual regions across the page. Use short searchable phrases separated by ' +
+  'commas or semicolons. Use only readable or visually evident details. Use each phrase once.'
+
+/**
+ * Create a `fast` profile captioner. The dispatcher has already configured
+ * `env.cacheDir`; this profile only owns lazy model loading and inference.
+ */
+export function createFastCaptioner(resolvedDevice: string): Captioner {
+  let processor: unknown = null
+  let model: unknown = null
+
+  type LoadState = { kind: 'pending' } | { kind: 'ok' } | { kind: 'failed'; cause: Error }
+  let loadState: LoadState = { kind: 'pending' }
+
+  async function ensureLoaded(): Promise<void> {
+    if (loadState.kind === 'ok') return
+    if (loadState.kind === 'failed') throw loadState.cause
+    try {
+      // Both classes accept `{ dtype }` (probe-verified). They load in sequence
+      // because the second resolves the runtime class
+      // (`Idefics3ForConditionalGeneration` for the default model) via the
+      // architecture-agnostic `AutoModelForImageTextToText` entry point. The
+      // transformers.js declared `dtype` is a literal union; cast through
+      // `unknown` to widen-to-string-then-back.
+      const dtypeOpt = { dtype: DTYPE } as unknown as { dtype: 'q4' }
+      const modelOpt = { dtype: DTYPE, device: resolvedDevice } as unknown as {
+        dtype: 'q4'
+        device: DeviceType
+      }
+      processor = await AutoProcessor.from_pretrained(MODEL_NAME, dtypeOpt)
+      model = await AutoModelForImageTextToText.from_pretrained(MODEL_NAME, modelOpt)
+      loadState = { kind: 'ok' }
+    } catch (err) {
+      const original = err instanceof Error ? err : new Error(String(err))
+      const wrapped = new Error(
+        `Captioner load failed (modelName=${MODEL_NAME}, device=${resolvedDevice}): ${original.message}`,
+        { cause: original }
+      )
+      loadState = { kind: 'failed', cause: wrapped }
+      throw wrapped
+    }
+  }
+
+  return {
+    async caption(pngBytes: Uint8Array, pageNum: number): Promise<string | null> {
+      try {
+        await ensureLoaded()
+
+        // Decode PNG → RawImage. `Blob` accepts `Uint8Array` directly (the
+        // renderer returns `Uint8Array` from `Pixmap.asPNG()`, not `Buffer`).
+        // The `BlobPart` type does not include `Uint8Array<ArrayBufferLike>`
+        // due to SharedArrayBuffer subtyping; cast through unknown.
+        const blob = new Blob([pngBytes as unknown as ArrayBuffer], { type: 'image/png' })
+        const rawImage = await RawImage.fromBlob(blob)
+
+        // Build chat-style input. The IDEFICS3 conversation shape is
+        // probe-verified for `Idefics3Processor.apply_chat_template`.
+        const messages = [
+          {
+            role: 'user',
+            content: [{ type: 'image' }, { type: 'text', text: PROMPT }],
+          },
+        ]
+        // The processor and model are dynamic in type at the boundary;
+        // narrow to a minimal callable / generate-able shape here. IDEFICS3
+        // processor takes an array of images.
+        const proc = processor as {
+          apply_chat_template: (m: unknown, o: { add_generation_prompt: boolean }) => string
+          batch_decode: (t: unknown, o: { skip_special_tokens: boolean }) => string[]
+        } & ((prompt: string, images: unknown[]) => Promise<{ input_ids: { dims: number[] } }>)
+        const mdl = model as {
+          generate: (inputs: unknown) => Promise<{
+            slice: (axis: null, range: [number, number | null]) => unknown
+          }>
+        }
+
+        const chatPrompt = proc.apply_chat_template(messages, { add_generation_prompt: true })
+        const inputs = await proc(chatPrompt, [rawImage])
+
+        const outputs = await mdl.generate({
+          ...inputs,
+          max_new_tokens: 128,
+          repetition_penalty: 1.15,
+          no_repeat_ngram_size: 3,
+        })
+
+        // `outputs.slice(null, [inputLen, null])` strips the prompt tokens.
+        const inputLen = inputs.input_ids.dims[1] as number
+        const newTokens = outputs.slice(null, [inputLen, null])
+
+        const decoded = proc.batch_decode(newTokens, { skip_special_tokens: true })
+        const text = decoded[0] ?? ''
+
+        return postProcess(text)
+      } catch (err) {
+        if (err instanceof VlmError) throw err
+        const cause = err instanceof Error ? err : new Error(String(err))
+        throw new VlmError(`Captioning failed for page ${pageNum}`, { cause, pageNum })
+      }
+    },
+  }
+}

--- a/src/pdf-visual/captioners/quality.ts
+++ b/src/pdf-visual/captioners/quality.ts
@@ -1,0 +1,180 @@
+// `quality` visual-quality profile — Qwen2.5-VL-3B-Instruct-ONNX.
+//
+// Verbatim port of the working-tree captioner validated during the visual-
+// quality design discussion. Higher fidelity than `fast` on figures with
+// in-image text (axis labels, panel sub-labels, annotations), at the cost of
+// a materially larger model cache (~10× `fast`) and ~2× per-page inference
+// time on CPU. Self-contained so `fast.ts` can stay frozen at v0.14.0.
+//
+// Implementation contract:
+//   1. Lazy-load processor + model on first `caption()` call with the pinned
+//      DTYPE and the resolved device. `env.cacheDir` is set by the dispatcher
+//      (`captioner.ts`) before this profile is constructed.
+//   2. Decode PNG bytes via `RawImage.fromBlob(...)` and resize to 448x448 —
+//      matches the onnx-community Qwen2-VL reference example. Qwen2.5-VL
+//      supports dynamic resolution natively, but the reference example uses
+//      a fixed resize for stable behavior.
+//   3. Build chat-style input via `processor.apply_chat_template(messages,
+//      { add_generation_prompt: true })` with the Qwen2.5-VL conversation
+//      shape `[{role:'user', content:[{type:'image'},{type:'text',text:...}]}]`.
+//      The shape is hard-coded against the Qwen2.5-VL family; swapping in a
+//      non-Qwen-VL model requires a new profile.
+//   4. Call `model.generate({ ...inputs, max_new_tokens: 128 })`. The
+//      `repetition_penalty` / `no_repeat_ngram_size` options used by `fast`
+//      are intentionally absent — on Qwen2.5-VL they cause forced variant
+//      generation (e.g. "Cycles per cycle" → "Cpu cycles/cycle" → "Cnt
+//      cyles/clk") whenever a figure naturally repeats a phrase.
+//   5. Decode via `processor.batch_decode(newTokens, { skip_special_tokens: true })`
+//      where `newTokens = outputs.slice(null, [inputs.input_ids.dims.at(-1), null])`.
+//      `dims.at(-1)` reads the last dimension defensively — matches the
+//      onnx-community reference example.
+//   6. Post-processing via `shared.postProcess` (same pipeline as `fast`).
+//   7. On model load / image decode / generation failure throw `VlmError`
+//      with `pageNum` + `cause`. No silent fallback to `fast`.
+
+import {
+  AutoProcessor,
+  type DeviceType,
+  Qwen2_5_VLForConditionalGeneration,
+  RawImage,
+} from '@huggingface/transformers'
+
+import type { Captioner } from '../types.js'
+import { VlmError } from '../types.js'
+import { postProcess } from './shared.js'
+
+const MODEL_NAME = 'onnx-community/Qwen2.5-VL-3B-Instruct-ONNX'
+
+/**
+ * ONNX quantization variant. Pinned to `q4` for the same disk-footprint /
+ * accuracy trade-off applied to `fast`. Local to this profile so it can be
+ * tuned independently if the `quality` model gains a smaller viable variant.
+ */
+const DTYPE = 'q4'
+
+/**
+ * Static prompt — tuned for retrieval search indexing. Asks the VLM to scan
+ * the whole image before composing output so coverage spans every region,
+ * then produces a two-part response (Summary + Keywords) suitable for
+ * embedding + downstream semantic / lexical search. No length specifiers —
+ * output length is controlled by `max_new_tokens` because length specs
+ * narrow coverage.
+ */
+const PROMPT = `Describe this PDF page image for retrieval search indexing.
+
+Procedure:
+1. Scan the whole image and identify every distinct region.
+2. Compose the output from across all regions identified.
+
+Output exactly two parts:
+
+Summary: Describe the page's content, including its type and subject when identifiable.
+
+Keywords: Phrases separated by semicolons. Capture readable text and visible labels from across the page — including section titles, sub-labels inside figures, tables, panels, or annotations. Use exact wording from the image when readable. Cover the visible regions of the page. List each phrase once.
+
+Use only details visible in the image. If a region is unreadable, skip it.`
+
+/**
+ * Create a `quality` profile captioner. The dispatcher has already configured
+ * `env.cacheDir`; this profile only owns lazy model loading and inference.
+ */
+export function createQualityCaptioner(resolvedDevice: string): Captioner {
+  let processor: unknown = null
+  let model: unknown = null
+
+  type LoadState = { kind: 'pending' } | { kind: 'ok' } | { kind: 'failed'; cause: Error }
+  let loadState: LoadState = { kind: 'pending' }
+
+  async function ensureLoaded(): Promise<void> {
+    if (loadState.kind === 'ok') return
+    if (loadState.kind === 'failed') throw loadState.cause
+    try {
+      // Both classes accept `{ dtype }`. They load in sequence because the
+      // second resolves the runtime class — using the explicit
+      // `Qwen2_5_VLForConditionalGeneration` class matches the onnx-community
+      // reference example. The transformers.js declared `dtype` is a literal
+      // union; cast through `unknown` to widen-to-string-then-back.
+      const dtypeOpt = { dtype: DTYPE } as unknown as { dtype: 'q4' }
+      const modelOpt = { dtype: DTYPE, device: resolvedDevice } as unknown as {
+        dtype: 'q4'
+        device: DeviceType
+      }
+      processor = await AutoProcessor.from_pretrained(MODEL_NAME, dtypeOpt)
+      model = await Qwen2_5_VLForConditionalGeneration.from_pretrained(MODEL_NAME, modelOpt)
+      loadState = { kind: 'ok' }
+    } catch (err) {
+      const original = err instanceof Error ? err : new Error(String(err))
+      const wrapped = new Error(
+        `Captioner load failed (modelName=${MODEL_NAME}, device=${resolvedDevice}): ${original.message}`,
+        { cause: original }
+      )
+      loadState = { kind: 'failed', cause: wrapped }
+      throw wrapped
+    }
+  }
+
+  return {
+    async caption(pngBytes: Uint8Array, pageNum: number): Promise<string | null> {
+      try {
+        await ensureLoaded()
+
+        // Decode PNG → RawImage. `Blob` accepts `Uint8Array` directly (the
+        // renderer returns `Uint8Array` from `Pixmap.asPNG()`, not `Buffer`).
+        // The `BlobPart` type does not include `Uint8Array<ArrayBufferLike>`
+        // due to SharedArrayBuffer subtyping; cast through unknown.
+        const blob = new Blob([pngBytes as unknown as ArrayBuffer], { type: 'image/png' })
+        // Resize to 448x448 to match the onnx-community Qwen2-VL reference
+        // example. Qwen2.5-VL supports dynamic resolution natively, but the
+        // reference example uses a fixed resize for stable behavior; revisit
+        // if empirical results show small in-figure text being lost.
+        const rawImage = await (await RawImage.fromBlob(blob)).resize(448, 448)
+
+        // Build chat-style input. The Qwen2.5-VL conversation shape mirrors
+        // the onnx-community Qwen2-VL reference: a single user turn with an
+        // image placeholder followed by the text prompt.
+        const messages = [
+          {
+            role: 'user',
+            content: [{ type: 'image' }, { type: 'text', text: PROMPT }],
+          },
+        ]
+        // The processor and model are dynamic in type at the boundary;
+        // narrow to a minimal callable / generate-able shape here. Qwen2.5-VL
+        // processor takes a single image (not an array), per the
+        // onnx-community reference example signature `processor(text, image)`.
+        const proc = processor as {
+          apply_chat_template: (m: unknown, o: { add_generation_prompt: boolean }) => string
+          batch_decode: (t: unknown, o: { skip_special_tokens: boolean }) => string[]
+        } & ((prompt: string, image: unknown) => Promise<{ input_ids: { dims: number[] } }>)
+        const mdl = model as {
+          generate: (inputs: unknown) => Promise<{
+            slice: (axis: null, range: [number, number | null]) => unknown
+          }>
+        }
+
+        const chatPrompt = proc.apply_chat_template(messages, { add_generation_prompt: true })
+        const inputs = await proc(chatPrompt, rawImage)
+
+        const outputs = await mdl.generate({
+          ...inputs,
+          max_new_tokens: 128,
+        })
+
+        // `outputs.slice(null, [inputLen, null])` strips the prompt tokens.
+        // `dims.at(-1)` reads the last dimension defensively — matches the
+        // onnx-community reference example.
+        const inputLen = inputs.input_ids.dims.at(-1) as number
+        const newTokens = outputs.slice(null, [inputLen, null])
+
+        const decoded = proc.batch_decode(newTokens, { skip_special_tokens: true })
+        const text = decoded[0] ?? ''
+
+        return postProcess(text)
+      } catch (err) {
+        if (err instanceof VlmError) throw err
+        const cause = err instanceof Error ? err : new Error(String(err))
+        throw new VlmError(`Captioning failed for page ${pageNum}`, { cause, pageNum })
+      }
+    },
+  }
+}

--- a/src/pdf-visual/captioners/shared.ts
+++ b/src/pdf-visual/captioners/shared.ts
@@ -1,0 +1,37 @@
+// Profile-agnostic helpers shared by every `captioners/*` profile.
+//
+// `stripControlChars` + `postProcess` are the post-generation pipeline
+// documented in the captioner contract: control-char stripping, whitespace
+// trim, empty → `null`, length cap with ellipsis. Both `fast` and `quality`
+// profiles run the captioner output through the same pipeline so caption
+// chunk shape is independent of profile.
+
+/**
+ * Strip C0 (U+0000–U+001F) and C1 (U+007F–U+009F) control characters from the
+ * input, except `\n` (U+000A) and `\t` (U+0009) which are kept verbatim.
+ */
+export function stripControlChars(input: string): string {
+  let out = ''
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i)
+    if (code === 0x09 || code === 0x0a) {
+      out += input[i]
+      continue
+    }
+    if (code <= 0x1f) continue
+    if (code >= 0x7f && code <= 0x9f) continue
+    out += input[i]
+  }
+  return out
+}
+
+/**
+ * Apply the post-generation processing rules. Returns the final caption or
+ * `null` when the result is empty after stripping.
+ */
+export function postProcess(decoded: string): string | null {
+  const stripped = stripControlChars(decoded).trim()
+  if (stripped.length === 0) return null
+  if (stripped.length > 1000) return `${stripped.slice(0, 1000)}…`
+  return stripped
+}

--- a/src/pdf-visual/index.ts
+++ b/src/pdf-visual/index.ts
@@ -8,23 +8,25 @@
 // site that catches those errors and continues with text-only output for the
 // offending page.
 //
-// Contract (DD §Component → enrichPagesWithCaptions orchestrator, lines
-// 712-742):
+// Captions are NOT mutated into `page.text`. Returning them as a separate
+// `captions` array lets the ingest layer emit them as dedicated chunks
+// (`src/ingest/visual.ts`), preserving the `Summary` + `Keywords` structure
+// against the semantic chunker's sentence-boundary splits.
+//
+// Contract:
 //   1. Build a Set of candidate page numbers from
 //      `candidates.filter(c => c.isCandidate).map(c => c.pageNum)`.
 //   2. Iterate `pages` in input order. For each page whose `pageNum` is in
 //      the candidate Set:
 //        - `pngBytes = await renderPdfPage(doc, page.pageNum, candidate.cropRect)`
 //        - `caption  = await captioner.caption(pngBytes, page.pageNum)`
-//        - `caption === null` → `console.warn` naming the page; leave
-//          `page.text` unchanged.
-//        - non-null → mutate `page.text` to
-//          `page.text + (page.text ? '\n\n' : '') + '[Visual content on page N: caption]'`.
+//        - `caption === null` → `console.warn` naming the page; no caption record.
+//        - non-null → push `{ pageNum, text: caption }` into `captions`.
 //        - thrown error → `console.warn` naming the page and including
-//          `err.message`; leave `page.text` unchanged. Per DD §FR-3, a
-//          per-page captioner failure is a warning-level event (the file
-//          ingest as a whole succeeds), not an error-level one.
-//   3. Return the (possibly mutated) `pages` array.
+//          `err.message`; no caption record. Per FR-3, a per-page captioner
+//          failure is warning-level (the file ingest as a whole succeeds).
+//   3. Return `{ pages, captions }`. The `pages` array is passed through
+//      unchanged (no text mutation).
 //
 // DPI is NOT a parameter of this function. The renderer owns DPI as a
 // module-private constant. If a future caller needs to override DPI it can
@@ -74,31 +76,44 @@ interface OrchestratorCandidate {
 }
 
 /**
- * Enrich the per-page text array with VLM-generated captions for each visual
- * candidate page. Per-page failures are tolerated: a thrown error or a `null`
- * caption leaves the offending page's text unchanged and logs an entry
- * naming the page. Other candidate pages are unaffected.
+ * Per-page caption record emitted by `enrichPagesWithCaptions`.
  *
- * @param pages - Per-page records from `parsePdfPages`. The same array is
- *                returned with `text` selectively mutated.
+ * `text` is the raw caption string returned by the captioner (without the
+ * `[Visual content on page N: …]` wrapper — wrapping happens at the ingest
+ * layer where the dedicated caption chunks are built).
+ */
+export interface VisualCaption {
+  pageNum: number
+  text: string
+}
+
+/**
+ * Generate VLM captions for each visual candidate page. Per-page failures are
+ * tolerated: a thrown error or a `null` caption is logged and the page produces
+ * no caption record. Other candidate pages are unaffected.
+ *
+ * @param pages - Per-page records from `parsePdfPages`. Passed through
+ *                unchanged (no text mutation).
  * @param candidates - Per-page `{ pageNum, isCandidate }` records from
  *                     `detectVisualCandidates`. Pages whose `isCandidate` is
- *                     false are passed through unchanged.
+ *                     false are skipped.
  * @param doc - The open mupdf `Document`. The orchestrator does not own its
  *              lifecycle — the caller is responsible for `doc.destroy()`.
  * @param captioner - The VLM wrapper from `createCaptioner`.
- * @returns The same `pages` array reference, with candidate pages' `text`
- *          fields possibly appended with `[Visual content on page N: …]`.
+ * @returns `{ pages, captions }`. `pages` is the same array reference, with
+ *          text fields untouched. `captions` contains one entry per page that
+ *          produced a non-empty caption.
  */
 export async function enrichPagesWithCaptions(
   pages: OrchestratorPage[],
   candidates: OrchestratorCandidate[],
   doc: MupdfDocument,
   captioner: Captioner
-): Promise<OrchestratorPage[]> {
+): Promise<{ pages: OrchestratorPage[]; captions: VisualCaption[] }> {
   const candidateByPage = new Map(
     candidates.filter((c) => c.isCandidate).map((c) => [c.pageNum, c])
   )
+  const captions: VisualCaption[] = []
 
   for (const page of pages) {
     const candidate = candidateByPage.get(page.pageNum)
@@ -110,26 +125,21 @@ export async function enrichPagesWithCaptions(
 
       if (caption === null) {
         // Empty / sanitized-empty caption is a documented non-failure (see
-        // DD §Component → captioner contract step 7 + §Component →
-        // orchestrator algorithm). Warn-log and skip the append.
+        // captioner contract step 7). Warn-log and emit no caption record.
         console.warn(`VLM caption empty for page ${page.pageNum}; proceeding text-only`)
         continue
       }
 
-      // Documented join string: a single blank line between existing text
-      // and the bracketed caption, but no leading separator when the page
-      // had no prior text (DD line 736).
-      const separator = page.text ? '\n\n' : ''
-      page.text = `${page.text}${separator}[Visual content on page ${page.pageNum}: ${caption}]`
+      captions.push({ pageNum: page.pageNum, text: caption })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      // Per DD §FR-3 ("logs a warning"), a per-page captioner failure is
+      // Per FR-3 ("logs a warning"), a per-page captioner failure is
       // emitted at warn-level. The file ingest as a whole completes
       // successfully — only this single page degrades to text-only.
       console.warn(`VLM caption failed for page ${page.pageNum}: ${message}`)
-      // page.text intentionally left unchanged — AC-004.
+      // No caption record for this page — AC-004 (text-only fallback).
     }
   }
 
-  return pages
+  return { pages, captions }
 }

--- a/src/pdf-visual/types.ts
+++ b/src/pdf-visual/types.ts
@@ -29,17 +29,23 @@ export class VlmError extends Error {
 }
 
 /**
- * Captioner configuration. Model identifier and quantization variant are
- * pinned for v1; the only caller-tunable fields are the cache directory and
- * the optional execution device.
+ * Visual-quality profile selector. Each profile resolves to a self-contained
+ * captioner implementation under `captioners/`. `fast` ports the original
+ * SmolVLM-256M / IDEFICS3 captioner (lightweight default, ~250 MB cache);
+ * `quality` ports the Qwen2.5-VL-3B-Instruct-ONNX captioner (~2.9 GB cache,
+ * ~2× per-page inference, higher fidelity on figures with in-image text).
+ */
+export type QualityProfile = 'fast' | 'quality'
+
+/**
+ * Captioner configuration. The model identifier is no longer caller-tunable;
+ * it is resolved inside the selected `profile` so that prompt, chat template,
+ * processor signature, generation options, and model class stay coherent per
+ * profile.
  */
 export interface CaptionerConfig {
-  /**
-   * HuggingFace model identifier. Fixed by the caller in v1; the field is
-   * retained so a future model-family adapter can flip it from a literal to a
-   * resolver without changing this contract.
-   */
-  modelName: string
+  /** Visual-quality profile — selects the underlying VLM family. */
+  profile: QualityProfile
   /** Model cache directory (shared with the embedder via `env.cacheDir`). */
   cacheDir: string
   /** Execution device passed through to Transformers.js model loading. */

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -89,13 +89,9 @@ export function parseChunkMinLength(value: string | undefined): ParseResult<numb
  */
 export async function startServer(): Promise<void> {
   try {
-    // VLM model identifier and ONNX quantization variant are fixed for v1.
-    // `vlmModelName` is kept in the config so a future model-family adapter
-    // can swap this literal for a resolver without changing the surrounding
-    // wiring.
-    const vlmModelName = 'HuggingFaceTB/SmolVLM-256M-Instruct'
-
-    // RAGServer configuration (env-only for MCP client compatibility)
+    // RAGServer configuration (env-only for MCP client compatibility). The
+    // VLM profile selection (`fast` vs `quality`) is a per-ingest parameter
+    // on the `ingest_file` MCP tool and is not configured here.
     const device = resolveDevice(process.env['RAG_DEVICE'])
     const config: ConstructorParameters<typeof RAGServer>[0] = {
       dbPath: process.env['DB_PATH'] || './lancedb/',
@@ -104,7 +100,6 @@ export async function startServer(): Promise<void> {
       baseDir: process.env['BASE_DIR'] || process.cwd(),
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
       device,
-      vlmModelName,
     }
 
     // Collect configuration warnings

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -62,8 +62,6 @@ export class RAGServer {
   private readonly excludePaths: string[]
   private readonly configWarnings: string[]
   private readonly minChunkLength: number
-  // Read by the visual dispatch branch to construct the captioner
-  private readonly vlmModelName: string
   private readonly device: string | undefined
   private queryWarningsShown = false
 
@@ -73,7 +71,6 @@ export class RAGServer {
     this.cacheDir = config.cacheDir
     this.configWarnings = config.configWarnings ?? []
     this.minChunkLength = config.chunkMinLength ?? DEFAULT_MIN_CHUNK_LENGTH
-    this.vlmModelName = config.vlmModelName
     this.device = config.device
     this.excludePaths = [`${resolve(this.dbPath)}${sep}`, `${resolve(this.cacheDir)}${sep}`]
     this.server = new Server(
@@ -192,7 +189,7 @@ export class RAGServer {
    */
   async initialize(): Promise<void> {
     await this.vectorStore.initialize()
-    console.error(`RAGServer initialized (vlmModelName=${this.vlmModelName})`)
+    console.error('RAGServer initialized')
   }
 
   /**
@@ -265,6 +262,23 @@ export class RAGServer {
       throw new McpError(ErrorCode.InvalidParams, "'visual' must be a boolean if provided")
     }
 
+    // Runtime validation + normalization of `visualQuality`. The MCP boundary
+    // receives `unknown`, so the JSON Schema enum is necessary but not
+    // sufficient. Some MCP clients send `""` for unspecified optional
+    // parameters; accept both `undefined` and `""` and normalize to `'fast'`
+    // so the internal `QualityProfile` type stays narrow.
+    const visualQualityArg: unknown = (args as { visualQuality?: unknown }).visualQuality
+    let visualQuality: 'fast' | 'quality' = 'fast'
+    if (visualQualityArg !== undefined && visualQualityArg !== '') {
+      if (visualQualityArg !== 'fast' && visualQualityArg !== 'quality') {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          "'visualQuality' must be 'fast' or 'quality' if provided"
+        )
+      }
+      visualQuality = visualQualityArg
+    }
+
     let backup: VectorChunk[] | null = null
 
     try {
@@ -301,7 +315,7 @@ export class RAGServer {
           this.chunker,
           this.embedder,
           {
-            modelName: this.vlmModelName,
+            profile: visualQuality,
             cacheDir: this.cacheDir,
             device: this.device,
           }

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -48,8 +48,9 @@ export const toolDefinitions: Tool[] = [
         visualQuality: {
           type: 'string',
           enum: ['fast', 'quality'],
+          default: 'fast',
           description:
-            'VLM profile to use when visual is true. "fast" (default) is the lightweight SmolVLM-256M; "quality" is Qwen2.5-VL-3B-Instruct-ONNX with higher fidelity on figures with in-image text (~10x model-cache footprint, ~2x per-page inference). Silently ignored when visual is false.',
+            'VLM profile to use when visual is true. "fast" (default) is the lightweight SmolVLM-256M; "quality" is Qwen2.5-VL-3B-Instruct-ONNX with higher fidelity on figures with in-image text (~10x model-cache footprint, ~2x per-page inference). The server also accepts an empty string as a synonym for omitted (normalized to "fast"). Silently ignored when visual is false.',
         },
       },
       required: ['filePath'],

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -45,6 +45,12 @@ export const toolDefinitions: Tool[] = [
           description:
             'If true and the file is a PDF, run VLM captioning on figure pages. No effect on non-PDF files.',
         },
+        visualQuality: {
+          type: 'string',
+          enum: ['fast', 'quality'],
+          description:
+            'VLM profile to use when visual is true. "fast" (default) is the lightweight SmolVLM-256M; "quality" is Qwen2.5-VL-3B-Instruct-ONNX with higher fidelity on figures with in-image text (~10x model-cache footprint, ~2x per-page inference). Silently ignored when visual is false.',
+        },
       },
       required: ['filePath'],
     },

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -13,8 +13,6 @@ export interface RAGServerConfig {
   modelName: string
   /** Model cache directory */
   cacheDir: string
-  /** VLM model identifier (defaults supplied by server-main / CLI resolver) */
-  vlmModelName: string
   /** Document base directory */
   baseDir: string
   /** Maximum file size (100MB) */
@@ -59,6 +57,14 @@ export interface IngestFileInput {
    * arrive as `unknown` from the SDK (AC-012).
    */
   visual?: boolean
+  /**
+   * Visual-quality profile when `visual` is true. Some MCP clients send the
+   * empty string for unspecified optional parameters, so the boundary
+   * handler also accepts `""` and normalizes it to `'fast'`. The internal
+   * `QualityProfile` type stays narrow (`'fast' | 'quality'`); `""` does
+   * not propagate past `handleIngestFile`.
+   */
+  visualQuality?: 'fast' | 'quality' | ''
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an opt-in `visualQuality: 'fast' | 'quality'` knob (CLI: `--visual-quality`, MCP `ingest_file` tool parameter) so visual PDF ingest can trade resource cost for caption fidelity. Default is `fast`, preserving v0.14.0 behavior.
- `fast` keeps `HuggingFaceTB/SmolVLM-256M-Instruct` (~250 MB cache). `quality` selects `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` (~2.9 GB cache, ~2× per-page inference) for figures whose in-image text (axis labels, panel sub-labels, flowchart nodes) needs reliable capture.
- Refactors the captioner into a thin profile dispatcher plus self-contained `captioners/fast.ts` and `captioners/quality.ts` so per-profile prompt, chat template, processor signature, generation options, and model class stay coherent and isolated.
- Captions are now emitted as **dedicated chunks** in `prepareVisualPdfChunks` rather than mutated into page text before chunking. This keeps multi-sentence `Summary` / `Keywords` captions atomic against the semantic chunker's sentence-boundary splits. Side effect: visual-ingest `metadata.fileSize` no longer counts caption character length (body-only) — noted in README and Design Doc revision.
- Bumps `package.json` and `server.json` to `0.14.1`.

## Design context

- Work plan: [`docs/plans/20260517-feature-vlm-visual-quality-mode.md`](docs/plans/20260517-feature-vlm-visual-quality-mode.md)
- Design Doc (revised in place under a new Revision History section): [`docs/design/vlm-pdf-enrichment-design.md`](docs/design/vlm-pdf-enrichment-design.md)
- Approach: Hybrid (vertical profile slices in Phase 1 / Phase 2, horizontal entry-point wiring in Phase 3, QA in Phase 4)

## Notable contract changes

- `CaptionerConfig`: `modelName` is removed in favor of `profile: QualityProfile`. The model identifier is internal to each profile and not user-overridable; `VLM_MODEL_NAME` and `VLM_DTYPE` env vars are removed.
- `enrichPagesWithCaptions` returns `{ pages, captions }` instead of mutating `page.text`. Failure semantics (warn-log + text-only fallback) are unchanged.
- MCP `ingest_file` accepts `visualQuality: 'fast' | 'quality'`. Runtime validation at the handler mirrors the existing `args.visual` check; the MCP boundary additionally accepts `\"\"` (empty string) and normalizes it to `'fast'` for clients that send empty strings for unspecified optional parameters. `\"\"` is never propagated past the handler.
- CLI flag `--visual-quality` lives on the ingest subcommand (not on global config) to match the `--visual` precedent.

## Verification

- Phase 1 early verification: serial CLI ingest of `arxiv-transformer.pdf` and `synthetic-complex-visual.pdf` with the default profile produces the expected per-PDF caption counts (4 / 1) in the SmolVLM phrase-extraction style — preserving v0.14.0 behavior.
- Phase 2 quality probe: same PDFs with `--visual-quality quality` produce intact `[Visual content on page N: Summary: … Keywords: …]` chunks with no `Cycles per cycle`-family hallucinations (the previous `no_repeat_ngram_size` artifact is gone for the quality profile).
- New unit tests: `src/pdf-visual/__tests__/captioner-quality.test.ts` (cross-file mock isolation per project context skill), updates to `captioner.test.ts` and `orchestrator.test.ts` for the dispatcher + dedicated-chunk shape.

## Test plan

- [ ] `pnpm run check:all` clean
- [ ] CLI: `npx mcp-local-rag ingest <pdf> --visual` produces caption chunks in v0.14.0 style (fast profile)
- [ ] CLI: `npx mcp-local-rag ingest <pdf> --visual --visual-quality quality` produces `Summary:` + `Keywords:` chunks
- [ ] MCP: `ingest_file` with `visual: true` (no `visualQuality`) routes to fast
- [ ] MCP: `ingest_file` with `visual: true, visualQuality: 'quality'` routes to quality
- [ ] MCP: `ingest_file` with `visualQuality: \"\"` is normalized to fast; any other value rejected with `McpError(InvalidParams)`
- [ ] Default behavior (no `--visual` / `visual: false`) loads no VLM (NFR-1 preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)