### PR TITLE
feat: multiple BASE_DIR roots (BASE_DIRS, repeatable --base-dir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ npx mcp-local-rag --db-path ./my-db query "auth" --base-dir ./docs
 The `--base-dir` flag is repeatable on `ingest` and `list`; pass it once per root:
 
 ```bash
-npx mcp-local-rag ingest --base-dir ./docs --base-dir ./specs ./readme.md
+npx mcp-local-rag ingest --base-dir ./docs --base-dir ./specs ./docs/readme.md
 npx mcp-local-rag list --base-dir ./docs --base-dir ./specs
 ```
 
-When at least one `--base-dir` is supplied, CLI roots replace any env-var roots (no merge).
+The positional path to `ingest` must sit inside one of the configured roots. When at least one `--base-dir` is supplied, CLI roots replace any env-var roots (no merge).
 
 **Environment variables** — set in your shell:
 
@@ -467,7 +467,7 @@ claude mcp add local-rag --scope user \
 
 ```bash
 # Repeatable --base-dir
-npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs ./readme.md
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
 npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
 
 # Or via BASE_DIRS env

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Semantic search with keyword boost for exact technical terms — fully private, 
 
 ## Quick Start
 
-Set `BASE_DIR` to the folder you want to search. Documents must live under it.
+Set `BASE_DIR` to the folder you want to search (or `BASE_DIRS` for multiple roots — see [Configuration](#configuration)). Documents must live under one of the configured roots.
 
 Add the MCP server to your AI coding tool:
 
@@ -206,7 +206,7 @@ Pass the `filePath` and `chunkIndex` from the search result. The response includ
 #### Managing Files
 
 ```
-"List all files in BASE_DIR and their ingested status"   # See what's indexed
+"List all files in configured base directories and their ingested status"   # See what's indexed
 "Delete old-spec.pdf from RAG"     # Remove a file
 "Show RAG server status"           # Check system health
 ```
@@ -237,12 +237,28 @@ npx mcp-local-rag delete --source "https://..."  # Remove by source URL
 npx mcp-local-rag --db-path ./my-db query "auth" --base-dir ./docs
 ```
 
+The `--base-dir` flag is repeatable on `ingest` and `list`; pass it once per root:
+
+```bash
+npx mcp-local-rag ingest --base-dir ./docs --base-dir ./specs ./readme.md
+npx mcp-local-rag list --base-dir ./docs --base-dir ./specs
+```
+
+When at least one `--base-dir` is supplied, CLI roots replace any env-var roots (no merge).
+
 **Environment variables** — set in your shell:
 
 ```bash
 export DB_PATH=./my-db
 export BASE_DIR=./docs
 npx mcp-local-rag query "auth"
+```
+
+For multiple roots, use `BASE_DIRS` (JSON array of non-empty path strings):
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+npx mcp-local-rag list
 ```
 
 **Sharing config between MCP and CLI** — if your MCP client inherits shell environment variables, you can set them in your shell profile (e.g., `~/.zshrc`) so both use the same values. Otherwise, set them explicitly in your MCP config as well.
@@ -359,7 +375,8 @@ The MCP server is configured by environment variables only — pass them through
 
 | Environment Variable | CLI Flag | Default | Description |
 |---------------------|----------|---------|-------------|
-| `BASE_DIR` | `--base-dir` | Current directory | Document root directory (security boundary) |
+| `BASE_DIR` | `--base-dir` (repeatable) | Current directory | Single document root directory (security boundary). See [Document Roots](#document-roots-base_dir-and-base_dirs) for multi-root setup. |
+| `BASE_DIRS` | — | (unset) | JSON array of document roots (security boundary). Takes precedence over `BASE_DIR`. See [Document Roots](#document-roots-base_dir-and-base_dirs). |
 | `DB_PATH` | `--db-path` | `./lancedb/` | Vector database location |
 | `CACHE_DIR` | `--cache-dir` | `./models/` | Model cache directory |
 | `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model ID ([available models](https://huggingface.co/models?library=transformers.js&pipeline_tag=feature-extraction)) |
@@ -373,6 +390,89 @@ The MCP server is configured by environment variables only — pass them through
 - Code repositories → default often suffices; keyword boost matters more (or `jinaai/jina-embeddings-v2-base-code`)
 
 ⚠️ Changing `MODEL_NAME` changes embedding dimensions. Delete `DB_PATH` and re-ingest after switching models.
+
+### Document Roots (`BASE_DIR` and `BASE_DIRS`)
+
+mcp-local-rag enforces a security boundary: only files under a configured root are accessible to ingest, list, delete, or read-neighbor operations.
+
+**Single root** — use `BASE_DIR`:
+
+```bash
+export BASE_DIR=/Users/me/Documents/work
+```
+
+**Multiple roots** — use `BASE_DIRS` with a JSON array:
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+Only JSON-array syntax is supported. Delimiter syntax such as `BASE_DIRS=/a:/b` is intentionally **not** supported (avoids ambiguity with spaces, colons, commas, and Windows paths).
+
+**Resolution order** (highest precedence first):
+
+1. CLI `--base-dir <path>` flags (repeatable on `ingest` and `list`)
+2. `BASE_DIRS` environment variable
+3. `BASE_DIR` environment variable
+4. `process.cwd()` (current working directory)
+
+CLI roots **replace** env roots — they are never merged. `BASE_DIRS` and `BASE_DIR` are never merged either: `BASE_DIRS` wins when both are set.
+
+**Precedence warning** — when `BASE_DIRS` and `BASE_DIR` are both set (and no CLI `--base-dir` is supplied), `BASE_DIR` is ignored and a warning is surfaced. The warning is visible:
+
+- In MCP tool responses (as an additional content block, on every tool — including `status`, `query_documents`, `ingest_file`, `ingest_data`, `list_files`, `delete_file`, `read_chunk_neighbors`).
+- On CLI `stderr`.
+
+Unset `BASE_DIR` (or remove `BASE_DIRS`) to silence the warning.
+
+**Nested-root pruning** — if one configured root sits inside another after realpath resolution, the nested child is dropped to avoid duplicate scan results. A pruning warning is surfaced the same way as the precedence warning. The surviving parent root still defines the security boundary.
+
+**Invalid `BASE_DIRS`** — when `BASE_DIRS` is not a valid JSON array of non-empty strings (malformed JSON, empty array, non-string elements, ...), root-dependent MCP tools return a structured error and CLI subcommands exit non-zero. There is **no silent fallback** to `BASE_DIR` or `cwd`. The MCP `status` tool remains callable so you can diagnose the config error through your MCP client.
+
+**MCP client examples** — multi-root setup:
+
+Cursor (`~/.cursor/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIRS": "[\"/Users/me/Documents/work\",\"/Users/me/Projects/specs\"]"
+      }
+    }
+  }
+}
+```
+
+Codex (`~/.codex/config.toml`):
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIRS = "[\"/Users/me/Documents/work\",\"/Users/me/Projects/specs\"]"
+```
+
+Claude Code:
+```bash
+claude mcp add local-rag --scope user \
+  --env BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]' \
+  -- npx -y mcp-local-rag
+```
+
+**CLI examples** — multi-root invocations:
+
+```bash
+# Repeatable --base-dir
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs ./readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+
+# Or via BASE_DIRS env
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
 
 ### Client-Specific Setup
 
@@ -417,7 +517,7 @@ The embedding model (~90MB) downloads on first use. Takes 1-2 minutes, then work
 
 ### Security
 
-- **Path restriction**: Only files within `BASE_DIR` are accessible
+- **Path restriction**: Only files within a configured root (`BASE_DIR` or any `BASE_DIRS` / `--base-dir` entry) are accessible. Symlinks resolving outside all configured roots, and sibling-prefix paths (e.g. `/foo/barista` for root `/foo/bar`), are rejected.
 - **Local only**: No network requests after model download
 - **Model sources** (all official HuggingFace repositories):
   - Embedder: [`Xenova/all-MiniLM-L6-v2`](https://huggingface.co/Xenova/all-MiniLM-L6-v2)
@@ -465,7 +565,18 @@ Check chunk count with `status`. Large documents with many chunks may slow queri
 
 ### "Path outside BASE_DIR"
 
-Ensure file paths are within `BASE_DIR`. Use absolute paths.
+Ensure file paths are within one of the configured roots (`BASE_DIR`, any `BASE_DIRS` entry, or any CLI `--base-dir`). Use absolute paths.
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` accepts only a JSON array of one or more non-empty path strings. Examples:
+
+- Valid: `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- Invalid: `BASE_DIRS=/a:/b` (delimiter syntax not supported)
+- Invalid: `BASE_DIRS='[]'` (empty array)
+- Invalid: `BASE_DIRS='["",""]'` (empty string element)
+
+When invalid, root-dependent operations fail with a clear error rather than silently falling back. The MCP `status` tool remains callable so you can inspect the diagnostic.
 
 ### MCP client doesn't see tools
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "@lancedb/lancedb": "^0.27.2",
+    "@lancedb/lancedb": "^0.29.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "0.6.0",
     "jsdom": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lint-staged": "^17.0.5",
     "tsc-alias": "^1.8.17",
     "tsx": "^4.22.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -74,16 +74,16 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@types/jsdom": "^28.0.3",
-    "@types/node": "^25.8.0",
+    "@types/node": "^25.9.1",
     "@types/turndown": "5.0.6",
     "dpdm": "^4.2.0",
     "husky": "^9.1.7",
-    "knip": "^6.14.1",
+    "knip": "^6.14.2",
     "lint-staged": "^17.0.5",
     "tsc-alias": "^1.8.17",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       '@lancedb/lancedb':
-        specifier: ^0.27.2
-        version: 0.27.2(apache-arrow@18.1.0)
+        specifier: ^0.29.0
+        version: 0.29.0(apache-arrow@18.1.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -686,54 +686,54 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@lancedb/lancedb-darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-+XM68V/Rou8kKWDnUeKvg9ChKS0zGeQC2sKAop+06Ty4LwIjEGkeYBYrK0vMhZkBN5EFaOjTOp8E8hGQxdFwXA==}
+  '@lancedb/lancedb-darwin-arm64@0.29.0':
+    resolution: {integrity: sha512-LzI8+2WKRBGmLbOBe/ojya1ihIGWD7lz9cKGOnCKZ4Wvnqm4RRhyL0r4ukAgmhgJGrVIbZj+juwgSs+NDErLcw==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@lancedb/lancedb-linux-arm64-gnu@0.27.2':
-    resolution: {integrity: sha512-laiTTDeMUTzm7t+t6ME5nNQMDoERjmkeuWAFWekbXiFdmp62Dqu34Lvf2BvpWnKwxLMZ5JcBJFIw32WS8/8Jnw==}
+  '@lancedb/lancedb-linux-arm64-gnu@0.29.0':
+    resolution: {integrity: sha512-y9hFXWVDJNxxpvR1XRrxSslFwIwBiXXDTwYQl/aKoIQ5irG1PdqKsnvCPGcIR01WhLlog12AGytby01lYuE7FA==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@lancedb/lancedb-linux-arm64-musl@0.27.2':
-    resolution: {integrity: sha512-bK5Mc50EvwGZaaiym5CoPu8Y4GNSyEEvTQ0dTC2AUIm83qdQu1rGw6kkYtc/rTH/hbvAvPQot4agHDZfMVxfYw==}
+  '@lancedb/lancedb-linux-arm64-musl@0.29.0':
+    resolution: {integrity: sha512-fZ8Y4pzm/xfkSKhgZ289puaShckAOwd8s1mt5mHNDC8IuAaBmA6YxpDEQCItiDX1CNgsN+L7BFZWu11x+gsDPQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@lancedb/lancedb-linux-x64-gnu@0.27.2':
-    resolution: {integrity: sha512-qe+ML0YmPru0o84f33RBHqoNk6zsHBjiXTLKsEBDiiFYKks/XMsrkKy9NQYcTxShBrg/nx/MLzCzd7dihqgNYw==}
+  '@lancedb/lancedb-linux-x64-gnu@0.29.0':
+    resolution: {integrity: sha512-1JLQohd/MKyAVVaO2unM66e80jm9F7CE1xCRlml+BNKUXReDI4m3Jg7DZLzor+jPs2+Si3dIwXa2Rzs/9plr5g==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@lancedb/lancedb-linux-x64-musl@0.27.2':
-    resolution: {integrity: sha512-ZpX6Oxn06qvzAdm+D/gNb3SRp/A9lgRAPvPg6nnMmSQk5XamC/hbGO07uK1wwop7nlqXUH/thk4is2y2ieWdTw==}
+  '@lancedb/lancedb-linux-x64-musl@0.29.0':
+    resolution: {integrity: sha512-OZ3X0Cksi0e5e0ILvH/mGvuP3rQ2Rj/csNScExM3lroxlnl359TGQod+o4Z1hjSjLbPAe7gRax5Xwmu0/fh7AQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@lancedb/lancedb-win32-arm64-msvc@0.27.2':
-    resolution: {integrity: sha512-4ffpFvh49MiUtkdFJOmBytXEbgUPXORphTOuExnJAgT1VAKwQcu4ZzdsgNoK6mumKBaU+pYQU/MedNkgTzx/Lw==}
+  '@lancedb/lancedb-win32-arm64-msvc@0.29.0':
+    resolution: {integrity: sha512-5BS/8sNmmqtuj4J5btaoG+mqhcrQZKMJQa4koc+VfzK6VW0KV465kkcXwPtyzgjF4SyionpO9SbUHZj6LHplYA==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [win32]
 
-  '@lancedb/lancedb-win32-x64-msvc@0.27.2':
-    resolution: {integrity: sha512-XlwiI6CK2Gkqq+FFVAStHojao/XjIJpDPTm7Tb9SpLL64IlwGw3yaT2hnWKTm90W4KlSrpfSldPly+s+y4U7JQ==}
+  '@lancedb/lancedb-win32-x64-msvc@0.29.0':
+    resolution: {integrity: sha512-cszoiRM0C1wYi7zbMTkQKhVLPWpsW4D3ZTVnukJrCW3faJ+GVyjkXCqpZebWgbq9/9XDNcS0/iJUbB/FbSUNSw==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [win32]
 
-  '@lancedb/lancedb@0.27.2':
-    resolution: {integrity: sha512-JQpZHV5KzUzDI3flYCjtZcfHlEbL8lM54E0NT+jrRYe29aKYegfavvPsAsuZp0VdcMwFMZcpMkaBhjQMo/fwvg==}
+  '@lancedb/lancedb@0.29.0':
+    resolution: {integrity: sha512-lqg2QVs+yriRZ30I1fqnR8qHTR8olSx+9gY7PKvbk19kjP9Ei3uvYhtNsoqdfaF8sdCXML9RczGP9HPYepF2yw==}
     engines: {node: '>= 18'}
     cpu: [x64, arm64]
     os: [darwin, linux, win32]
@@ -2947,39 +2947,39 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@lancedb/lancedb-darwin-arm64@0.27.2':
+  '@lancedb/lancedb-darwin-arm64@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-linux-arm64-gnu@0.27.2':
+  '@lancedb/lancedb-linux-arm64-gnu@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-linux-arm64-musl@0.27.2':
+  '@lancedb/lancedb-linux-arm64-musl@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-linux-x64-gnu@0.27.2':
+  '@lancedb/lancedb-linux-x64-gnu@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-linux-x64-musl@0.27.2':
+  '@lancedb/lancedb-linux-x64-musl@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-win32-arm64-msvc@0.27.2':
+  '@lancedb/lancedb-win32-arm64-msvc@0.29.0':
     optional: true
 
-  '@lancedb/lancedb-win32-x64-msvc@0.27.2':
+  '@lancedb/lancedb-win32-x64-msvc@0.29.0':
     optional: true
 
-  '@lancedb/lancedb@0.27.2(apache-arrow@18.1.0)':
+  '@lancedb/lancedb@0.29.0(apache-arrow@18.1.0)':
     dependencies:
       apache-arrow: 18.1.0
       reflect-metadata: 0.2.2
     optionalDependencies:
-      '@lancedb/lancedb-darwin-arm64': 0.27.2
-      '@lancedb/lancedb-linux-arm64-gnu': 0.27.2
-      '@lancedb/lancedb-linux-arm64-musl': 0.27.2
-      '@lancedb/lancedb-linux-x64-gnu': 0.27.2
-      '@lancedb/lancedb-linux-x64-musl': 0.27.2
-      '@lancedb/lancedb-win32-arm64-msvc': 0.27.2
-      '@lancedb/lancedb-win32-x64-msvc': 0.27.2
+      '@lancedb/lancedb-darwin-arm64': 0.29.0
+      '@lancedb/lancedb-linux-arm64-gnu': 0.29.0
+      '@lancedb/lancedb-linux-arm64-musl': 0.29.0
+      '@lancedb/lancedb-linux-x64-gnu': 0.29.0
+      '@lancedb/lancedb-linux-x64-musl': 0.29.0
+      '@lancedb/lancedb-win32-arm64-msvc': 0.29.0
+      '@lancedb/lancedb-win32-x64-msvc': 0.29.0
 
   '@mixmark-io/domino@2.2.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^4.22.3
         version: 4.22.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -2365,6 +2365,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
@@ -4632,6 +4637,8 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   typical@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^28.0.3
         version: 28.0.3
       '@types/node':
-        specifier: ^25.8.0
-        version: 25.8.0
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/turndown':
         specifier: 5.0.6
         version: 5.0.6
@@ -52,8 +52,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       knip:
-        specifier: ^6.14.1
-        version: 6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^6.14.2
+        version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       lint-staged:
         specifier: ^17.0.5
         version: 17.0.5
@@ -61,14 +61,14 @@ importers:
         specifier: ^1.8.17
         version: 1.8.17
       tsx:
-        specifier: ^4.22.0
-        version: 4.22.0
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -152,15 +152,15 @@ packages:
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
 
-  '@csstools/css-calc@3.2.0':
-    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.0':
-    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -172,8 +172,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.3':
-    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -189,9 +189,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -508,8 +505,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       '@noble/hashes': ^1.8.0 || ^2.0.0
@@ -517,14 +514,14 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
 
-  '@huggingface/jinja@0.5.6':
-    resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
   '@huggingface/tokenizers@0.1.3':
@@ -533,8 +530,8 @@ packages:
   '@huggingface/transformers@4.2.0':
     resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -1025,17 +1022,17 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.1':
-    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -1217,8 +1214,8 @@ packages:
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -1226,11 +1223,11 @@ packages:
   '@types/turndown@5.0.6':
     resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1240,32 +1237,31 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
 
   ajv-formats@3.0.1:
@@ -1276,8 +1272,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -1422,13 +1418,17 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
-  content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1535,11 +1535,11 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es6-error@4.1.1:
@@ -1576,8 +1576,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -1588,8 +1588,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.3.1:
-    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -1605,8 +1605,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1682,9 +1682,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.0:
-    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
-
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
@@ -1729,12 +1726,12 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.8:
-    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -1764,8 +1761,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1816,8 +1813,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -1847,8 +1844,8 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
-  knip@6.14.1:
-    resolution: {integrity: sha512-SN3Ly0ixzj5CQkY/rc4OPHpWrCC0XRIIjgdP76G9Cni5k72ur5jBYOyvJuF5oPTM14v8eHcMUgPbElHa+lnR0g==}
+  knip@6.14.2:
+    resolution: {integrity: sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1881,12 +1878,8 @@ packages:
   lop@0.4.2:
     resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
 
-  lru-cache@11.3.5:
-    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
-    engines: {node: 20 || >=22}
-
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -1953,9 +1946,9 @@ packages:
   mupdf@1.27.0:
     resolution: {integrity: sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ==}
 
-  mylas@2.1.13:
-    resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
-    engines: {node: '>=12.0.0'}
+  mylas@2.1.14:
+    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
+    engines: {node: '>=16.0.0'}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2045,8 +2038,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2058,8 +2051,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
@@ -2077,15 +2070,15 @@ packages:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
     engines: {node: '>=12'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  protobufjs@7.5.6:
-    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -2096,8 +2089,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-lit@1.5.2:
@@ -2172,8 +2165,8 @@ packages:
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2207,8 +2200,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2263,8 +2256,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -2307,10 +2300,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
@@ -2323,11 +2312,11 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.19:
-    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
 
-  tldts@7.0.19:
-    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -2354,8 +2343,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.0:
-    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2367,9 +2356,9 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2388,8 +2377,8 @@ packages:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
     engines: {node: '>=14'}
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2459,20 +2448,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2560,11 +2549,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2582,10 +2566,10 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2595,8 +2579,8 @@ snapshots:
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
-      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -2653,15 +2637,15 @@ snapshots:
 
   '@csstools/color-helpers@6.0.2': {}
 
-  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -2669,7 +2653,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -2682,11 +2666,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.9.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2852,25 +2831,25 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.1': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.8)':
+  '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
-      hono: 4.12.8
+      hono: 4.12.22
 
-  '@huggingface/jinja@0.5.6': {}
+  '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tokenizers@0.1.3': {}
 
   '@huggingface/transformers@4.2.0':
     dependencies:
-      '@huggingface/jinja': 0.5.6
+      '@huggingface/jinja': 0.5.9
       '@huggingface/tokenizers': 0.1.3
       onnxruntime-node: 1.24.3
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.34.5
 
-  '@img/colour@1.0.0': {}
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -2954,7 +2933,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -3006,23 +2985,23 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.8)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
-      jose: 6.1.3
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.22
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3184,16 +3163,15 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.1': {}
+  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -3304,7 +3282,7 @@ snapshots:
 
   '@types/jsdom@28.0.3':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
       undici-types: 7.25.0
@@ -3313,7 +3291,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.8.0':
+  '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
 
@@ -3321,64 +3299,64 @@ snapshots:
 
   '@types/turndown@5.0.6': {}
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.6
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+      vite: 7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.6':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.6': {}
+  '@vitest/spy@4.1.7': {}
 
-  '@vitest/utils@4.1.6':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  adm-zip@0.5.16: {}
+  adm-zip@0.5.17: {}
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3397,7 +3375,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   apache-arrow@18.1.0:
     dependencies:
@@ -3443,9 +3421,9 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -3535,9 +3513,11 @@ snapshots:
 
   commander@9.5.0: {}
 
-  content-disposition@1.0.1: {}
+  content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -3612,7 +3592,7 @@ snapshots:
 
   duck@0.1.12:
     dependencies:
-      underscore: 1.13.7
+      underscore: 1.13.8
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3634,9 +3614,9 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -3714,24 +3694,24 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.1(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.2
-      content-disposition: 1.0.1
+      content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
@@ -3749,13 +3729,13 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3770,7 +3750,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3835,22 +3815,18 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
-
-  get-tsconfig@4.13.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -3872,7 +3848,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.3
+      semver: 7.8.1
       serialize-error: 7.0.1
 
   globalthis@1.0.4:
@@ -3903,15 +3879,15 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.8: {}
+  hono@4.12.22: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -3935,7 +3911,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -3969,21 +3945,21 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@6.1.3: {}
+  jose@6.2.3: {}
 
   jsdom@29.1.1:
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
+      lru-cache: 11.5.0
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -4018,7 +3994,7 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
-  knip@6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  knip@6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -4049,7 +4025,7 @@ snapshots:
       string-argv: 0.3.2
       tinyexec: 1.1.2
     optionalDependencies:
-      yaml: 2.8.4
+      yaml: 2.9.0
 
   listr2@10.2.1:
     dependencies:
@@ -4080,11 +4056,9 @@ snapshots:
     dependencies:
       duck: 0.1.12
       option: 0.2.4
-      underscore: 1.13.7
+      underscore: 1.13.8
 
-  lru-cache@11.3.5: {}
-
-  lru-cache@11.3.6: {}
+  lru-cache@11.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4092,7 +4066,7 @@ snapshots:
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.13
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7
@@ -4100,7 +4074,7 @@ snapshots:
       jszip: 3.10.1
       lop: 0.4.2
       path-is-absolute: 1.0.1
-      underscore: 1.13.7
+      underscore: 1.13.8
       xmlbuilder: 10.1.1
 
   matcher@3.0.0:
@@ -4120,7 +4094,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.54.0: {}
 
@@ -4142,7 +4116,7 @@ snapshots:
 
   mupdf@1.27.0: {}
 
-  mylas@2.1.13: {}
+  mylas@2.1.14: {}
 
   nanoid@3.3.12: {}
 
@@ -4176,7 +4150,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.16
+      adm-zip: 0.5.17
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
@@ -4187,7 +4161,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
-      protobufjs: 7.5.6
+      protobufjs: 7.6.1
 
   option@0.2.4: {}
 
@@ -4267,10 +4241,10 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.5.0
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -4278,7 +4252,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -4290,7 +4264,7 @@ snapshots:
     dependencies:
       queue-lit: 1.5.2
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -4298,19 +4272,19 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  protobufjs@7.5.6:
+  protobufjs@7.6.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -4320,7 +4294,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -4349,7 +4323,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   reflect-metadata@0.2.2: {}
 
@@ -4412,7 +4386,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4430,7 +4404,7 @@ snapshots:
 
   semver-compare@1.0.0: {}
 
-  semver@7.7.3: {}
+  semver@7.8.1: {}
 
   send@1.2.1:
     dependencies:
@@ -4467,9 +4441,9 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.1
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -4502,7 +4476,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -4526,7 +4500,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -4558,7 +4532,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -4598,8 +4572,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
@@ -4609,11 +4581,11 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.19: {}
+  tldts-core@7.0.30: {}
 
-  tldts@7.0.19:
+  tldts@7.0.30:
     dependencies:
-      tldts-core: 7.0.19
+      tldts-core: 7.0.30
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4623,7 +4595,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.19
+      tldts: 7.0.30
 
   tr46@6.0.0:
     dependencies:
@@ -4633,15 +4605,15 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       commander: 9.5.0
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.14.0
       globby: 11.1.0
-      mylas: 2.1.13
+      mylas: 2.1.14
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
   tslib@2.8.1: {}
 
-  tsx@4.22.0:
+  tsx@4.22.3:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:
@@ -4653,9 +4625,9 @@ snapshots:
 
   type-fest@0.13.1: {}
 
-  type-is@2.0.1:
+  type-is@2.1.0:
     dependencies:
-      content-type: 1.0.5
+      content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
@@ -4667,7 +4639,7 @@ snapshots:
 
   unbash@3.0.0: {}
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 
@@ -4685,45 +4657,45 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0):
+  vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.22.0
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.1.12(@types/node@25.8.0)(jiti@2.7.0)(tsx@4.22.0)(yaml@2.9.0)
+      vite: 7.1.12(@types/node@25.9.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -4740,7 +4712,7 @@ snapshots:
 
   whatwg-url@16.0.1:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.1
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -4779,9 +4751,6 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml@2.8.4:
-    optional: true
-
   yaml@2.9.0: {}
 
   yargs-parser@22.0.0: {}
@@ -4797,7 +4766,7 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
 

--- a/server.json
+++ b/server.json
@@ -8,20 +8,27 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.14.1",
+  "version": "0.14.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
           "name": "BASE_DIR",
-          "description": "Base directory for document storage (defaults to current working directory)",
+          "description": "Base directory for document storage (defaults to current working directory). Ignored when BASE_DIRS is set.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "BASE_DIRS",
+          "description": "JSON array of base directories (e.g. '[\"/a\",\"/b\"]'). Takes precedence over BASE_DIR.",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -239,7 +239,7 @@ All ingest/list/delete/read-neighbor operations are confined to one or more conf
 - `BASE_DIRS is set; BASE_DIR is ignored.` — both env vars set with no CLI override. `BASE_DIR` is silently shadowed; unset it or remove `BASE_DIRS` to silence.
 - `Nested base directory pruned: <child> is inside <parent>.` — a configured root sits inside another. Child is dropped to avoid duplicate scan results; parent remains the boundary.
 
-**Invalid `BASE_DIRS`** — malformed JSON, empty array, or non-string entries cause root-dependent tools to return a structured error. There is no fallback to `BASE_DIR` or `cwd`. `status` remains callable so users can diagnose via your MCP client.
+**Invalid `BASE_DIRS`** — malformed JSON, empty array, or non-string entries cause root-dependent tools to return a structured error so the misconfiguration surfaces at the call site. `status` remains callable for diagnosis via the MCP client.
 
 When a user reports unexpected ingest scope or "path outside BASE_DIR" errors, call `status` first to inspect the resolved roots and any active config warnings.
 

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -222,6 +222,27 @@ CLI subcommands mirror MCP tools. Useful for bulk operations, scripting, and env
 - Use `--help` on any command for options
 - See [cli-reference.md](references/cli-reference.md) for options and config matching
 
+## Document Roots (Security Boundary)
+
+All ingest/list/delete/read-neighbor operations are confined to one or more configured root directories. Files outside every configured root are rejected.
+
+| Setting | How | When |
+|---------|-----|------|
+| `BASE_DIR` | Single path string env var | Single-root setups (legacy, still supported) |
+| `BASE_DIRS` | JSON array env var: `'["/a","/b"]'` | Multi-root setups via env (MCP and CLI) |
+| `--base-dir <path>` | Repeatable CLI flag on `ingest` and `list` | Multi-root setups via CLI; CLI roots replace env roots |
+
+**Resolution order**: CLI `--base-dir` > `BASE_DIRS` > `BASE_DIR` > `process.cwd()`.
+
+**Warnings surfaced in MCP tool responses** (additional content block on every tool):
+
+- `BASE_DIRS is set; BASE_DIR is ignored.` — both env vars set with no CLI override. `BASE_DIR` is silently shadowed; unset it or remove `BASE_DIRS` to silence.
+- `Nested base directory pruned: <child> is inside <parent>.` — a configured root sits inside another. Child is dropped to avoid duplicate scan results; parent remains the boundary.
+
+**Invalid `BASE_DIRS`** — malformed JSON, empty array, or non-string entries cause root-dependent tools to return a structured error. There is no fallback to `BASE_DIR` or `cwd`. `status` remains callable so users can diagnose via your MCP client.
+
+When a user reports unexpected ingest scope or "path outside BASE_DIR" errors, call `status` first to inspect the resolved roots and any active config warnings.
+
 ## References
 
 For edge cases and examples:

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -25,7 +25,7 @@ npx mcp-local-rag [global-options] ingest [options] <path>
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
-| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Document root directory. Repeatable: pass once per root (e.g. `--base-dir /a --base-dir /b`). When at least one `--base-dir` is supplied, CLI roots replace env roots. See [Document Roots](#document-roots) below. |
+| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Document root directory. Repeatable; CLI roots replace env roots. |
 | `--max-file-size <n>` | `MAX_FILE_SIZE` | `104857600` | Max file size in bytes (1–500MB) |
 | `--visual` | — | `false` | Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types) |
 | `--visual-quality <profile>` | — | `fast` | VLM profile when `--visual` is set: `fast` or `quality`. Silently ignored when `--visual` is absent. See "Visual quality profiles" below. |
@@ -77,7 +77,7 @@ npx mcp-local-rag [global-options] list [--base-dir <path>]...
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
-| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Base directory to scan. Repeatable: pass once per root. When at least one `--base-dir` is supplied, CLI roots replace env roots. See [Document Roots](#document-roots) below. |
+| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Base directory to scan. Repeatable; CLI roots replace env roots. |
 
 Output: JSON to stdout. The result includes `baseDirs: string[]` (all effective roots) plus a legacy `baseDir: string` (first effective root after normalization and nested-root pruning). Each file entry is annotated with the `baseDir` that produced it. Raw-data/orphaned entries remain under `sources` without a root annotation.
 
@@ -160,46 +160,6 @@ Example output (truncated):
 ```
 
 Out-of-range indices are filtered; only existing chunks within the document are returned. The response can be an empty array.
-
-## Document Roots
-
-mcp-local-rag enforces a security boundary: only files under a configured root are accessible. Roots come from three sources, with this precedence (highest first):
-
-1. CLI `--base-dir <path>` flags (repeatable; supported on `ingest` and `list`)
-2. `BASE_DIRS` env var — JSON array of non-empty path strings
-3. `BASE_DIR` env var — single path string
-4. `process.cwd()` (final fallback when none of the above is set)
-
-CLI roots **replace** env roots. When both `BASE_DIRS` and `BASE_DIR` are set, `BASE_DIRS` wins.
-
-**`BASE_DIRS` syntax** — JSON array only:
-
-```bash
-export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
-```
-
-`BASE_DIRS` accepts JSON arrays only; this keeps parsing unambiguous across spaces, colons, commas, and Windows paths.
-
-**Repeatable `--base-dir` examples**:
-
-```bash
-# Two roots via CLI (the positional path must sit inside one of the roots).
-npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
-npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
-
-# Two roots via env
-BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
-
-# CLI overrides env entirely (env roots are not merged in)
-BASE_DIRS='["/ignored"]' npx mcp-local-rag list --base-dir /Users/me/work
-```
-
-**Warnings** — surfaced on CLI `stderr` and in MCP tool response content blocks:
-
-- `BASE_DIRS is set; BASE_DIR is ignored.` — both env vars set with no CLI override.
-- `Nested base directory pruned: <child> is inside <parent>.` — one configured root sits inside another after realpath resolution. The child is dropped to avoid duplicate scan results; the parent remains the boundary.
-
-**Invalid `BASE_DIRS`** — malformed JSON, empty array, or empty/non-string entries cause root-dependent subcommands and MCP tools to fail loud with a structured error, surfacing the misconfiguration at the call site. The MCP `status` tool stays callable so the diagnostic remains visible through your MCP client.
 
 ## Config Matching
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -25,7 +25,7 @@ npx mcp-local-rag [global-options] ingest [options] <path>
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
-| `--base-dir <path>` | `BASE_DIR` | cwd | Base directory for documents |
+| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Document root directory. Repeatable: pass once per root (e.g. `--base-dir /a --base-dir /b`). When at least one `--base-dir` is supplied, CLI roots replace env roots. See [Document Roots](#document-roots) below. |
 | `--max-file-size <n>` | `MAX_FILE_SIZE` | `104857600` | Max file size in bytes (1–500MB) |
 | `--visual` | — | `false` | Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types) |
 | `--visual-quality <profile>` | — | `fast` | VLM profile when `--visual` is set: `fast` or `quality`. Silently ignored when `--visual` is absent. See "Visual quality profiles" below. |
@@ -72,14 +72,14 @@ Output: JSON array to stdout.
 ### list
 
 ```bash
-npx mcp-local-rag [global-options] list [--base-dir <path>]
+npx mcp-local-rag [global-options] list [--base-dir <path>]...
 ```
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
-| `--base-dir <path>` | `BASE_DIR` | cwd | Base directory to scan |
+| `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Base directory to scan. Repeatable: pass once per root. When at least one `--base-dir` is supplied, CLI roots replace env roots. See [Document Roots](#document-roots) below. |
 
-Output: JSON to stdout.
+Output: JSON to stdout. The result includes `baseDirs: string[]` (all effective roots) plus a legacy `baseDir: string` (first effective root after normalization and nested-root pruning). Each file entry is annotated with the `baseDir` that produced it. Raw-data/orphaned entries remain under `sources` without a root annotation.
 
 ### status
 
@@ -160,6 +160,46 @@ Example output (truncated):
 ```
 
 Out-of-range indices are filtered; only existing chunks within the document are returned. The response can be an empty array.
+
+## Document Roots
+
+mcp-local-rag enforces a security boundary: only files under a configured root are accessible. Roots come from three sources, with this precedence (highest first):
+
+1. CLI `--base-dir <path>` flags (repeatable; supported on `ingest` and `list`)
+2. `BASE_DIRS` env var — JSON array of non-empty path strings
+3. `BASE_DIR` env var — single path string
+4. `process.cwd()` (final fallback when none of the above is set)
+
+CLI roots **replace** env roots; they are never merged. `BASE_DIRS` and `BASE_DIR` are also never merged: `BASE_DIRS` wins when both are set.
+
+**`BASE_DIRS` syntax** — JSON array only:
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+Delimiter syntax such as `BASE_DIRS=/a:/b` is intentionally unsupported (avoids ambiguity with spaces, colons, commas, and Windows paths).
+
+**Repeatable `--base-dir` examples**:
+
+```bash
+# Two roots via CLI
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs ./readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+
+# Two roots via env
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+
+# CLI overrides env entirely (env roots are not merged in)
+BASE_DIRS='["/ignored"]' npx mcp-local-rag list --base-dir /Users/me/work
+```
+
+**Warnings** — surfaced on CLI `stderr` and in MCP tool response content blocks:
+
+- `BASE_DIRS is set; BASE_DIR is ignored.` — both env vars set with no CLI override.
+- `Nested base directory pruned: <child> is inside <parent>.` — one configured root sits inside another after realpath resolution. The child is dropped to avoid duplicate scan results; the parent remains the boundary.
+
+**Invalid `BASE_DIRS`** — malformed JSON, empty array, or empty/non-string entries cause root-dependent subcommands and MCP tools to fail with a structured error. There is no silent fallback to `BASE_DIR` or `cwd`. The MCP `status` tool stays callable so the diagnostic remains visible through your MCP client.
 
 ## Config Matching
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -170,7 +170,7 @@ mcp-local-rag enforces a security boundary: only files under a configured root a
 3. `BASE_DIR` env var — single path string
 4. `process.cwd()` (final fallback when none of the above is set)
 
-CLI roots **replace** env roots; they are never merged. `BASE_DIRS` and `BASE_DIR` are also never merged: `BASE_DIRS` wins when both are set.
+CLI roots **replace** env roots. When both `BASE_DIRS` and `BASE_DIR` are set, `BASE_DIRS` wins.
 
 **`BASE_DIRS` syntax** — JSON array only:
 
@@ -178,13 +178,13 @@ CLI roots **replace** env roots; they are never merged. `BASE_DIRS` and `BASE_DI
 export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
 ```
 
-Delimiter syntax such as `BASE_DIRS=/a:/b` is intentionally unsupported (avoids ambiguity with spaces, colons, commas, and Windows paths).
+`BASE_DIRS` accepts JSON arrays only; this keeps parsing unambiguous across spaces, colons, commas, and Windows paths.
 
 **Repeatable `--base-dir` examples**:
 
 ```bash
-# Two roots via CLI
-npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs ./readme.md
+# Two roots via CLI (the positional path must sit inside one of the roots).
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
 npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
 
 # Two roots via env
@@ -199,7 +199,7 @@ BASE_DIRS='["/ignored"]' npx mcp-local-rag list --base-dir /Users/me/work
 - `BASE_DIRS is set; BASE_DIR is ignored.` — both env vars set with no CLI override.
 - `Nested base directory pruned: <child> is inside <parent>.` — one configured root sits inside another after realpath resolution. The child is dropped to avoid duplicate scan results; the parent remains the boundary.
 
-**Invalid `BASE_DIRS`** — malformed JSON, empty array, or empty/non-string entries cause root-dependent subcommands and MCP tools to fail with a structured error. There is no silent fallback to `BASE_DIR` or `cwd`. The MCP `status` tool stays callable so the diagnostic remains visible through your MCP client.
+**Invalid `BASE_DIRS`** — malformed JSON, empty array, or empty/non-string entries cause root-dependent subcommands and MCP tools to fail loud with a structured error, surfacing the misconfiguration at the call site. The MCP `status` tool stays callable so the diagnostic remains visible through your MCP client.
 
 ## Config Matching
 

--- a/src/__tests__/cli/delete.test.ts
+++ b/src/__tests__/cli/delete.test.ts
@@ -42,9 +42,15 @@ const fsPromisesFactory = async (
 
 const MOCKED_PATHS = ['../../cli/common.js', 'node:fs/promises'] as const
 
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 let runDelete: typeof import('../../cli/delete.js').runDelete
+
+// Temp dbPath used by the raw-data cleanup tests so the boundary check's
+// realpath() resolves a real file. `unlink` itself stays mocked, so we
+// observe the call without actually removing anything.
+const cleanupDbPath = resolve('./tmp/test-cli-delete-cleanup-db')
 
 // ============================================
 // Helpers
@@ -83,7 +89,8 @@ describe('CLI delete', () => {
     ;({ runDelete } = await import('../../cli/delete.js'))
   })
 
-  afterAll(() => {
+  afterAll(async () => {
+    await rm(cleanupDbPath, { recursive: true, force: true })
     for (const p of MOCKED_PATHS) vi.doUnmock(p)
     vi.resetModules()
   })
@@ -217,8 +224,17 @@ describe('CLI delete', () => {
   // Raw-data file cleanup (unlink .md and .meta.json)
   // --------------------------------------------
   it('should clean up raw-data files (.md and .meta.json) when path is a raw-data path', async () => {
-    // Use --source to generate a raw-data path
-    const { error } = await captureStderr(() => runDelete(['--source', 'https://example.com/page']))
+    // Pre-create the on-disk raw-data .md so `isPathInRawDataDir`'s realpath
+    // resolves and the cleanup branch runs. `unlink` is mocked so the file
+    // stays on disk and is removed by the afterAll cleanup below.
+    const { generateRawDataPath } = await import('../../utils/raw-data-utils.js')
+    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/page', 'markdown')
+    await mkdir(resolve(cleanupDbPath, 'raw-data'), { recursive: true })
+    await writeFile(mdPath, 'fixture')
+
+    const { error } = await captureStderr(() =>
+      runDelete(['--source', 'https://example.com/page'], { dbPath: cleanupDbPath })
+    )
 
     expect(error).toBeUndefined()
 
@@ -259,6 +275,19 @@ describe('CLI delete', () => {
     const writtenData = stdoutSpy.mock.calls[0]![0] as string
     const parsed = JSON.parse(writtenData)
     expect(parsed.deleted).toBe(true)
+  })
+
+  it('attempts .meta.json cleanup even when the .md file is already missing', async () => {
+    mocks.deleteChunks.mockResolvedValue(undefined)
+    const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    mocks.unlink.mockRejectedValue(enoentError)
+
+    await captureStderr(() => runDelete(['--source', 'https://example.com/missing']))
+
+    expect(mocks.unlink).toHaveBeenCalledTimes(2)
+    const paths = mocks.unlink.mock.calls.map((c: unknown[]) => c[0] as string)
+    expect(paths.some((p: string) => p.endsWith('.md'))).toBe(true)
+    expect(paths.some((p: string) => p.endsWith('.meta.json'))).toBe(true)
   })
 
   // --------------------------------------------

--- a/src/__tests__/cli/ingest-visual.test.ts
+++ b/src/__tests__/cli/ingest-visual.test.ts
@@ -107,6 +107,16 @@ const cliCommonFactory = () => ({
     optimize: mocks.optimize,
     close: vi.fn(),
   })),
+  // Stub the shared CLI base-dirs resolver so visual-mode tests skip the
+  // realpath I/O the production resolver performs. The visual tests do not
+  // exercise base-dir precedence — they only need a valid config so the
+  // `DocumentParser` constructor receives a `baseDirs` array.
+  resolveCliBaseDirsOrExit: vi.fn().mockImplementation((cliRoots: string[]) =>
+    Promise.resolve({
+      config: { baseDirs: cliRoots.length > 0 ? cliRoots : ['/mock/cwd/'] },
+      warnings: [],
+    })
+  ),
 })
 
 // Real-shaped pdf-visual barrel. `detectVisualCandidates` reflects

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -21,6 +21,11 @@ const mocks = vi.hoisted(() => {
     // fs/promises
     stat: vi.fn(),
     opendir: vi.fn(),
+    // `collectFiles` now realpath-resolves the positional path before the
+    // "inside any configured root" check (Finding #1). The default mock is
+    // identity (no symlinks) so existing tests behave as if the positional
+    // path is its own realpath; per-test mocks can override.
+    realpath: vi.fn().mockImplementation((p: string) => Promise.resolve(p)),
 
     // Shared CLI base-dirs resolver
     resolveCliBaseDirs: vi.fn().mockImplementation(defaultResolve),
@@ -62,6 +67,7 @@ const fsPromisesFactory = async (
     ...actual,
     stat: mocks.stat,
     opendir: mocks.opendir,
+    realpath: mocks.realpath,
   }
 }
 
@@ -341,10 +347,13 @@ describe('CLI ingest', () => {
   // --------------------------------------------
   // Multi-root directory ingest (P2-T2)
   // --------------------------------------------
-  it('should walk every effective root and aggregate files across roots', async () => {
-    // Arrange: two disjoint roots, each with one file. The resolver returns
-    // both as effective roots; the directory-mode scan walks each one and
-    // concatenates the per-root file lists.
+  it('should scan only the positional directory even when multiple roots are configured', async () => {
+    // Post-Finding-#1: `ingest <dir>` scans `<dir>` (the positional path).
+    // The configured roots are the VALIDATION boundary (passed to the
+    // parser), not a replacement for the user's scan target. Previously
+    // this test asserted the buggy behavior of aggregating every root; that
+    // broke the CLI contract by ingesting unrelated content under `rootB`
+    // when the user only asked for `rootA`.
     const rootA = resolve('/tmp/test/rootA')
     const rootB = resolve('/tmp/test/rootB')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
@@ -355,95 +364,88 @@ describe('CLI ingest', () => {
 
     setupMockOpendir({
       [rootA]: [mockDirent('a.md')],
+      // rootB has a file too, but it must NOT be ingested because the
+      // positional path is `rootA`.
       [rootB]: [mockDirent('b.md')],
     })
     setupSuccessfulIngestion()
 
-    // Act: positional is one of the roots (or any extant path — directory
-    // mode just triggers the multi-root scan branch).
+    // Act: positional path is rootA.
     const { output, error } = await captureStderr(() =>
       runIngest(['--base-dir', rootA, '--base-dir', rootB, rootA])
     )
 
-    // Assert
-    expect(error).toBeUndefined()
-    const joined = output.join('\n')
-    expect(joined).toContain('Found 2 file(s) to ingest')
-    expect(joined).toContain(resolve(rootA, 'a.md'))
-    expect(joined).toContain(resolve(rootB, 'b.md'))
-    expect(joined).toContain('Succeeded: 2')
-  })
-
-  it('should dedup files by absolute path when roots surface the same file', async () => {
-    // Arrange: two roots that both surface the same absolute file path (the
-    // realistic scenario is a bind mount or symlink that survived nested
-    // pruning). The scan must emit the file exactly once.
-    const rootA = resolve('/tmp/test/share')
-    const rootB = resolve('/tmp/test/share') // duplicate after normalization
-    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
-    mocks.resolveCliBaseDirs.mockResolvedValue({
-      // Caller emulates a scenario where the resolver still hands two roots
-      // that yield the same file (e.g., symlink-equivalent realpaths that
-      // landed in the post-dedup list because they came from different
-      // user-supplied strings).
-      config: { baseDirs: [rootA, rootB] },
-      warnings: [],
-    })
-
-    setupMockOpendir({
-      [rootA]: [mockDirent('shared.md')],
-      [rootB]: [mockDirent('shared.md')],
-    })
-    setupSuccessfulIngestion()
-
-    // Act
-    const { output, error } = await captureStderr(() => runIngest([rootA]))
-
-    // Assert: file appears exactly once in the ingest summary
+    // Assert: exactly one file (rootA/a.md) ingested.
     expect(error).toBeUndefined()
     const joined = output.join('\n')
     expect(joined).toContain('Found 1 file(s) to ingest')
+    expect(joined).toContain(resolve(rootA, 'a.md'))
+    expect(joined).not.toContain(resolve(rootB, 'b.md'))
     expect(joined).toContain('Succeeded: 1')
-    // The progress marker [1/1] appears for the single deduped file
-    expect(joined).toContain('[1/1]')
   })
 
-  it('should preserve dbPath and cacheDir exclusion across every root', async () => {
-    // Arrange: two roots, each containing a file that lives under the
-    // resolved dbPath / cacheDir prefix. Both should be excluded.
-    const rootA = resolve('/tmp/test/dbA')
-    const rootB = resolve('/tmp/test/dbB')
-    const dbPath = resolve('/tmp/test/dbA/lancedb')
-    const cacheDir = resolve('/tmp/test/dbB/cache')
-    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+  it('should exit 1 with a clear message when the positional path is outside all configured roots', async () => {
+    // Regression test for Finding #1: previously the CLI silently fell back
+    // to scanning every configured root when the positional path lived
+    // outside all of them. The contract is now: fail loud, exit 1, and tell
+    // the user which roots are allowed.
+    const rootA = resolve('/tmp/test/rootA')
+    const rootB = resolve('/tmp/test/rootB')
+    const outsidePath = resolve('/tmp/test/outside')
+    mocks.stat.mockResolvedValue(mockDirStat())
     mocks.resolveCliBaseDirs.mockResolvedValue({
       config: { baseDirs: [rootA, rootB] },
       warnings: [],
     })
 
+    const { output, error } = await captureStderr(() =>
+      runIngest(['--base-dir', rootA, '--base-dir', rootB, outsidePath])
+    )
+
+    // Process exits with code 1.
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+
+    // Error message names the offending path and lists the allowed roots.
+    const joined = output.join('\n')
+    expect(joined).toContain('not under any configured base directory')
+    expect(joined).toContain(outsidePath)
+    expect(joined).toContain(rootA)
+    expect(joined).toContain(rootB)
+  })
+
+  it('should preserve dbPath and cacheDir exclusion when scanning the positional directory', async () => {
+    // Post-Finding-#1: only the positional path is scanned. The dbPath /
+    // cacheDir exclusion still applies under that single scanned tree, so
+    // files under either excluded path are skipped.
+    const rootA = resolve('/tmp/test/dbA')
+    const dbPath = resolve('/tmp/test/dbA/lancedb')
+    const cacheDir = resolve('/tmp/test/dbA/cache')
+    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA] },
+      warnings: [],
+    })
+
     setupMockOpendir({
-      [rootA]: [mockDirent('keep.md'), mockDirent('lancedb', 'directory')],
-      [dbPath]: [mockDirent('chunks.md')], // should be excluded under rootA
-      [rootB]: [mockDirent('also-keep.md'), mockDirent('cache', 'directory')],
-      [cacheDir]: [mockDirent('model.md')], // should be excluded under rootB
+      [rootA]: [
+        mockDirent('keep.md'),
+        mockDirent('lancedb', 'directory'),
+        mockDirent('cache', 'directory'),
+      ],
+      [dbPath]: [mockDirent('chunks.md')], // excluded
+      [cacheDir]: [mockDirent('model.md')], // excluded
     })
     setupSuccessfulIngestion()
 
-    // Act
     const { output, error } = await captureStderr(() =>
-      runIngest([rootA], {
-        dbPath,
-        cacheDir,
-        modelName: 'm',
-      })
+      runIngest([rootA], { dbPath, cacheDir, modelName: 'm' })
     )
 
-    // Assert: only the two non-excluded files were ingested
     expect(error).toBeUndefined()
     const joined = output.join('\n')
-    expect(joined).toContain('Found 2 file(s) to ingest')
+    expect(joined).toContain('Found 1 file(s) to ingest')
     expect(joined).toContain('keep.md')
-    expect(joined).toContain('also-keep.md')
     expect(joined).not.toContain('chunks.md')
     expect(joined).not.toContain('model.md')
   })
@@ -1384,6 +1386,9 @@ describe('CLI ingest', () => {
     it('passes CLI roots verbatim to the resolver and suppresses any env precedence warning', async () => {
       // Arrange: env vars are set but the user supplied --base-dir. The
       // resolver contract is "CLI replaces env, no precedence warning".
+      // Post-Finding-#1: the scan walks only the positional path. We still
+      // assert resolver wiring + no-precedence-warning; the scan is single-
+      // tree under `cliRootA`.
       process.env['BASE_DIR'] = '/env/single'
       process.env['BASE_DIRS'] = '["/env/multi/a","/env/multi/b"]'
       const cliRootA = resolve('/cli/precedence/a')
@@ -1393,7 +1398,7 @@ describe('CLI ingest', () => {
         config: { baseDirs: [cliRootA, cliRootB] },
         warnings: [],
       })
-      setupMockOpendir({ [cliRootA]: [mockDirent('a.md')], [cliRootB]: [mockDirent('b.md')] })
+      setupMockOpendir({ [cliRootA]: [mockDirent('a.md')] })
       setupSuccessfulIngestion()
 
       try {
@@ -1419,7 +1424,9 @@ describe('CLI ingest', () => {
     it('uses BASE_DIRS fallback (multi-root) when no --base-dir is provided', async () => {
       // Arrange: no CLI roots; resolver returns the BASE_DIRS-driven multi-root
       // set. The CLI must forward an empty `cliRoots` array so the resolver
-      // applies env precedence.
+      // applies env precedence. Post-Finding-#1: only the positional path is
+      // scanned, but the resolver invocation contract is still
+      // "empty cliRoots when --base-dir is absent".
       const envRootA = resolve('/env/multi/a')
       const envRootB = resolve('/env/multi/b')
       mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
@@ -1427,7 +1434,7 @@ describe('CLI ingest', () => {
         config: { baseDirs: [envRootA, envRootB] },
         warnings: [],
       })
-      setupMockOpendir({ [envRootA]: [mockDirent('a.md')], [envRootB]: [mockDirent('b.md')] })
+      setupMockOpendir({ [envRootA]: [mockDirent('a.md')] })
       setupSuccessfulIngestion()
 
       // Act
@@ -1437,11 +1444,11 @@ describe('CLI ingest', () => {
       expect(error).toBeUndefined()
       expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([])
 
-      // Assert: both roots were scanned (aggregated file count).
+      // Assert: only the positional tree was scanned.
       const joined = output.join('\n')
-      expect(joined).toContain('Found 2 file(s) to ingest')
+      expect(joined).toContain('Found 1 file(s) to ingest')
       expect(joined).toContain(resolve(envRootA, 'a.md'))
-      expect(joined).toContain(resolve(envRootB, 'b.md'))
+      expect(joined).not.toContain(resolve(envRootB, 'b.md'))
     })
 
     it('surfaces BASE_DIRS > BASE_DIR precedence warning on stderr (no CLI roots)', async () => {

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -730,12 +730,12 @@ describe('CLI ingest', () => {
   // --------------------------------------------
   it('should exit gracefully with message when directory has no supported files', async () => {
     // Arrange
-    const dirPath = '/tmp/test/empty'
+    const dirPath = resolve('/tmp/test/empty')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
     mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
-      '/tmp/test/empty': [mockDirent('readme.jpg')],
+      [dirPath]: [mockDirent('readme.jpg')],
     })
 
     // Act

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -1371,4 +1371,148 @@ describe('CLI ingest', () => {
       }
     })
   })
+
+  // --------------------------------------------
+  // P2-T3: CLI multi-root precedence / fallback / config-error matrix
+  //
+  // Mirrors the cases added to `list.test.ts` so the boundary contract
+  // between `runIngest` and the shared resolver is asserted at both CLI
+  // entry points. Scenarios are driven from the resolver mock (no real env
+  // vars / filesystem) so they remain deterministic.
+  // --------------------------------------------
+  describe('multi-root precedence (P2-T3)', () => {
+    it('passes CLI roots verbatim to the resolver and suppresses any env precedence warning', async () => {
+      // Arrange: env vars are set but the user supplied --base-dir. The
+      // resolver contract is "CLI replaces env, no precedence warning".
+      process.env['BASE_DIR'] = '/env/single'
+      process.env['BASE_DIRS'] = '["/env/multi/a","/env/multi/b"]'
+      const cliRootA = resolve('/cli/precedence/a')
+      const cliRootB = resolve('/cli/precedence/b')
+      mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [cliRootA, cliRootB] },
+        warnings: [],
+      })
+      setupMockOpendir({ [cliRootA]: [mockDirent('a.md')], [cliRootB]: [mockDirent('b.md')] })
+      setupSuccessfulIngestion()
+
+      try {
+        // Act
+        const { output, error } = await captureStderr(() =>
+          runIngest(['--base-dir', cliRootA, '--base-dir', cliRootB, cliRootA])
+        )
+
+        // Assert: resolver received the CLI roots verbatim and in order.
+        expect(error).toBeUndefined()
+        expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([cliRootA, cliRootB])
+
+        // Assert: no precedence warning surfaced to stderr.
+        const joined = output.join('\n')
+        expect(joined).not.toContain('BASE_DIRS is set')
+        expect(joined).not.toContain('BASE_DIR is ignored')
+      } finally {
+        delete process.env['BASE_DIR']
+        delete process.env['BASE_DIRS']
+      }
+    })
+
+    it('uses BASE_DIRS fallback (multi-root) when no --base-dir is provided', async () => {
+      // Arrange: no CLI roots; resolver returns the BASE_DIRS-driven multi-root
+      // set. The CLI must forward an empty `cliRoots` array so the resolver
+      // applies env precedence.
+      const envRootA = resolve('/env/multi/a')
+      const envRootB = resolve('/env/multi/b')
+      mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [envRootA, envRootB] },
+        warnings: [],
+      })
+      setupMockOpendir({ [envRootA]: [mockDirent('a.md')], [envRootB]: [mockDirent('b.md')] })
+      setupSuccessfulIngestion()
+
+      // Act
+      const { output, error } = await captureStderr(() => runIngest([envRootA]))
+
+      // Assert: resolver invoked with empty CLI roots.
+      expect(error).toBeUndefined()
+      expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([])
+
+      // Assert: both roots were scanned (aggregated file count).
+      const joined = output.join('\n')
+      expect(joined).toContain('Found 2 file(s) to ingest')
+      expect(joined).toContain(resolve(envRootA, 'a.md'))
+      expect(joined).toContain(resolve(envRootB, 'b.md'))
+    })
+
+    it('surfaces BASE_DIRS > BASE_DIR precedence warning on stderr (no CLI roots)', async () => {
+      // Arrange: resolver yields the precedence warning. The CLI prints
+      // every resolver warning to stderr before the scan output begins.
+      const root = resolve('/env/multi/only')
+      mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [root] },
+        warnings: [
+          {
+            kind: 'base-dirs-overrides-base-dir',
+            message:
+              'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.',
+          },
+        ],
+      })
+      setupMockOpendir({ [root]: [mockDirent('a.md')] })
+      setupSuccessfulIngestion()
+
+      // Act
+      const { output, error } = await captureStderr(() => runIngest([root]))
+
+      // Assert: precedence warning reached stderr.
+      expect(error).toBeUndefined()
+      const joined = output.join('\n')
+      expect(joined).toContain('BASE_DIRS is set')
+      expect(joined).toContain('BASE_DIR is ignored')
+    })
+
+    it('exits non-zero with a stderr error when the resolver rejects invalid BASE_DIRS', async () => {
+      // Arrange: `resolveCliBaseDirsOrExit` exits with code 1 after printing
+      // the BASE_DIRS config error. We simulate that path with a throwing
+      // mock so the CLI's exit handling can be verified.
+      mocks.stat.mockResolvedValue(mockFileStat())
+      mocks.resolveCliBaseDirs.mockImplementation(() => {
+        console.error('BASE_DIRS must be a JSON array of non-empty path strings.')
+        throw new Error('process.exit(1)')
+      })
+
+      // Act
+      const { output, error } = await captureStderr(() => runIngest(['/tmp/test/document.md']))
+
+      // Assert: CLI propagates exit(1) and config error is visible.
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe('process.exit(1)')
+      const joined = output.join('\n')
+      expect(joined).toContain('BASE_DIRS')
+    })
+
+    it('uses cwd as the only effective root when neither CLI roots nor env vars are set', async () => {
+      // Arrange: resolver returns cwd as the only effective root (final
+      // fallback). The ingest scan walks cwd as the sole effective root.
+      const cwd = process.cwd()
+      mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [cwd] },
+        warnings: [],
+      })
+      setupMockOpendir({ [cwd]: [mockDirent('a.md')] })
+      setupSuccessfulIngestion()
+
+      // Act
+      const { output, error } = await captureStderr(() => runIngest([cwd]))
+
+      // Assert: resolver received no CLI roots; the cwd-rooted file was ingested.
+      expect(error).toBeUndefined()
+      expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([])
+      const joined = output.join('\n')
+      expect(joined).toContain('Found 1 file(s) to ingest')
+      expect(joined).toContain(resolve(cwd, 'a.md'))
+    })
+  })
 })

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -384,11 +384,7 @@ describe('CLI ingest', () => {
     expect(joined).toContain('Succeeded: 1')
   })
 
-  it('should exit 1 with a clear message when the positional path is outside all configured roots', async () => {
-    // Regression test for Finding #1: previously the CLI silently fell back
-    // to scanning every configured root when the positional path lived
-    // outside all of them. The contract is now: fail loud, exit 1, and tell
-    // the user which roots are allowed.
+  it('should exit 1 with a clear message when the positional directory is outside all configured roots', async () => {
     const rootA = resolve('/tmp/test/rootA')
     const rootB = resolve('/tmp/test/rootB')
     const outsidePath = resolve('/tmp/test/outside')
@@ -402,11 +398,9 @@ describe('CLI ingest', () => {
       runIngest(['--base-dir', rootA, '--base-dir', rootB, outsidePath])
     )
 
-    // Process exits with code 1.
     expect(error).toBeInstanceOf(Error)
     expect((error as Error).message).toBe('process.exit(1)')
 
-    // Error message names the offending path and lists the allowed roots.
     const joined = output.join('\n')
     expect(joined).toContain('not under any configured base directory')
     expect(joined).toContain(outsidePath)

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -9,10 +9,21 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 // ============================================
 
 const mocks = vi.hoisted(() => {
+  // Default base-dirs resolution: CLI roots when provided, otherwise a fixed
+  // cwd-derived stand-in. Each test can reassign `mocks.resolveCliBaseDirs`
+  // before invoking `runIngest` / `resolveConfig` to inject scenario-specific
+  // results (precedence, warnings, ...).
+  const defaultResolve = (cliRoots: string[]) => {
+    const baseDirs = cliRoots.length > 0 ? cliRoots : ['/mock/cwd/']
+    return Promise.resolve({ config: { baseDirs }, warnings: [] })
+  }
   return {
     // fs/promises
     stat: vi.fn(),
     opendir: vi.fn(),
+
+    // Shared CLI base-dirs resolver
+    resolveCliBaseDirs: vi.fn().mockImplementation(defaultResolve),
 
     // Component instances
     parseFile: vi.fn(),
@@ -80,6 +91,12 @@ const cliCommonFactory = () => ({
     optimize: mocks.optimize,
     close: vi.fn(),
   })),
+  // Mock the shared CLI base-dirs resolver to skip realpath I/O. Each test
+  // sets `mocks.resolveCliBaseDirs` to mirror the precedence under test
+  // (e.g. CLI roots replace env roots; env roots fall through to cwd).
+  resolveCliBaseDirsOrExit: vi
+    .fn()
+    .mockImplementation((cliRoots: string[]) => mocks.resolveCliBaseDirs(cliRoots)),
 })
 
 const MOCKED_PATHS = [
@@ -220,6 +237,12 @@ describe('CLI ingest', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Restore the default base-dirs resolution after vi.clearAllMocks so
+    // tests that don't customize the resolver still get a valid config.
+    mocks.resolveCliBaseDirs.mockImplementation((cliRoots: string[]) => {
+      const baseDirs = cliRoots.length > 0 ? cliRoots : ['/mock/cwd/']
+      return Promise.resolve({ config: { baseDirs }, warnings: [] })
+    })
     // Mock process.exit to throw so we can catch it
     exitSpy = vi
       .spyOn(process, 'exit')
@@ -702,11 +725,15 @@ describe('CLI ingest', () => {
       })
     )
 
-    // Assert: DocumentParser was called with ingest-specific base-dir and max-file-size
+    // Assert: DocumentParser was called with the resolved multi-root config.
+    // The CLI resolver mock echoes CLI roots verbatim, so a single
+    // --base-dir A surfaces as `baseDirs: ['/cli/base']` here. P2-T1 keeps
+    // the single-root scan path identical; only the constructor shape
+    // changes (baseDir → baseDirs).
     const { DocumentParser } = await import('../../parser/index.js')
     expect(DocumentParser).toHaveBeenCalledWith(
       expect.objectContaining({
-        baseDir: '/cli/base',
+        baseDirs: ['/cli/base'],
         maxFileSize: 555,
       })
     )
@@ -831,10 +858,26 @@ describe('CLI ingest', () => {
 
       expect(result.positional).toBe('/target')
       expect(result.options).toEqual({
-        baseDir: '/base',
+        baseDirs: ['/base'],
         maxFileSize: 1024,
       })
       expect(result.help).toBe(false)
+    })
+
+    it('should accumulate repeated --base-dir into baseDirs array in CLI order', () => {
+      const result = parseArgs(['--base-dir', '/a', '--base-dir', '/b', '/target'])
+      expect(result.positional).toBe('/target')
+      expect(result.options.baseDirs).toEqual(['/a', '/b'])
+    })
+
+    it('should leave baseDirs undefined when --base-dir is not provided', () => {
+      const result = parseArgs(['/target'])
+      expect(result.options.baseDirs).toBeUndefined()
+    })
+
+    it('should keep single --base-dir backward-compatible (array of one)', () => {
+      const result = parseArgs(['--base-dir', '/only', '/target'])
+      expect(result.options.baseDirs).toEqual(['/only'])
     })
 
     it('should parse --help flag', () => {
@@ -850,13 +893,13 @@ describe('CLI ingest', () => {
     it('should handle flags before positional', () => {
       const result = parseArgs(['--base-dir', '/base', '/target'])
       expect(result.positional).toBe('/target')
-      expect(result.options.baseDir).toBe('/base')
+      expect(result.options.baseDirs).toEqual(['/base'])
     })
 
     it('should handle flags after positional', () => {
       const result = parseArgs(['/target', '--base-dir', '/base'])
       expect(result.positional).toBe('/target')
-      expect(result.options.baseDir).toBe('/base')
+      expect(result.options.baseDirs).toEqual(['/base'])
     })
 
     it('should error on unknown flags', () => {
@@ -1026,24 +1069,35 @@ describe('CLI ingest', () => {
       delete process.env['CHUNK_MIN_LENGTH']
     })
 
-    it('should error when BASE_DIR env var points to sensitive path', () => {
+    it('should error when BASE_DIR env var points to sensitive path', async () => {
+      // After the multi-root resolver rewiring (P2-T1), env-derived
+      // sensitive-path rejection lives in `resolveCliBaseDirsOrExit` rather
+      // than in `resolveConfig` itself. The shared CLI common mock here
+      // delegates to a per-test impl, so we simulate the resolver returning
+      // a BASE_DIR-resolved root and trust the unit under test
+      // (resolveConfig) to propagate the rejection by letting the mocked
+      // resolveCliBaseDirsOrExit raise the same exit(1).
       process.env['BASE_DIR'] = '/etc/documents'
+      mocks.resolveCliBaseDirs.mockImplementation(() => {
+        console.error('Refusing to use sensitive system path for --base-dir: /etc/documents')
+        throw new Error('process.exit(1)')
+      })
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, {})).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, {})).rejects.toThrow('process.exit(1)')
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('sensitive system path'))
       } finally {
         errorSpy.mockRestore()
       }
     })
 
-    it('should error when MAX_FILE_SIZE env var is zero', () => {
+    it('should error when MAX_FILE_SIZE env var is zero', async () => {
       process.env['MAX_FILE_SIZE'] = '0'
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, {})).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, {})).rejects.toThrow('process.exit(1)')
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 524288000')
         )
@@ -1052,12 +1106,12 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should error when MAX_FILE_SIZE env var is negative', () => {
+    it('should error when MAX_FILE_SIZE env var is negative', async () => {
       process.env['MAX_FILE_SIZE'] = '-100'
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, {})).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, {})).rejects.toThrow('process.exit(1)')
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 524288000')
         )
@@ -1066,12 +1120,12 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should error when MAX_FILE_SIZE env var exceeds 500MB', () => {
+    it('should error when MAX_FILE_SIZE env var exceeds 500MB', async () => {
       process.env['MAX_FILE_SIZE'] = '999999999'
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, {})).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, {})).rejects.toThrow('process.exit(1)')
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 524288000')
         )
@@ -1080,11 +1134,11 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should error when --base-dir CLI option points to sensitive path', () => {
+    it('should error when --base-dir CLI option points to sensitive path', async () => {
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, { baseDir: '/proc/self' })).toThrow(
+        await expect(resolveConfig(globalConfig, { baseDirs: ['/proc/self'] })).rejects.toThrow(
           'process.exit(1)'
         )
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('sensitive system path'))
@@ -1093,11 +1147,13 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should error when --max-file-size CLI option is zero', () => {
+    it('should error when --max-file-size CLI option is zero', async () => {
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, { maxFileSize: 0 })).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, { maxFileSize: 0 })).rejects.toThrow(
+          'process.exit(1)'
+        )
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 524288000')
         )
@@ -1106,37 +1162,39 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should resolve chunkMinLength from CLI option', () => {
+    it('should resolve chunkMinLength from CLI option', async () => {
       const globalConfig = resolveGlobalConfig({})
-      const result = resolveConfig(globalConfig, { chunkMinLength: 200 })
+      const result = await resolveConfig(globalConfig, { chunkMinLength: 200 })
       expect(result.chunkMinLength).toBe(200)
     })
 
-    it('should resolve chunkMinLength from CHUNK_MIN_LENGTH env var', () => {
+    it('should resolve chunkMinLength from CHUNK_MIN_LENGTH env var', async () => {
       process.env['CHUNK_MIN_LENGTH'] = '300'
       const globalConfig = resolveGlobalConfig({})
-      const result = resolveConfig(globalConfig)
+      const result = await resolveConfig(globalConfig)
       expect(result.chunkMinLength).toBe(300)
     })
 
-    it('should prefer CLI chunkMinLength over env var', () => {
+    it('should prefer CLI chunkMinLength over env var', async () => {
       process.env['CHUNK_MIN_LENGTH'] = '300'
       const globalConfig = resolveGlobalConfig({})
-      const result = resolveConfig(globalConfig, { chunkMinLength: 100 })
+      const result = await resolveConfig(globalConfig, { chunkMinLength: 100 })
       expect(result.chunkMinLength).toBe(100)
     })
 
-    it('should leave chunkMinLength undefined when not specified', () => {
+    it('should leave chunkMinLength undefined when not specified', async () => {
       const globalConfig = resolveGlobalConfig({})
-      const result = resolveConfig(globalConfig)
+      const result = await resolveConfig(globalConfig)
       expect(result.chunkMinLength).toBeUndefined()
     })
 
-    it('should error when --chunk-min-length CLI option is zero', () => {
+    it('should error when --chunk-min-length CLI option is zero', async () => {
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, { chunkMinLength: 0 })).toThrow('process.exit(1)')
+        await expect(resolveConfig(globalConfig, { chunkMinLength: 0 })).rejects.toThrow(
+          'process.exit(1)'
+        )
         expect(errorSpy).toHaveBeenCalledWith(
           expect.stringContaining('must be between 1 and 10000')
         )
@@ -1145,11 +1203,11 @@ describe('CLI ingest', () => {
       }
     })
 
-    it('should error when --chunk-min-length CLI option exceeds 10000', () => {
+    it('should error when --chunk-min-length CLI option exceeds 10000', async () => {
       const globalConfig = resolveGlobalConfig({})
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {
-        expect(() => resolveConfig(globalConfig, { chunkMinLength: 10001 })).toThrow(
+        await expect(resolveConfig(globalConfig, { chunkMinLength: 10001 })).rejects.toThrow(
           'process.exit(1)'
         )
         expect(errorSpy).toHaveBeenCalledWith(

--- a/src/__tests__/cli/ingest.test.ts
+++ b/src/__tests__/cli/ingest.test.ts
@@ -302,11 +302,15 @@ describe('CLI ingest', () => {
   // Directory ingest
   // --------------------------------------------
   it('should recursively find supported files and ingest all when given a directory', async () => {
-    // Arrange: first stat call for path validation, second for collectFiles
+    // Arrange: first stat call for path validation, second for collectFiles.
+    // After P2-T2 the directory-mode scan walks every effective root in
+    // `config.baseDirs.baseDirs` rather than the positional path, so the
+    // resolver mock must echo `dirPath` as the effective root.
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat
       .mockResolvedValueOnce(mockDirStat()) // path validation in runIngest
       .mockResolvedValueOnce(mockDirStat()) // stat in collectFiles
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
       [dirPath]: [mockDirent('file1.md'), mockDirent('sub', 'directory')],
@@ -335,12 +339,154 @@ describe('CLI ingest', () => {
   })
 
   // --------------------------------------------
+  // Multi-root directory ingest (P2-T2)
+  // --------------------------------------------
+  it('should walk every effective root and aggregate files across roots', async () => {
+    // Arrange: two disjoint roots, each with one file. The resolver returns
+    // both as effective roots; the directory-mode scan walks each one and
+    // concatenates the per-root file lists.
+    const rootA = resolve('/tmp/test/rootA')
+    const rootB = resolve('/tmp/test/rootB')
+    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+
+    setupMockOpendir({
+      [rootA]: [mockDirent('a.md')],
+      [rootB]: [mockDirent('b.md')],
+    })
+    setupSuccessfulIngestion()
+
+    // Act: positional is one of the roots (or any extant path — directory
+    // mode just triggers the multi-root scan branch).
+    const { output, error } = await captureStderr(() =>
+      runIngest(['--base-dir', rootA, '--base-dir', rootB, rootA])
+    )
+
+    // Assert
+    expect(error).toBeUndefined()
+    const joined = output.join('\n')
+    expect(joined).toContain('Found 2 file(s) to ingest')
+    expect(joined).toContain(resolve(rootA, 'a.md'))
+    expect(joined).toContain(resolve(rootB, 'b.md'))
+    expect(joined).toContain('Succeeded: 2')
+  })
+
+  it('should dedup files by absolute path when roots surface the same file', async () => {
+    // Arrange: two roots that both surface the same absolute file path (the
+    // realistic scenario is a bind mount or symlink that survived nested
+    // pruning). The scan must emit the file exactly once.
+    const rootA = resolve('/tmp/test/share')
+    const rootB = resolve('/tmp/test/share') // duplicate after normalization
+    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      // Caller emulates a scenario where the resolver still hands two roots
+      // that yield the same file (e.g., symlink-equivalent realpaths that
+      // landed in the post-dedup list because they came from different
+      // user-supplied strings).
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+
+    setupMockOpendir({
+      [rootA]: [mockDirent('shared.md')],
+      [rootB]: [mockDirent('shared.md')],
+    })
+    setupSuccessfulIngestion()
+
+    // Act
+    const { output, error } = await captureStderr(() => runIngest([rootA]))
+
+    // Assert: file appears exactly once in the ingest summary
+    expect(error).toBeUndefined()
+    const joined = output.join('\n')
+    expect(joined).toContain('Found 1 file(s) to ingest')
+    expect(joined).toContain('Succeeded: 1')
+    // The progress marker [1/1] appears for the single deduped file
+    expect(joined).toContain('[1/1]')
+  })
+
+  it('should preserve dbPath and cacheDir exclusion across every root', async () => {
+    // Arrange: two roots, each containing a file that lives under the
+    // resolved dbPath / cacheDir prefix. Both should be excluded.
+    const rootA = resolve('/tmp/test/dbA')
+    const rootB = resolve('/tmp/test/dbB')
+    const dbPath = resolve('/tmp/test/dbA/lancedb')
+    const cacheDir = resolve('/tmp/test/dbB/cache')
+    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+
+    setupMockOpendir({
+      [rootA]: [mockDirent('keep.md'), mockDirent('lancedb', 'directory')],
+      [dbPath]: [mockDirent('chunks.md')], // should be excluded under rootA
+      [rootB]: [mockDirent('also-keep.md'), mockDirent('cache', 'directory')],
+      [cacheDir]: [mockDirent('model.md')], // should be excluded under rootB
+    })
+    setupSuccessfulIngestion()
+
+    // Act
+    const { output, error } = await captureStderr(() =>
+      runIngest([rootA], {
+        dbPath,
+        cacheDir,
+        modelName: 'm',
+      })
+    )
+
+    // Assert: only the two non-excluded files were ingested
+    expect(error).toBeUndefined()
+    const joined = output.join('\n')
+    expect(joined).toContain('Found 2 file(s) to ingest')
+    expect(joined).toContain('keep.md')
+    expect(joined).toContain('also-keep.md')
+    expect(joined).not.toContain('chunks.md')
+    expect(joined).not.toContain('model.md')
+  })
+
+  it('should surface nested-root pruning warnings from the resolver to stderr', async () => {
+    // Arrange: resolver returns a single effective root plus a
+    // nested-root-pruned warning describing the dropped child. The CLI must
+    // print the warning on stderr so the user sees it in the same stream
+    // as the scan output.
+    const root = resolve('/tmp/test/parent')
+    mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [root] },
+      warnings: [
+        {
+          kind: 'nested-root-pruned',
+          message: `Nested base directory pruned: ${root}/child/ is inside ${root}/. Keeping ${root}/ only.`,
+          parent: `${root}/`,
+          pruned: `${root}/child/`,
+        },
+      ],
+    })
+
+    setupMockOpendir({ [root]: [mockDirent('a.md')] })
+    setupSuccessfulIngestion()
+
+    // Act
+    const { output, error } = await captureStderr(() => runIngest([root]))
+
+    // Assert: the pruning warning appears on stderr
+    expect(error).toBeUndefined()
+    const joined = output.join('\n')
+    expect(joined).toContain('Nested base directory pruned')
+  })
+
+  // --------------------------------------------
   // Max depth limit
   // --------------------------------------------
   it('should include files within max depth and skip directories beyond it', async () => {
     // Arrange: nested directories, depth 10 directory is not entered
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     // Build a chain of 10 nested directories (depth 0..9), plus one at depth 10
     const dirMap: Record<string, ReturnType<typeof mockDirent>[]> = {
@@ -384,6 +530,7 @@ describe('CLI ingest', () => {
     // Arrange: single file at depth 9 (deepest allowed)
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     const dirMap: Record<string, ReturnType<typeof mockDirent>[]> = {
       [dirPath]: [mockDirent('d1', 'directory')],
@@ -413,6 +560,7 @@ describe('CLI ingest', () => {
     // Arrange: all files are beyond depth 10
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     // Build 10 levels of directories so depth 10 is skipped
     const dirMap: Record<string, ReturnType<typeof mockDirent>[]> = {
@@ -448,6 +596,7 @@ describe('CLI ingest', () => {
     // Arrange
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
       [dirPath]: [
@@ -478,6 +627,7 @@ describe('CLI ingest', () => {
     const restrictedPath = resolve('/tmp/test/docs/restricted')
     const subPath = resolve('/tmp/test/docs/sub')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     mocks.opendir.mockImplementation(async (path: string) => {
       if (path === restrictedPath) {
@@ -541,6 +691,7 @@ describe('CLI ingest', () => {
     // Arrange
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
       [dirPath]: [mockDirent('bad.md'), mockDirent('good.md'), mockDirent('good2.txt')],
@@ -585,6 +736,7 @@ describe('CLI ingest', () => {
     // Arrange
     const dirPath = '/tmp/test/empty'
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
       '/tmp/test/empty': [mockDirent('readme.jpg')],
@@ -628,6 +780,7 @@ describe('CLI ingest', () => {
     // Arrange
     const dirPath = resolve('/tmp/test/docs')
     mocks.stat.mockResolvedValueOnce(mockDirStat()).mockResolvedValueOnce(mockDirStat())
+    mocks.resolveCliBaseDirs.mockResolvedValue({ config: { baseDirs: [dirPath] }, warnings: [] })
 
     setupMockOpendir({
       [dirPath]: [mockDirent('a.md'), mockDirent('b.txt'), mockDirent('sub', 'directory')],

--- a/src/__tests__/cli/list.test.ts
+++ b/src/__tests__/cli/list.test.ts
@@ -91,18 +91,20 @@ function captureOutput(
 function mockDirent(
   name: string,
   parentPath: string,
-  type: 'file' | 'directory' = 'file'
+  type: 'file' | 'directory' | 'symlink' = 'file'
 ): {
   name: string
   parentPath: string
   isFile: () => boolean
   isDirectory: () => boolean
+  isSymbolicLink: () => boolean
 } {
   return {
     name,
     parentPath,
     isFile: () => type === 'file',
     isDirectory: () => type === 'directory',
+    isSymbolicLink: () => type === 'symlink',
   }
 }
 
@@ -195,10 +197,13 @@ describe('CLI list', () => {
     // Assert: no error
     expect(error).toBeUndefined()
 
-    // Assert: JSON output to stdout
+    // Assert: JSON output to stdout (multi-root-aware shape, Finding #5)
     expect(stdout.length).toBeGreaterThan(0)
     const result = JSON.parse(stdout.join(''))
     expect(result).toHaveProperty('baseDir')
+    expect(result).toHaveProperty('baseDirs')
+    expect(Array.isArray(result.baseDirs)).toBe(true)
+    expect(result.baseDir).toBe(result.baseDirs[0])
     expect(result).toHaveProperty('files')
     expect(result).toHaveProperty('sources')
 
@@ -207,11 +212,11 @@ describe('CLI list', () => {
     const docEntry = result.files.find((f: Record<string, unknown>) =>
       String(f.filePath).endsWith('doc.md')
     )
-    expect(docEntry).toMatchObject({ ingested: true, chunkCount: 3 })
+    expect(docEntry).toMatchObject({ ingested: true, chunkCount: 3, baseDir: baseDir })
     const txtEntry = result.files.find((f: Record<string, unknown>) =>
       String(f.filePath).endsWith('notes.txt')
     )
-    expect(txtEntry).toMatchObject({ ingested: false })
+    expect(txtEntry).toMatchObject({ ingested: false, baseDir: baseDir })
   })
 
   // --------------------------------------------
@@ -324,14 +329,23 @@ describe('CLI list', () => {
   // Excludes dbPath and cacheDir from scan
   // --------------------------------------------
   it('should exclude dbPath and cacheDir paths from file scan', async () => {
-    // Arrange
+    // Arrange — scanRoot now uses bounded BFS (Finding #10), so the
+    // exclude check must see a real subdirectory under the root. The
+    // `lancedb` directory and its `chunks.md` file are returned by
+    // `readdir(lancedb)`, where the join() composes a path under
+    // `resolvedDbPath` that the excludePaths prefix check rejects.
     const baseDir = process.cwd()
     const resolvedDbPath = resolve(baseDir, 'lancedb')
 
-    mocks.readdir.mockResolvedValue([
-      mockDirent('doc.md', baseDir),
-      mockDirent('chunks.md', resolvedDbPath),
-    ])
+    mocks.readdir.mockImplementation(async (path: string) => {
+      if (path === baseDir) {
+        return [mockDirent('doc.md', baseDir), mockDirent('lancedb', baseDir, 'directory')]
+      }
+      if (path === resolvedDbPath) {
+        return [mockDirent('chunks.md', resolvedDbPath)]
+      }
+      return []
+    })
     mocks.listFiles.mockResolvedValue([])
 
     // Act
@@ -396,10 +410,20 @@ describe('CLI list', () => {
     // Assert
     expect(error).toBeUndefined()
     const result = JSON.parse(stdout.join(''))
+    expect(result.baseDirs).toEqual([rootA, rootB])
     const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
     expect(filePaths).toContain(resolve(rootA, 'a.md'))
     expect(filePaths).toContain(resolve(rootB, 'b.md'))
     expect(filePaths).toHaveLength(2)
+    // Each file is annotated with its producing root (Finding #5).
+    const aEntry = result.files.find((f: Record<string, unknown>) =>
+      String(f.filePath).endsWith('a.md')
+    )
+    const bEntry = result.files.find((f: Record<string, unknown>) =>
+      String(f.filePath).endsWith('b.md')
+    )
+    expect(aEntry.baseDir).toBe(rootA)
+    expect(bEntry.baseDir).toBe(rootB)
   })
 
   it('should dedup file entries when roots surface the same absolute path', async () => {
@@ -438,9 +462,16 @@ describe('CLI list', () => {
       config: { baseDirs: [rootA, rootB] },
       warnings: [],
     })
+    // Post-Finding-#10: scanRoot now uses bounded BFS. The `lancedb`
+    // directory under rootA is returned as a child entry and walked into
+    // separately so the excludePaths prefix check actually sees a path
+    // under `dbPath`.
     mocks.readdir.mockImplementation(async (path: string) => {
       if (path === rootA) {
-        return [mockDirent('keep.md', rootA), mockDirent('chunks.md', dbPath)]
+        return [mockDirent('keep.md', rootA), mockDirent('lancedb', rootA, 'directory')]
+      }
+      if (path === dbPath) {
+        return [mockDirent('chunks.md', dbPath)]
       }
       if (path === rootB) {
         return [mockDirent('also-keep.md', rootB)]
@@ -465,6 +496,85 @@ describe('CLI list', () => {
     expect(filePaths).toContain(resolve(rootA, 'keep.md'))
     expect(filePaths).toContain(resolve(rootB, 'also-keep.md'))
     expect(filePaths.some((p: string) => p.includes('chunks.md'))).toBe(false)
+  })
+
+  it('should keep listing other roots when one root readdir errors (Finding #10)', async () => {
+    // Per-root error tolerance: an EACCES under rootA must not hide files
+    // under rootB. The CLI prints a per-root warning to stderr and continues.
+    mocks.initialize.mockResolvedValue(undefined)
+    const rootA = resolve('/tmp/list/inaccessible')
+    const rootB = resolve('/tmp/list/accessible')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+    mocks.readdir.mockImplementation(async (path: string) => {
+      if (path === rootA) {
+        const err = new Error('EACCES: permission denied, scandir') as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      if (path === rootB) return [mockDirent('survives.md', rootB)]
+      return []
+    })
+    mocks.listFiles.mockResolvedValue([])
+
+    const { stdout, stderr, error } = await captureOutput(() =>
+      runList(['--base-dir', rootA, '--base-dir', rootB])
+    )
+
+    expect(error).toBeUndefined()
+    // rootB's file is still listed.
+    const result = JSON.parse(stdout.join(''))
+    const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+    expect(filePaths).toContain(resolve(rootB, 'survives.md'))
+    // Per-root warning was surfaced on stderr.
+    const joined = stderr.join('\n')
+    expect(joined).toContain(`Warning [${rootA}]: cannot read directory`)
+    expect(joined).toContain('EACCES')
+    // Do not leak the raw OS error message into the warning content.
+    expect(joined).not.toContain('permission denied, scandir')
+  })
+
+  it('should stop scanning a root at MAX_DEPTH=10 and emit a depth warning (Finding #10)', async () => {
+    // Build a chain of 11 nested directories. The BFS must skip depth 10
+    // and produce a warning, but the file at depth 9 must still appear.
+    mocks.initialize.mockResolvedValue(undefined)
+    const root = resolve('/tmp/list/deep')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [root] },
+      warnings: [],
+    })
+
+    const dirMap: Record<string, ReturnType<typeof mockDirent>[]> = {
+      [root]: [mockDirent('d1', root, 'directory')],
+    }
+    let current = root
+    for (let i = 1; i <= 10; i++) {
+      const next = resolve(`${current}/d${i}`)
+      // Depth 9 contains a markdown file (within MAX_DEPTH); depths above
+      // continue chaining so depth 10 entry remains a directory that must
+      // be SKIPPED with a depth warning.
+      if (i === 9) {
+        dirMap[next] = [mockDirent('boundary.md', next), mockDirent(`d${i + 1}`, next, 'directory')]
+      } else if (i < 10) {
+        dirMap[next] = [mockDirent(`d${i + 1}`, next, 'directory')]
+      }
+      current = next
+    }
+    mocks.readdir.mockImplementation(async (path: string) => dirMap[path] ?? [])
+    mocks.listFiles.mockResolvedValue([])
+
+    const { stdout, stderr, error } = await captureOutput(() => runList(['--base-dir', root]))
+
+    expect(error).toBeUndefined()
+    const result = JSON.parse(stdout.join(''))
+    const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+    // The depth-9 file is present (within MAX_DEPTH=10).
+    expect(filePaths.some((p: string) => p.endsWith('boundary.md'))).toBe(true)
+    // The depth warning reached stderr.
+    const joined = stderr.join('\n')
+    expect(joined).toContain('maximum depth')
   })
 
   it('should surface nested-root pruning warnings from the resolver to stderr', async () => {

--- a/src/__tests__/cli/list.test.ts
+++ b/src/__tests__/cli/list.test.ts
@@ -563,4 +563,164 @@ describe('CLI list', () => {
       }
     })
   })
+
+  // --------------------------------------------
+  // P2-T3: CLI multi-root precedence / fallback / config-error matrix
+  //
+  // These tests assert the boundary contract between `runList` and the shared
+  // `resolveCliBaseDirsOrExit` helper. They drive each scenario from the
+  // resolver mock (env vars, warnings, error path) rather than touching the
+  // real env / filesystem so the cases remain deterministic and isolated.
+  // --------------------------------------------
+  describe('multi-root precedence (P2-T3)', () => {
+    it('passes CLI roots verbatim to the resolver and suppresses any env precedence warning', async () => {
+      // Arrange: both env vars set, but CLI provides roots. The resolver
+      // contract is "CLI replaces env, no precedence warning even if env vars
+      // are also set". The CLI must (a) hand the CLI roots to the resolver and
+      // (b) NOT print a `base-dirs-overrides-base-dir` message — the resolver
+      // is the single source of truth for that warning.
+      mocks.initialize.mockResolvedValue(undefined)
+      process.env['BASE_DIR'] = '/env/single'
+      process.env['BASE_DIRS'] = '["/env/multi/a","/env/multi/b"]'
+      const cliRootA = resolve('/cli/precedence/a')
+      const cliRootB = resolve('/cli/precedence/b')
+      // Resolver behaves like the real one: CLI overrides env, no warnings.
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [cliRootA, cliRootB] },
+        warnings: [],
+      })
+      mocks.readdir.mockResolvedValue([])
+      mocks.listFiles.mockResolvedValue([])
+
+      try {
+        // Act
+        const { stderr, error } = await captureOutput(() =>
+          runList(['--base-dir', cliRootA, '--base-dir', cliRootB])
+        )
+
+        // Assert: resolver received the CLI roots verbatim and in order.
+        expect(error).toBeUndefined()
+        expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([cliRootA, cliRootB])
+
+        // Assert: no precedence warning surfaced to stderr (CLI overrides env).
+        const joined = stderr.join('\n')
+        expect(joined).not.toContain('BASE_DIRS is set')
+        expect(joined).not.toContain('BASE_DIR is ignored')
+      } finally {
+        delete process.env['BASE_DIR']
+        delete process.env['BASE_DIRS']
+      }
+    })
+
+    it('uses BASE_DIRS fallback (multi-root) when no --base-dir is provided', async () => {
+      // Arrange: no CLI roots; resolver yields the BASE_DIRS-driven multi-root
+      // result. The CLI call site MUST forward an empty `cliRoots` array
+      // (signaling "no CLI override") so the resolver applies env precedence.
+      mocks.initialize.mockResolvedValue(undefined)
+      const envRootA = resolve('/env/multi/a')
+      const envRootB = resolve('/env/multi/b')
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [envRootA, envRootB] },
+        warnings: [],
+      })
+      mocks.readdir.mockImplementation(async (path: string) => {
+        if (path === envRootA) return [mockDirent('a.md', envRootA)]
+        if (path === envRootB) return [mockDirent('b.md', envRootB)]
+        return []
+      })
+      mocks.listFiles.mockResolvedValue([])
+
+      // Act
+      const { stdout, stderr, error } = await captureOutput(() => runList([]))
+
+      // Assert: resolver invoked with empty CLI roots (env path triggers).
+      expect(error).toBeUndefined()
+      expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([])
+
+      // Assert: both roots were scanned and aggregated in the output.
+      const result = JSON.parse(stdout.join(''))
+      const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+      expect(filePaths).toContain(resolve(envRootA, 'a.md'))
+      expect(filePaths).toContain(resolve(envRootB, 'b.md'))
+
+      // Assert: no warnings surfaced because the resolver returned none.
+      expect(stderr.join('\n')).not.toMatch(/BASE_DIRS|BASE_DIR/)
+    })
+
+    it('surfaces BASE_DIRS > BASE_DIR precedence warning on stderr (no CLI roots)', async () => {
+      // Arrange: resolver attaches `base-dirs-overrides-base-dir` because both
+      // BASE_DIRS and BASE_DIR are set with no CLI override. The CLI must
+      // print the warning message to stderr.
+      mocks.initialize.mockResolvedValue(undefined)
+      const root = resolve('/env/multi/only')
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [root] },
+        warnings: [
+          {
+            kind: 'base-dirs-overrides-base-dir',
+            message:
+              'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.',
+          },
+        ],
+      })
+      mocks.readdir.mockResolvedValue([])
+      mocks.listFiles.mockResolvedValue([])
+
+      // Act
+      const { stderr, error } = await captureOutput(() => runList([]))
+
+      // Assert: precedence message reached stderr.
+      expect(error).toBeUndefined()
+      const joined = stderr.join('\n')
+      expect(joined).toContain('BASE_DIRS is set')
+      expect(joined).toContain('BASE_DIR is ignored')
+    })
+
+    it('exits non-zero with a stderr error when the resolver rejects invalid BASE_DIRS', async () => {
+      // Arrange: `resolveCliBaseDirsOrExit` itself calls process.exit(1) after
+      // printing the config error to stderr (see common.ts). We simulate
+      // that path by making the mock throw `process.exit(1)` and writing the
+      // error message to stderr first, mirroring production behavior.
+      mocks.initialize.mockResolvedValue(undefined)
+      mocks.resolveCliBaseDirs.mockImplementation(() => {
+        console.error(
+          'BASE_DIRS must be a JSON array of non-empty path strings. Failed to parse as JSON: not-json'
+        )
+        throw new Error('process.exit(1)')
+      })
+
+      // Act
+      const { stderr, error } = await captureOutput(() => runList([]))
+
+      // Assert: CLI propagates exit(1) and the config error is visible.
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe('process.exit(1)')
+      const joined = stderr.join('\n')
+      expect(joined).toContain('BASE_DIRS')
+      expect(joined).toContain('JSON')
+    })
+
+    it('uses cwd as the only effective root when neither CLI roots nor env vars are set', async () => {
+      // Arrange: resolver returns cwd as the only effective root (matches the
+      // resolver's final fallback rule). No warnings expected.
+      mocks.initialize.mockResolvedValue(undefined)
+      const cwd = process.cwd()
+      mocks.resolveCliBaseDirs.mockResolvedValue({
+        config: { baseDirs: [cwd] },
+        warnings: [],
+      })
+      mocks.readdir.mockResolvedValue([])
+      mocks.listFiles.mockResolvedValue([])
+
+      // Act
+      const { stdout, stderr, error } = await captureOutput(() => runList([]))
+
+      // Assert: baseDir in JSON output is cwd; resolver called with no CLI roots.
+      expect(error).toBeUndefined()
+      expect(mocks.resolveCliBaseDirs).toHaveBeenCalledWith([])
+      const result = JSON.parse(stdout.join(''))
+      expect(result.baseDir).toBe(cwd)
+      expect(stderr.join('\n')).not.toMatch(/BASE_DIRS|BASE_DIR/)
+    })
+  })
 })

--- a/src/__tests__/cli/list.test.ts
+++ b/src/__tests__/cli/list.test.ts
@@ -16,6 +16,11 @@ const mocks = vi.hoisted(() => {
     // VectorStore instance methods
     initialize: vi.fn().mockResolvedValue(undefined),
     listFiles: vi.fn().mockResolvedValue([]),
+
+    // Shared CLI base-dirs resolver. Per-test impls can mirror precedence
+    // (CLI roots replace env roots, env falls through to cwd) or simulate
+    // resolver errors.
+    resolveCliBaseDirs: vi.fn(),
   }
 })
 
@@ -37,6 +42,9 @@ const cliCommonFactory = () => ({
     initialize: mocks.initialize,
     listFiles: mocks.listFiles,
   })),
+  resolveCliBaseDirsOrExit: vi
+    .fn()
+    .mockImplementation((cliRoots: string[]) => mocks.resolveCliBaseDirs(cliRoots)),
 })
 
 const MOCKED_PATHS = ['node:fs/promises', '../../cli/common.js'] as const
@@ -119,6 +127,14 @@ describe('CLI list', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default resolver impl: CLI roots when provided, otherwise the
+    // BASE_DIR env value if set (so existing precedence tests continue to
+    // verify CLI > env), otherwise cwd. Per-test impls can override before
+    // calling `runList`.
+    mocks.resolveCliBaseDirs.mockImplementation((cliRoots: string[]) => {
+      const first = cliRoots[0] ?? process.env['BASE_DIR'] ?? process.cwd()
+      return Promise.resolve({ config: { baseDirs: [first] }, warnings: [] })
+    })
     exitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((code?: number | string | null | undefined) => {
@@ -358,7 +374,22 @@ describe('CLI list', () => {
 
     it('should parse --base-dir flag', () => {
       const result = parseArgs(['--base-dir', '/my/docs'])
-      expect(result).toEqual({ options: { baseDir: '/my/docs' }, help: false })
+      expect(result).toEqual({ options: { baseDirs: ['/my/docs'] }, help: false })
+    })
+
+    it('should accumulate repeated --base-dir into baseDirs array in CLI order', () => {
+      const result = parseArgs(['--base-dir', '/a', '--base-dir', '/b'])
+      expect(result.options.baseDirs).toEqual(['/a', '/b'])
+    })
+
+    it('should leave baseDirs undefined when --base-dir is not provided', () => {
+      const result = parseArgs([])
+      expect(result.options.baseDirs).toBeUndefined()
+    })
+
+    it('should keep single --base-dir backward-compatible (array of one)', () => {
+      const result = parseArgs(['--base-dir', '/only'])
+      expect(result.options.baseDirs).toEqual(['/only'])
     })
 
     it('should parse --help flag', () => {

--- a/src/__tests__/cli/list.test.ts
+++ b/src/__tests__/cli/list.test.ts
@@ -364,6 +364,139 @@ describe('CLI list', () => {
   })
 
   // --------------------------------------------
+  // Multi-root scan (P2-T2)
+  // --------------------------------------------
+  it('should walk every effective root and aggregate files across roots', async () => {
+    // Arrange: two disjoint effective roots, each contributing one file.
+    // Reset `initialize` because the preceding error-handling test leaves a
+    // rejection installed and `vi.clearAllMocks()` does not reset
+    // `mockRejectedValue` (only call history). Same for the other multi-root
+    // tests below.
+    mocks.initialize.mockResolvedValue(undefined)
+    const rootA = resolve('/tmp/list/rootA')
+    const rootB = resolve('/tmp/list/rootB')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+    // readdir is called once per root; mock matches the requested path so
+    // the per-root file lists do not bleed across roots.
+    mocks.readdir.mockImplementation(async (path: string) => {
+      if (path === rootA) return [mockDirent('a.md', rootA)]
+      if (path === rootB) return [mockDirent('b.md', rootB)]
+      return []
+    })
+    mocks.listFiles.mockResolvedValue([])
+
+    // Act
+    const { stdout, error } = await captureOutput(() =>
+      runList(['--base-dir', rootA, '--base-dir', rootB])
+    )
+
+    // Assert
+    expect(error).toBeUndefined()
+    const result = JSON.parse(stdout.join(''))
+    const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+    expect(filePaths).toContain(resolve(rootA, 'a.md'))
+    expect(filePaths).toContain(resolve(rootB, 'b.md'))
+    expect(filePaths).toHaveLength(2)
+  })
+
+  it('should dedup file entries when roots surface the same absolute path', async () => {
+    // Arrange: two roots, each yielding the same file path (overlap that
+    // survived nested-root pruning — e.g. symlink-equivalent realpaths).
+    // The list output must contain the file exactly once.
+    mocks.initialize.mockResolvedValue(undefined)
+    const rootA = resolve('/tmp/list/share')
+    const rootB = resolve('/tmp/list/share') // duplicate after normalization
+    const sharedPath = resolve(rootA, 'shared.md')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+    mocks.readdir.mockImplementation(async () => [mockDirent('shared.md', rootA)])
+    mocks.listFiles.mockResolvedValue([])
+
+    // Act
+    const { stdout, error } = await captureOutput(() => runList(['--base-dir', rootA]))
+
+    // Assert: file appears once
+    expect(error).toBeUndefined()
+    const result = JSON.parse(stdout.join(''))
+    const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+    expect(filePaths.filter((p: string) => p === sharedPath)).toHaveLength(1)
+  })
+
+  it('should preserve dbPath and cacheDir exclusion across all roots', async () => {
+    // Arrange: two roots, each containing a file under the global
+    // dbPath/cacheDir path. Both must be excluded.
+    mocks.initialize.mockResolvedValue(undefined)
+    const rootA = resolve('/tmp/list/dbA')
+    const rootB = resolve('/tmp/list/dbB')
+    const dbPath = resolve('/tmp/list/dbA/lancedb')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [rootA, rootB] },
+      warnings: [],
+    })
+    mocks.readdir.mockImplementation(async (path: string) => {
+      if (path === rootA) {
+        return [mockDirent('keep.md', rootA), mockDirent('chunks.md', dbPath)]
+      }
+      if (path === rootB) {
+        return [mockDirent('also-keep.md', rootB)]
+      }
+      return []
+    })
+    mocks.listFiles.mockResolvedValue([])
+
+    // Act
+    const { stdout, error } = await captureOutput(() =>
+      runList(['--base-dir', rootA, '--base-dir', rootB], {
+        dbPath,
+        cacheDir: '/tmp/list/cache',
+        modelName: 'm',
+      })
+    )
+
+    // Assert: only the two non-excluded files were listed
+    expect(error).toBeUndefined()
+    const result = JSON.parse(stdout.join(''))
+    const filePaths = result.files.map((f: Record<string, unknown>) => f.filePath)
+    expect(filePaths).toContain(resolve(rootA, 'keep.md'))
+    expect(filePaths).toContain(resolve(rootB, 'also-keep.md'))
+    expect(filePaths.some((p: string) => p.includes('chunks.md'))).toBe(false)
+  })
+
+  it('should surface nested-root pruning warnings from the resolver to stderr', async () => {
+    // Arrange: resolver returns a single effective root plus a pruning
+    // warning. The CLI prints warnings on stderr so the JSON stdout
+    // contract stays clean.
+    mocks.initialize.mockResolvedValue(undefined)
+    const root = resolve('/tmp/list/parent')
+    mocks.resolveCliBaseDirs.mockResolvedValue({
+      config: { baseDirs: [root] },
+      warnings: [
+        {
+          kind: 'nested-root-pruned',
+          message: `Nested base directory pruned: ${root}/child/ is inside ${root}/. Keeping ${root}/ only.`,
+          parent: `${root}/`,
+          pruned: `${root}/child/`,
+        },
+      ],
+    })
+    mocks.readdir.mockResolvedValue([])
+    mocks.listFiles.mockResolvedValue([])
+
+    // Act
+    const { stderr, error } = await captureOutput(() => runList([]))
+
+    // Assert: warning appears on stderr
+    expect(error).toBeUndefined()
+    const joined = stderr.join('\n')
+    expect(joined).toContain('Nested base directory pruned')
+  })
+
+  // --------------------------------------------
   // parseArgs unit tests
   // --------------------------------------------
   describe('parseArgs', () => {

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -34,8 +34,15 @@ const cliCommonFactory = () => ({
   })),
 })
 
+// NOTE: the mock factory below mirrors the NEW raw-data-utils contract.
+// `looksLikeRawDataPath` is the display-only heuristic CLI query uses; the
+// boundary check `isPathInRawDataDir` is exported for parity but unused by
+// the query subcommand (no path traversal surface).
 const rawDataUtilsFactory = () => ({
-  isRawDataPath: vi.fn().mockImplementation((filePath: string) => filePath.includes('/raw-data/')),
+  looksLikeRawDataPath: vi
+    .fn()
+    .mockImplementation((filePath: string) => filePath.includes('/raw-data/')),
+  isPathInRawDataDir: vi.fn().mockResolvedValue(false),
   extractSourceFromPath: vi.fn().mockImplementation((filePath: string) => {
     if (!filePath.includes('/raw-data/')) return null
     return 'https://example.com/page'

--- a/src/__tests__/server/config-warnings.test.ts
+++ b/src/__tests__/server/config-warnings.test.ts
@@ -268,7 +268,11 @@ describe('Config warning delivery via MCP annotations', () => {
       await server.initialize()
     })
 
-    it('includes warnings on first query call only', async () => {
+    // AC-009 (P3-T3): config warnings must appear in every MCP tool response,
+    // not only the first. MCP clients may hide stderr and may not retain
+    // content across tool calls, so the previous "first call only" gate was
+    // removed when warning attachment was centralized in `withWarnings`.
+    it('includes warnings on every query call (AC-009)', async () => {
       const result1 = await server.handleQueryDocuments({ query: 'test' })
       expect(result1.content.length).toBe(2)
       expect(result1.content[1]?.text).toContain('Warning:')
@@ -278,7 +282,12 @@ describe('Config warning delivery via MCP annotations', () => {
       })
 
       const result2 = await server.handleQueryDocuments({ query: 'test again' })
-      expect(result2.content.length).toBe(1)
+      expect(result2.content.length).toBe(2)
+      expect(result2.content[1]?.text).toContain('Warning:')
+      expect(result2.content[1]?.annotations).toEqual({
+        audience: ['user', 'assistant'],
+        priority: 0.3,
+      })
     })
   })
 

--- a/src/__tests__/server/raw-data-utils.test.ts
+++ b/src/__tests__/server/raw-data-utils.test.ts
@@ -1,8 +1,8 @@
 // Raw Data Utilities Test
 // Test Type: Unit Test
 
-import { mkdir, readFile, rm } from 'node:fs/promises'
-import { join, sep } from 'node:path'
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import {
@@ -12,7 +12,8 @@ import {
   formatToExtension,
   generateRawDataPath,
   getRawDataDir,
-  isRawDataPath,
+  isPathInRawDataDir,
+  looksLikeRawDataPath,
   normalizeSource,
   saveRawData,
 } from '../../utils/raw-data-utils.js'
@@ -232,15 +233,85 @@ describe('Raw Data Utilities', () => {
   // --------------------------------------------
   // Path Detection
   // --------------------------------------------
-  describe('Path Detection', () => {
-    it('isRawDataPath returns true for raw-data paths', () => {
-      expect(isRawDataPath('/path/to/lancedb/raw-data/abc123.html')).toBe(true)
-      expect(isRawDataPath('./lancedb/raw-data/xyz.txt')).toBe(true)
+  describe('Path Detection (display heuristic)', () => {
+    it('looksLikeRawDataPath returns true for raw-data paths', () => {
+      expect(looksLikeRawDataPath('/path/to/lancedb/raw-data/abc123.html')).toBe(true)
+      expect(looksLikeRawDataPath('./lancedb/raw-data/xyz.txt')).toBe(true)
     })
 
-    it('isRawDataPath returns false for non-raw-data paths', () => {
-      expect(isRawDataPath('/path/to/documents/file.pdf')).toBe(false)
-      expect(isRawDataPath('/home/user/raw-data-backup/file.txt')).toBe(false)
+    it('looksLikeRawDataPath returns false for non-raw-data paths', () => {
+      expect(looksLikeRawDataPath('/path/to/documents/file.pdf')).toBe(false)
+      expect(looksLikeRawDataPath('/home/user/raw-data-backup/file.txt')).toBe(false)
+    })
+  })
+
+  // --------------------------------------------
+  // Boundary Containment (security)
+  // --------------------------------------------
+  describe('isPathInRawDataDir (security boundary)', () => {
+    const boundaryDbPath = resolve('./tmp/test-raw-data-db-boundary')
+    const boundaryRawDir = `${boundaryDbPath}${sep}raw-data`
+    const outsideFile = resolve('./tmp/test-raw-data-db-boundary-outside.txt')
+    const symlinkEscape = `${boundaryRawDir}${sep}escape.md`
+    const realFile = `${boundaryRawDir}${sep}real.md`
+    const nestedFile = `${boundaryRawDir}${sep}sub${sep}deep${sep}file.md`
+
+    beforeAll(async () => {
+      await mkdir(`${boundaryRawDir}${sep}sub${sep}deep`, { recursive: true })
+      await writeFile(realFile, 'real')
+      await writeFile(nestedFile, 'nested')
+      await writeFile(outsideFile, 'secret')
+      await symlink(outsideFile, symlinkEscape)
+    })
+
+    afterAll(async () => {
+      await rm(boundaryDbPath, { recursive: true, force: true })
+      await rm(outsideFile, { force: true })
+    })
+
+    it('accepts a real raw-data file inside the configured dbPath', async () => {
+      await expect(isPathInRawDataDir(realFile, boundaryDbPath)).resolves.toBe(true)
+    })
+
+    it('rejects a traversal payload that escapes the raw-data dir', async () => {
+      const evil = `${boundaryDbPath}/raw-data/../../../etc/passwd`
+      await expect(isPathInRawDataDir(evil, boundaryDbPath)).resolves.toBe(false)
+    })
+
+    it('rejects a path matching the directory name but a different dbPath', async () => {
+      await expect(isPathInRawDataDir('/other/db/raw-data/abc.md', boundaryDbPath)).resolves.toBe(
+        false
+      )
+    })
+
+    it('rejects sibling-prefix paths', async () => {
+      const sibling = `${boundaryDbPath}/raw-data-backup/foo.md`
+      await expect(isPathInRawDataDir(sibling, boundaryDbPath)).resolves.toBe(false)
+    })
+
+    it('accepts the raw-data directory itself', async () => {
+      await expect(isPathInRawDataDir(getRawDataDir(boundaryDbPath), boundaryDbPath)).resolves.toBe(
+        true
+      )
+    })
+
+    it('accepts nested children of the raw-data directory', async () => {
+      await expect(isPathInRawDataDir(nestedFile, boundaryDbPath)).resolves.toBe(true)
+    })
+
+    it('rejects a symlink under raw-data that resolves outside the directory', async () => {
+      // Lexical containment passes (the symlink path string is under raw-data),
+      // so without realpath this would be a false positive. realpath collapses
+      // the symlink to the outside target which is no longer contained.
+      await expect(isPathInRawDataDir(symlinkEscape, boundaryDbPath)).resolves.toBe(false)
+    })
+
+    it('treats matching paths case-insensitively on win32', async () => {
+      // Skip on POSIX where the filesystem is case-sensitive — the lexical
+      // comparison stays strict there, matching FS semantics.
+      if (process.platform !== 'win32') return
+      const mixed = realFile.toUpperCase()
+      await expect(isPathInRawDataDir(mixed, boundaryDbPath)).resolves.toBe(true)
     })
   })
 

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -5,8 +5,10 @@ import { Embedder } from '../embedder/index.js'
 import {
   type BaseDirsConfig,
   type BaseDirsConfigWarning,
+  parseBaseDirsEnv,
   resolveBaseDirs,
 } from '../utils/base-dirs.js'
+import { checkSensitivePath } from '../utils/sensitive-path.js'
 import { VectorStore } from '../vectordb/index.js'
 import { type ResolvedGlobalConfig, resolveDevice, validatePath } from './options.js'
 
@@ -71,6 +73,31 @@ export interface CliBaseDirsResolution {
  * to keep stderr clean even when warnings are present).
  */
 export async function resolveCliBaseDirsOrExit(cliRoots: string[]): Promise<CliBaseDirsResolution> {
+  // Screen the raw env-supplied paths before the resolver realpath-
+  // normalizes them, so a literal `BASE_DIR=/etc` is rejected with the
+  // env var as the attribution surface.
+  if (cliRoots.length === 0) {
+    if (process.env['BASE_DIRS'] !== undefined && process.env['BASE_DIRS'].length > 0) {
+      const parsed = parseBaseDirsEnv(process.env['BASE_DIRS'])
+      if (parsed.ok) {
+        for (const raw of parsed.value) {
+          const sensitive = checkSensitivePath(raw, 'BASE_DIRS')
+          if (sensitive) {
+            console.error(sensitive)
+            process.exit(1)
+          }
+        }
+      }
+      // Malformed BASE_DIRS surfaces below via resolveBaseDirs.
+    } else if (process.env['BASE_DIR'] !== undefined && process.env['BASE_DIR'].trim().length > 0) {
+      const sensitive = checkSensitivePath(process.env['BASE_DIR'], 'BASE_DIR')
+      if (sensitive) {
+        console.error(sensitive)
+        process.exit(1)
+      }
+    }
+  }
+
   const result = await resolveBaseDirs({
     cliRoots,
     envBaseDirs: process.env['BASE_DIRS'],

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -1,8 +1,14 @@
 // Shared CLI component helpers — factory functions for VectorStore and Embedder
+// plus base-directory resolution shared by every subcommand that scans files.
 
 import { Embedder } from '../embedder/index.js'
+import {
+  type BaseDirsConfig,
+  type BaseDirsConfigWarning,
+  resolveBaseDirs,
+} from '../utils/base-dirs.js'
 import { VectorStore } from '../vectordb/index.js'
-import { type ResolvedGlobalConfig, resolveDevice } from './options.js'
+import { type ResolvedGlobalConfig, resolveDevice, validatePath } from './options.js'
 
 /**
  * Create an uninitialized VectorStore from resolved global config.
@@ -26,4 +32,70 @@ export function createEmbedder(config: ResolvedGlobalConfig): Embedder {
     cacheDir: config.cacheDir,
     device: resolveDevice(process.env['RAG_DEVICE']),
   })
+}
+
+/**
+ * Result of {@link resolveCliBaseDirsOrExit}. Resolution warnings travel with
+ * the config so subcommands can render them per their own UI contract (CLI
+ * subcommands generally write them to stderr).
+ */
+export interface CliBaseDirsResolution {
+  config: BaseDirsConfig
+  warnings: BaseDirsConfigWarning[]
+}
+
+/**
+ * Resolve effective base directories for a CLI subcommand using the shared
+ * resolver, surfacing any configuration error as a process-level failure.
+ *
+ * Inputs (single source of truth for CLI precedence — kept here so per-
+ * subcommand entry points don't each replicate the env-fallback chain):
+ *  - `cliRoots`: repeated `--base-dir` flag values in CLI order. When non-
+ *    empty, REPLACES env roots — no merge.
+ *  - `process.env['BASE_DIRS']`: JSON array, used only when CLI roots are
+ *    absent.
+ *  - `process.env['BASE_DIR']`: single path, used only when CLI roots and
+ *    `BASE_DIRS` are absent.
+ *  - `process.cwd()`: final fallback.
+ *
+ * Failure mode: a `BaseDirsConfigError` (invalid `BASE_DIRS` JSON, missing
+ * directory, not-a-directory, ...) is reported to stderr and exits with
+ * code 1. This is intentional: the resolver explicitly does NOT fall back
+ * (see §Technical Decisions → Resolution order in the multi-base-dirs
+ * plan), so CLI consumers should fail fast rather than silently degrading
+ * to `cwd`.
+ *
+ * Warnings (`base-dirs-overrides-base-dir`, `nested-root-pruned`) are
+ * returned to the caller rather than written here, so each subcommand can
+ * decide its own rendering (JSON-output subcommands like `list` may need
+ * to keep stderr clean even when warnings are present).
+ */
+export async function resolveCliBaseDirsOrExit(cliRoots: string[]): Promise<CliBaseDirsResolution> {
+  const result = await resolveBaseDirs({
+    cliRoots,
+    envBaseDirs: process.env['BASE_DIRS'],
+    envBaseDir: process.env['BASE_DIR'],
+    cwd: process.cwd(),
+  })
+
+  if (!result.ok) {
+    console.error(result.error.message)
+    process.exit(1)
+  }
+
+  // Apply the sensitive-path policy uniformly to every effective root
+  // (CLI, env, or cwd). Pre-multi-root code validated `BASE_DIR` here; the
+  // same policy must continue to apply to `BASE_DIRS` entries and to CLI
+  // roots that pre-validation in the subcommand may have missed (e.g.
+  // realpath-resolved targets of symlinks). Reported under `--base-dir`
+  // because that is the flag the user most directly controls.
+  for (const root of result.config.baseDirs) {
+    const sensitive = validatePath(root, '--base-dir')
+    if (sensitive) {
+      console.error(sensitive)
+      process.exit(1)
+    }
+  }
+
+  return { config: result.config, warnings: result.warnings }
 }

--- a/src/cli/delete.ts
+++ b/src/cli/delete.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path'
 import {
   generateMetaJsonPath,
   generateRawDataPath,
-  isRawDataPath,
+  isPathInRawDataDirLexical,
 } from '../utils/raw-data-utils.js'
 import { createVectorStore } from './common.js'
 import type { GlobalOptions } from './options.js'
@@ -148,8 +148,8 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
     // Delete chunks from VectorStore
     await vectorStore.deleteChunks(targetPath)
 
-    // Clean up physical raw-data files if applicable
-    if (isRawDataPath(targetPath)) {
+    // Clean up physical raw-data files if applicable.
+    if (isPathInRawDataDirLexical(targetPath, globalConfig.dbPath)) {
       try {
         await unlink(targetPath)
       } catch (error: unknown) {

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -1,7 +1,7 @@
 // CLI ingest subcommand — bulk file ingestion with single optimize() at end
 
 import { randomUUID } from 'node:crypto'
-import { opendir, stat } from 'node:fs/promises'
+import { opendir, realpath, stat } from 'node:fs/promises'
 import { basename, extname, join, resolve, sep } from 'node:path'
 
 import { SemanticChunker } from '../chunker/index.js'
@@ -328,7 +328,10 @@ async function walkDirectory(
     for await (const entry of dir) {
       const fullPath = join(dirPath, entry.name)
 
-      if (!fullPath.startsWith(rootPath)) continue
+      // `join(dirPath, entry.name)` always produces a path under `dirPath`,
+      // which itself stays under `rootPath` because the BFS only enqueues
+      // descendants of `rootPath`. We therefore do not need a per-entry
+      // `startsWith(rootPath)` re-check here.
       if (entry.isSymbolicLink()) continue
       if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
 
@@ -349,23 +352,21 @@ async function walkDirectory(
  * Two modes:
  *  - **Single-file mode**: `targetPath` resolves to a regular file. Returns
  *    `[resolved]` when the extension is supported, otherwise the empty array
- *    (after warning on stderr). Single-file mode ignores `baseDirs` because
- *    the parser still validates the file path against the configured roots —
- *    this preserves the pre-P2-T2 behavior for users who pass an explicit
- *    file path to ingest.
- *  - **Directory mode**: `targetPath` resolves to a directory. Walks EVERY
- *    effective root in `baseDirs` (not `targetPath`) using {@link walkDirectory},
- *    aggregates the per-root file lists, and deduplicates by absolute path so
- *    overlap that survived nested-root pruning (e.g. symlinks pointing into
- *    multiple roots) does not produce duplicate ingest activity. Sorted for
- *    deterministic ingest order.
+ *    (after warning on stderr). The parser still validates the file path
+ *    against the configured roots, so a file outside all roots is rejected
+ *    downstream.
+ *  - **Directory mode**: `targetPath` resolves to a directory. Walks only the
+ *    positional directory `resolved` using {@link walkDirectory}. The multi-
+ *    root configuration is the SECURITY boundary (passed to the parser via
+ *    `DocumentParser.validateFilePath`), not a replacement for the user's
+ *    scan target. `resolved` must live under one of the configured roots
+ *    after realpath normalization; otherwise we fail loud with a clear
+ *    message rather than scanning every configured root (which was the
+ *    pre-Finding-#1 behavior and broke the `ingest <dir>` contract).
  *
- * Why iterate `baseDirs` rather than `targetPath` in directory mode: the
- * multi-base-dirs plan (§ Phase 2 completion criteria, AC-008/AC-011/AC-012)
- * makes the configured roots the security AND scan boundary. A directory
- * positional with multiple `--base-dir` flags scans across all roots, not
- * only the positional directory. Users who want to ingest a single subtree
- * can pass it via `--base-dir` or use the single-file mode.
+ * Sibling-prefix safety: the `startsWith(root)` check uses `baseDirs`
+ * entries with their realpath-normalized trailing separator, so
+ * `/foo/barista` does not match root `/foo/bar/`.
  */
 async function collectFiles(
   targetPath: string,
@@ -387,16 +388,37 @@ async function collectFiles(
   }
 
   if (info.isDirectory()) {
-    const state = { depthLimited: false }
-    const collected: string[] = []
-    for (const root of baseDirs) {
-      // `baseDirs` entries from `resolveCliBaseDirsOrExit` already carry a
-      // trailing separator (realpath-normalized). `walkDirectory`'s
-      // `startsWith(rootPath)` prefix check uses that separator so it stays
-      // sibling-prefix safe across roots.
-      const perRoot = await walkDirectory(root, excludePaths, state)
-      collected.push(...perRoot)
+    // Resolve the symlink-targets of the positional path before the prefix
+    // check, so a symlinked CLI argument still passes when its realpath
+    // agrees with one of the configured (already-realpath-normalized) roots.
+    // Roots from `resolveCliBaseDirsOrExit` already end with `sep`.
+    const realResolved = await realpath(resolved)
+    // Append a trailing separator to the positional path so the
+    // `startsWith` prefix-check is sibling-prefix safe in BOTH directions.
+    const realResolvedWithSep = realResolved.endsWith(sep) ? realResolved : realResolved + sep
+    // A path is "under" a root iff:
+    //  - the path equals the root (with both ending in sep), or
+    //  - the path starts with the root's trailing-separator form.
+    const insideAnyRoot = baseDirs.some(
+      (root) => realResolvedWithSep === root || realResolvedWithSep.startsWith(root)
+    )
+    if (!insideAnyRoot) {
+      // Fail loud — silently scanning baseDirs in this case (the pre-fix
+      // behavior) violated the CLI contract by ingesting unrelated content.
+      console.error(
+        `Error: ${targetPath} is not under any configured base directory. ` +
+          `Allowed roots: ${baseDirs.join(', ')}. ` +
+          `Provide a path inside one of the configured roots, or set BASE_DIRS / --base-dir to include the desired tree.`
+      )
+      process.exit(1)
     }
+
+    // Walk only the user-supplied positional directory. The configured roots
+    // remain the security boundary (enforced by the parser); they do not
+    // replace the user's scan target. This restores the pre-multi-root CLI
+    // contract: `ingest <dir>` scans `<dir>`, not every configured root.
+    const state = { depthLimited: false }
+    const collected = await walkDirectory(resolved, excludePaths, state)
 
     if (state.depthLimited) {
       console.error(
@@ -404,10 +426,8 @@ async function collectFiles(
       )
     }
 
-    // Cross-root dedup by absolute path string. Nested-root pruning already
-    // removes ancestor/descendant overlap at resolve time, but two disjoint
-    // realpath-normalized roots can still surface the same file via symlinks
-    // or bind mounts. Use a Set so the output is unique-and-sorted.
+    // Single-tree scan — no cross-root dedup necessary. Sort for
+    // deterministic ingest order.
     return [...new Set(collected)].sort()
   }
 

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -10,10 +10,12 @@ import { buildChunksAndEmbeddings } from '../ingest/compute.js'
 import { prepareVisualPdfChunks } from '../ingest/visual.js'
 import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import type { QualityProfile } from '../pdf-visual/types.js'
+import type { BaseDirsConfig, BaseDirsConfigWarning } from '../utils/base-dirs.js'
 import type { VectorChunk, VectorStore } from '../vectordb/index.js'
-import { createEmbedder, createVectorStore } from './common.js'
+import { createEmbedder, createVectorStore, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions, ResolvedGlobalConfig } from './options.js'
 import {
+  consumeBaseDirArg,
   resolveDevice,
   resolveGlobalConfig,
   validateChunkMinLength,
@@ -32,7 +34,8 @@ const MAX_DEPTH = 10
 // ============================================
 
 interface IngestConfig {
-  baseDir: string
+  baseDirs: BaseDirsConfig
+  baseDirsWarnings: BaseDirsConfigWarning[]
   dbPath: string
   cacheDir: string
   modelName: string
@@ -47,7 +50,12 @@ interface IngestSummary {
 }
 
 interface IngestCliOptions {
-  baseDir?: string | undefined
+  /**
+   * Collected `--base-dir` values in CLI order. Repeatable: each flag
+   * occurrence appends one entry. An empty array means the flag was not
+   * provided (resolver then falls through to env / cwd).
+   */
+  baseDirs?: string[] | undefined
   maxFileSize?: number | undefined
   chunkMinLength?: number | undefined
   visual?: boolean | undefined
@@ -82,7 +90,7 @@ const HELP_TEXT = `Usage: mcp-local-rag [global-options] ingest [options] <path>
 Ingest a single file or all supported files under a directory.
 
 Options:
-  --base-dir <path>          Base directory for documents (default: cwd)
+  --base-dir <path>          Base directory for documents (repeatable: pass once per root; default: BASE_DIRS/BASE_DIR env or cwd)
   --max-file-size <n>        Max file size in bytes (default: ${INGEST_DEFAULTS.maxFileSize})
   --chunk-min-length <n>     Minimum chunk length in characters (default: 50, range: 1-10000)
   --visual                   Enable VLM captioning for PDF figure pages (PDFs only; no effect on other types)
@@ -118,13 +126,15 @@ export function parseArgs(args: string[]): ParsedArgs {
         i++
         break
       case '--base-dir': {
-        const value = args[++i]
-        if (value === undefined || value.startsWith('-')) {
-          console.error('Missing value for --base-dir')
-          process.exit(1)
+        // Repeatable: each `--base-dir <path>` occurrence appends one entry
+        // to `options.baseDirs`. The accumulator is lazily initialized so
+        // an absent flag leaves `options.baseDirs` as `undefined`, which
+        // the resolver treats as "fall through to env / cwd".
+        if (options.baseDirs === undefined) {
+          options.baseDirs = []
         }
-        options.baseDir = value
-        i++
+        const valueIndex = consumeBaseDirArg(args, i, options.baseDirs)
+        i = valueIndex + 1
         break
       }
       case '--max-file-size': {
@@ -204,14 +214,40 @@ export function parseArgs(args: string[]): ParsedArgs {
 
 /**
  * Resolve ingest config by merging global config with ingest-specific options.
- * Ingest-specific: baseDir, maxFileSize (CLI flags > env vars > defaults).
- * Validates all resolved values before returning.
+ *
+ * Base directories are resolved via the shared CLI resolver
+ * ({@link resolveCliBaseDirsOrExit}) which applies the documented precedence
+ * (CLI roots > `BASE_DIRS` > `BASE_DIR` > `cwd`), realpath-normalizes every
+ * effective root, dedupes exact duplicates, and prunes nested roots. CLI
+ * roots are pre-validated against the sensitive-path policy here so the
+ * user sees `--base-dir`-attributed errors before the resolver touches the
+ * filesystem.
+ *
+ * Other ingest-specific values (maxFileSize, chunkMinLength) follow the
+ * existing CLI > env > defaults order and are validated against the same
+ * ranges as before.
  */
-export function resolveConfig(
+export async function resolveConfig(
   globalConfig: ResolvedGlobalConfig,
   ingestOptions: IngestCliOptions = {}
-): IngestConfig {
-  const baseDir = ingestOptions.baseDir ?? process.env['BASE_DIR'] ?? process.cwd()
+): Promise<IngestConfig> {
+  const cliBaseDirs = ingestOptions.baseDirs ?? []
+
+  // Validate CLI-supplied paths against the sensitive-path policy before
+  // calling the resolver. Doing this here (rather than relying on the
+  // resolver) keeps the error message attributed to `--base-dir` and avoids
+  // an unnecessary realpath round-trip on a path we will reject anyway.
+  for (const root of cliBaseDirs) {
+    const baseDirError = validatePath(root, '--base-dir')
+    if (baseDirError) {
+      console.error(baseDirError)
+      process.exit(1)
+    }
+  }
+
+  const { config: baseDirs, warnings: baseDirsWarnings } =
+    await resolveCliBaseDirsOrExit(cliBaseDirs)
+
   const maxFileSize =
     ingestOptions.maxFileSize ??
     (process.env['MAX_FILE_SIZE']
@@ -222,13 +258,6 @@ export function resolveConfig(
     (process.env['CHUNK_MIN_LENGTH']
       ? Number.parseInt(process.env['CHUNK_MIN_LENGTH'], 10)
       : undefined)
-
-  // Validate baseDir path
-  const baseDirError = validatePath(baseDir, '--base-dir')
-  if (baseDirError) {
-    console.error(baseDirError)
-    process.exit(1)
-  }
 
   // Validate maxFileSize range
   const maxFileSizeError = validateMaxFileSize(maxFileSize)
@@ -250,7 +279,8 @@ export function resolveConfig(
     dbPath: globalConfig.dbPath,
     cacheDir: globalConfig.cacheDir,
     modelName: globalConfig.modelName,
-    baseDir,
+    baseDirs,
+    baseDirsWarnings,
     maxFileSize,
   }
   if (chunkMinLength !== undefined) {
@@ -524,8 +554,15 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
 
   // Resolve config: CLI flags > env vars > defaults
   const globalConfig = resolveGlobalConfig(globalOptions)
-  const config = resolveConfig(globalConfig, options)
+  const config = await resolveConfig(globalConfig, options)
   const excludePaths = [`${resolve(config.dbPath)}${sep}`, `${resolve(config.cacheDir)}${sep}`]
+
+  // Surface resolver warnings (precedence, nested-root pruning) on stderr
+  // before scan output starts. Scan-loop multi-root behavior is P2-T2; this
+  // task only wires the resolver so the warnings are visible today.
+  for (const warning of config.baseDirsWarnings) {
+    console.error(warning.message)
+  }
 
   // Collect files
   const files = await collectFiles(targetPath, excludePaths)
@@ -536,9 +573,13 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
 
   console.error(`Found ${files.length} file(s) to ingest.`)
 
-  // Initialize components (single instances reused across all files)
+  // Initialize components (single instances reused across all files).
+  // The parser receives the full multi-root config; P2-T2 will switch the
+  // scan loop (`collectFiles`) to iterate every effective root. Today the
+  // scan still walks `targetPath`, which keeps single-root behavior
+  // byte-identical when exactly one root is configured.
   const parser = new DocumentParser({
-    baseDir: config.baseDir,
+    baseDirs: config.baseDirs.baseDirs,
     maxFileSize: config.maxFileSize,
   })
   const chunker = new SemanticChunker(

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -346,28 +346,6 @@ async function walkDirectory(
   return files
 }
 
-/**
- * Collect files to ingest.
- *
- * Two modes:
- *  - **Single-file mode**: `targetPath` resolves to a regular file. Returns
- *    `[resolved]` when the extension is supported, otherwise the empty array
- *    (after warning on stderr). The parser still validates the file path
- *    against the configured roots, so a file outside all roots is rejected
- *    downstream.
- *  - **Directory mode**: `targetPath` resolves to a directory. Walks only the
- *    positional directory `resolved` using {@link walkDirectory}. The multi-
- *    root configuration is the SECURITY boundary (passed to the parser via
- *    `DocumentParser.validateFilePath`), not a replacement for the user's
- *    scan target. `resolved` must live under one of the configured roots
- *    after realpath normalization; otherwise we fail loud with a clear
- *    message rather than scanning every configured root (which was the
- *    pre-Finding-#1 behavior and broke the `ingest <dir>` contract).
- *
- * Sibling-prefix safety: the `startsWith(root)` check uses `baseDirs`
- * entries with their realpath-normalized trailing separator, so
- * `/foo/barista` does not match root `/foo/bar/`.
- */
 async function collectFiles(
   targetPath: string,
   baseDirs: readonly string[],
@@ -388,23 +366,15 @@ async function collectFiles(
   }
 
   if (info.isDirectory()) {
-    // Resolve the symlink-targets of the positional path before the prefix
-    // check, so a symlinked CLI argument still passes when its realpath
-    // agrees with one of the configured (already-realpath-normalized) roots.
-    // Roots from `resolveCliBaseDirsOrExit` already end with `sep`.
+    // realpath both sides so a symlinked positional path still matches a
+    // root whose realpath agrees. baseDirs from resolveCliBaseDirsOrExit
+    // are already realpath-normalized with a trailing sep.
     const realResolved = await realpath(resolved)
-    // Append a trailing separator to the positional path so the
-    // `startsWith` prefix-check is sibling-prefix safe in BOTH directions.
     const realResolvedWithSep = realResolved.endsWith(sep) ? realResolved : realResolved + sep
-    // A path is "under" a root iff:
-    //  - the path equals the root (with both ending in sep), or
-    //  - the path starts with the root's trailing-separator form.
     const insideAnyRoot = baseDirs.some(
       (root) => realResolvedWithSep === root || realResolvedWithSep.startsWith(root)
     )
     if (!insideAnyRoot) {
-      // Fail loud — silently scanning baseDirs in this case (the pre-fix
-      // behavior) violated the CLI contract by ingesting unrelated content.
       console.error(
         `Error: ${targetPath} is not under any configured base directory. ` +
           `Allowed roots: ${baseDirs.join(', ')}. ` +
@@ -413,10 +383,6 @@ async function collectFiles(
       process.exit(1)
     }
 
-    // Walk only the user-supplied positional directory. The configured roots
-    // remain the security boundary (enforced by the parser); they do not
-    // replace the user's scan target. This restores the pre-multi-root CLI
-    // contract: `ingest <dir>` scans `<dir>`, not every configured root.
     const state = { depthLimited: false }
     const collected = await walkDirectory(resolved, excludePaths, state)
 
@@ -426,8 +392,6 @@ async function collectFiles(
       )
     }
 
-    // Single-tree scan — no cross-root dedup necessary. Sort for
-    // deterministic ingest order.
     return [...new Set(collected)].sort()
   }
 

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -294,12 +294,84 @@ export async function resolveConfig(
 // ============================================
 
 /**
- * Collect files to ingest from a path.
- * - If path is a file with supported extension, return [path].
- * - If path is a directory, walk with BFS up to MAX_DEPTH levels.
- * - Skip symlinks, permission errors, and excluded directories.
+ * BFS-walk a single directory up to {@link MAX_DEPTH} levels, returning every
+ * supported file path under it. Skips symlinks, permission errors, and excluded
+ * directories. Reports a single shared `depthLimited` flag via an out-param so
+ * the caller can emit one combined warning across multiple roots instead of
+ * one per root.
  */
-async function collectFiles(targetPath: string, excludePaths: string[]): Promise<string[]> {
+async function walkDirectory(
+  rootPath: string,
+  excludePaths: string[],
+  state: { depthLimited: boolean }
+): Promise<string[]> {
+  const files: string[] = []
+
+  const queue: { dirPath: string; depth: number }[] = [{ dirPath: rootPath, depth: 0 }]
+
+  while (queue.length > 0) {
+    const { dirPath, depth } = queue.shift()!
+
+    if (depth >= MAX_DEPTH) {
+      state.depthLimited = true
+      continue
+    }
+
+    let dir: Awaited<ReturnType<typeof opendir>>
+    try {
+      dir = await opendir(dirPath)
+    } catch {
+      console.error(`Warning: cannot read directory: ${dirPath}`)
+      continue
+    }
+
+    for await (const entry of dir) {
+      const fullPath = join(dirPath, entry.name)
+
+      if (!fullPath.startsWith(rootPath)) continue
+      if (entry.isSymbolicLink()) continue
+      if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
+
+      if (entry.isDirectory()) {
+        queue.push({ dirPath: fullPath, depth: depth + 1 })
+      } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+        files.push(fullPath)
+      }
+    }
+  }
+
+  return files
+}
+
+/**
+ * Collect files to ingest.
+ *
+ * Two modes:
+ *  - **Single-file mode**: `targetPath` resolves to a regular file. Returns
+ *    `[resolved]` when the extension is supported, otherwise the empty array
+ *    (after warning on stderr). Single-file mode ignores `baseDirs` because
+ *    the parser still validates the file path against the configured roots —
+ *    this preserves the pre-P2-T2 behavior for users who pass an explicit
+ *    file path to ingest.
+ *  - **Directory mode**: `targetPath` resolves to a directory. Walks EVERY
+ *    effective root in `baseDirs` (not `targetPath`) using {@link walkDirectory},
+ *    aggregates the per-root file lists, and deduplicates by absolute path so
+ *    overlap that survived nested-root pruning (e.g. symlinks pointing into
+ *    multiple roots) does not produce duplicate ingest activity. Sorted for
+ *    deterministic ingest order.
+ *
+ * Why iterate `baseDirs` rather than `targetPath` in directory mode: the
+ * multi-base-dirs plan (§ Phase 2 completion criteria, AC-008/AC-011/AC-012)
+ * makes the configured roots the security AND scan boundary. A directory
+ * positional with multiple `--base-dir` flags scans across all roots, not
+ * only the positional directory. Users who want to ingest a single subtree
+ * can pass it via `--base-dir` or use the single-file mode.
+ */
+async function collectFiles(
+  targetPath: string,
+  baseDirs: readonly string[],
+  excludePaths: string[]
+): Promise<string[]> {
   const resolved = resolve(targetPath)
   const info = await stat(resolved)
 
@@ -315,49 +387,28 @@ async function collectFiles(targetPath: string, excludePaths: string[]): Promise
   }
 
   if (info.isDirectory()) {
-    const files: string[] = []
-    let depthLimited = false
-
-    const queue: { dirPath: string; depth: number }[] = [{ dirPath: resolved, depth: 0 }]
-
-    while (queue.length > 0) {
-      const { dirPath, depth } = queue.shift()!
-
-      if (depth >= MAX_DEPTH) {
-        depthLimited = true
-        continue
-      }
-
-      let dir: Awaited<ReturnType<typeof opendir>>
-      try {
-        dir = await opendir(dirPath)
-      } catch {
-        console.error(`Warning: cannot read directory: ${dirPath}`)
-        continue
-      }
-
-      for await (const entry of dir) {
-        const fullPath = join(dirPath, entry.name)
-
-        if (!fullPath.startsWith(resolved)) continue
-        if (entry.isSymbolicLink()) continue
-        if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
-
-        if (entry.isDirectory()) {
-          queue.push({ dirPath: fullPath, depth: depth + 1 })
-        } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
-          files.push(fullPath)
-        }
-      }
+    const state = { depthLimited: false }
+    const collected: string[] = []
+    for (const root of baseDirs) {
+      // `baseDirs` entries from `resolveCliBaseDirsOrExit` already carry a
+      // trailing separator (realpath-normalized). `walkDirectory`'s
+      // `startsWith(rootPath)` prefix check uses that separator so it stays
+      // sibling-prefix safe across roots.
+      const perRoot = await walkDirectory(root, excludePaths, state)
+      collected.push(...perRoot)
     }
 
-    if (depthLimited) {
+    if (state.depthLimited) {
       console.error(
         `Warning: some directories were skipped because they exceed the maximum depth (${MAX_DEPTH})`
       )
     }
 
-    return files.sort()
+    // Cross-root dedup by absolute path string. Nested-root pruning already
+    // removes ancestor/descendant overlap at resolve time, but two disjoint
+    // realpath-normalized roots can still surface the same file via symlinks
+    // or bind mounts. Use a Set so the output is unique-and-sorted.
+    return [...new Set(collected)].sort()
   }
 
   return []
@@ -564,8 +615,11 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
     console.error(warning.message)
   }
 
-  // Collect files
-  const files = await collectFiles(targetPath, excludePaths)
+  // Collect files: when `targetPath` is a directory, the scan iterates every
+  // effective root in `config.baseDirs.baseDirs` (P2-T2) — the positional
+  // directory only triggers directory mode and is no longer the scan target.
+  // Single-file mode is unchanged. See `collectFiles` for the full rationale.
+  const files = await collectFiles(targetPath, config.baseDirs.baseDirs, excludePaths)
   if (files.length === 0) {
     console.error('No supported files found.')
     process.exit(1)
@@ -574,10 +628,11 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
   console.error(`Found ${files.length} file(s) to ingest.`)
 
   // Initialize components (single instances reused across all files).
-  // The parser receives the full multi-root config; P2-T2 will switch the
-  // scan loop (`collectFiles`) to iterate every effective root. Today the
-  // scan still walks `targetPath`, which keeps single-root behavior
-  // byte-identical when exactly one root is configured.
+  // The parser receives the full multi-root config. The directory-scan loop
+  // (`collectFiles`) iterates every effective root in `config.baseDirs.baseDirs`
+  // (P2-T2). Under a single configured root this is byte-identical to the
+  // pre-P2-T2 single-root scan; under multiple roots it walks each one and
+  // dedupes overlap.
   const parser = new DocumentParser({
     baseDirs: config.baseDirs.baseDirs,
     maxFileSize: config.maxFileSize,

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -4,31 +4,103 @@ import { readdir } from 'node:fs/promises'
 import { extname, join, resolve, sep } from 'node:path'
 
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
-import { legacyBaseDir } from '../utils/base-dirs.js'
-import { extractSourceFromPath, isRawDataPath } from '../utils/raw-data-utils.js'
+import { displayPath, legacyBaseDir } from '../utils/base-dirs.js'
+import { extractSourceFromPath, looksLikeRawDataPath } from '../utils/raw-data-utils.js'
 import { createVectorStore, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions } from './options.js'
 import { consumeBaseDirArg, resolveGlobalConfig, validatePath } from './options.js'
+
+// ============================================
+// Constants
+// ============================================
+
+/**
+ * Maximum directory recursion depth for `list` scans. Mirrors the
+ * `MAX_DEPTH` used by `ingest`'s `walkDirectory` so the two CLI subcommands
+ * apply the same boundary to "how deep do we look under a root".
+ */
+const MAX_DEPTH = 10
 
 // ============================================
 // Helpers
 // ============================================
 
 /**
- * Scan a single root with `readdir({ recursive: true })`, returning every
- * supported file under it (absolute paths) after excluding paths under
- * `excludePaths`. Mirrors the pre-P2-T2 single-root scan body so per-root
- * behavior is byte-identical when exactly one root is configured.
+ * Result of scanning a single root: the supported file paths found plus a
+ * non-fatal warning when applicable (depth limit hit, readdir error, ...).
+ * Per-root errors no longer abort the entire `list` call (Finding #10): one
+ * unreadable root must not hide files under the other roots.
  */
-async function scanRoot(root: string, excludePaths: string[]): Promise<string[]> {
-  const entries = await readdir(root, { recursive: true, withFileTypes: true })
-  return entries
-    .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
-    .map((e) => {
-      const dir = e.parentPath
-      return join(dir, e.name)
-    })
-    .filter((filePath) => !excludePaths.some((ep) => filePath.startsWith(ep)))
+interface ScanRootResult {
+  files: string[]
+  warnings: string[]
+}
+
+/**
+ * Bounded BFS scan of a single root, up to {@link MAX_DEPTH} levels deep.
+ * Symlinks are skipped (mirrors `walkDirectory` in `cli/ingest.ts`) and
+ * paths under `excludePaths` are filtered out. Per-directory `readdir`
+ * errors are captured into the returned `warnings` and do not abort the
+ * scan; this is the key change introduced by Finding #10 — a permission-
+ * denied error under one root must not hide files under another root.
+ */
+async function scanRoot(root: string, excludePaths: string[]): Promise<ScanRootResult> {
+  const files: string[] = []
+  const warnings: string[] = []
+  let depthLimited = false
+
+  const queue: { dirPath: string; depth: number }[] = [{ dirPath: root, depth: 0 }]
+
+  while (queue.length > 0) {
+    const { dirPath, depth } = queue.shift()!
+
+    if (depth >= MAX_DEPTH) {
+      depthLimited = true
+      continue
+    }
+
+    // TypeScript's `readdir` has overloads keyed on the options shape; when
+    // `withFileTypes: true` is passed as a literal-typed object the inferred
+    // return is `Dirent<string>[]`, which we use directly. The explicit
+    // type here keeps the loop body's `entry.isFile()` / `entry.name`
+    // accesses pointed at the string-encoded Dirent shape.
+    let entries: import('node:fs').Dirent<string>[]
+    try {
+      entries = (await readdir(dirPath, {
+        withFileTypes: true,
+        encoding: 'utf8',
+      })) as import('node:fs').Dirent<string>[]
+    } catch (error) {
+      // Per-root error tolerance: record the warning and continue. The
+      // typical case is permission-denied under a subdirectory; previously
+      // this killed the whole `list` invocation.
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? ((error as NodeJS.ErrnoException).code ?? 'UNKNOWN')
+          : 'UNKNOWN'
+      warnings.push(`cannot read directory: ${displayPath(dirPath)} (${code})`)
+      continue
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dirPath, entry.name)
+      if (entry.isSymbolicLink()) continue
+      if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
+      if (entry.isDirectory()) {
+        queue.push({ dirPath: fullPath, depth: depth + 1 })
+      } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+        files.push(fullPath)
+      }
+    }
+  }
+
+  if (depthLimited) {
+    warnings.push(
+      `some directories under ${displayPath(root)} were skipped because they exceed the maximum depth (${MAX_DEPTH})`
+    )
+  }
+
+  return { files, warnings }
 }
 
 // ============================================
@@ -51,6 +123,12 @@ interface ParsedArgs {
 
 interface FileEntry {
   filePath: string
+  /**
+   * Producing root for this file (one of `ListResult.baseDirs`). Mirrors the
+   * MCP `list_files` response shape so a single client schema works for
+   * both surfaces. Added in Finding #5 (post-launch review).
+   */
+  baseDir: string
   ingested: boolean
   chunkCount?: number
   timestamp?: string
@@ -63,7 +141,20 @@ interface SourceEntry {
   timestamp: string
 }
 
+/**
+ * CLI `list` JSON output.
+ *
+ * Multi-root shape (post-Finding-#5 alignment with the MCP `list_files`
+ * response):
+ *  - `baseDirs`: every effective root (after realpath + nested-pruning).
+ *  - `baseDir`: legacy first-effective-root, preserved so single-root
+ *    clients continue to work unchanged.
+ *  - `files[].baseDir`: per-file producing root.
+ *  - `sources`: raw-data and orphaned DB entries; never annotated with a
+ *    producing root (matches the MCP contract).
+ */
 interface ListResult {
+  baseDirs: string[]
   baseDir: string
   files: FileEntry[]
   sources: SourceEntry[]
@@ -206,42 +297,70 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     const ingested = await vectorStore.listFiles()
     const ingestedMap = new Map(ingested.map((f) => [f.filePath, f]))
 
-    // Scan every effective root. Per-root file lists are concatenated, then
-    // deduped by absolute path string. Nested-root pruning already removes
-    // ancestor/descendant overlap at resolve time, but disjoint roots can
-    // still surface the same file through symlinks or bind mounts — dedup
-    // here guarantees no duplicate file entry under any configuration
-    // (AC-012).
-    const collected: string[] = []
+    // Scan every effective root, recording the producing root for each
+    // file path. Disjoint roots can still surface the same file through
+    // symlinks or bind mounts; the first-occurrence-wins dedup preserves
+    // root iteration order, mirroring the MCP `list_files` contract.
+    // Per-root errors are non-fatal (Finding #10): we collect them as stderr
+    // warnings and continue with the remaining roots so one unreadable
+    // root does not hide the others.
+    const fileToRoot = new Map<string, string>()
     for (const root of baseDirsConfig.baseDirs) {
-      const perRoot = await scanRoot(root, excludePaths)
-      collected.push(...perRoot)
+      const { files: perRoot, warnings: rootWarnings } = await scanRoot(root, excludePaths)
+      for (const warning of rootWarnings) {
+        console.error(`Warning [${root}]: ${warning}`)
+      }
+      for (const filePath of perRoot) {
+        if (!fileToRoot.has(filePath)) {
+          fileToRoot.set(filePath, root)
+        }
+      }
     }
-    const baseDirFiles = [...new Set(collected)].sort()
-
+    const baseDirFiles = [...fileToRoot.keys()].sort()
     const baseDirSet = new Set(baseDirFiles)
 
-    // Files in baseDir with ingestion status
+    // Files with ingestion status and producing-root annotation. The
+    // producing root is guaranteed to be present because the path came from
+    // the scan above; the non-null assertion below documents the invariant.
     const files: FileEntry[] = baseDirFiles.map((filePath) => {
+      const producingRoot = fileToRoot.get(filePath)
+      if (producingRoot === undefined) {
+        // Cannot happen by construction (the key came from the same map).
+        // Surface as a programming error rather than silently shipping an
+        // empty `baseDir` field.
+        throw new Error(`internal: missing producing root for ${filePath}`)
+      }
       const entry = ingestedMap.get(filePath)
       return entry
-        ? { filePath, ingested: true, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
-        : { filePath, ingested: false }
+        ? {
+            filePath,
+            baseDir: producingRoot,
+            ingested: true,
+            chunkCount: entry.chunkCount,
+            timestamp: entry.timestamp,
+          }
+        : { filePath, baseDir: producingRoot, ingested: false }
     })
 
     // Content ingested via ingest_data (web pages, clipboard, etc.) plus any
-    // orphaned DB entries whose files no longer exist on disk
+    // orphaned DB entries whose files no longer exist on disk. Sources are
+    // never annotated with a producing root — matches the MCP contract.
     const sources: SourceEntry[] = ingested
       .filter((f) => !baseDirSet.has(f.filePath))
       .map((f) => {
-        if (isRawDataPath(f.filePath)) {
+        if (looksLikeRawDataPath(f.filePath)) {
           const source = extractSourceFromPath(f.filePath)
           if (source) return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
         }
         return { filePath: f.filePath, chunkCount: f.chunkCount, timestamp: f.timestamp }
       })
 
-    const result: ListResult = { baseDir, files, sources }
+    const result: ListResult = {
+      baseDirs: [...baseDirsConfig.baseDirs],
+      baseDir,
+      files,
+      sources,
+    }
 
     // Output JSON to stdout
     process.stdout.write(JSON.stringify(result, null, 2))

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -4,17 +4,23 @@ import { readdir } from 'node:fs/promises'
 import { extname, join, resolve, sep } from 'node:path'
 
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
+import { legacyBaseDir } from '../utils/base-dirs.js'
 import { extractSourceFromPath, isRawDataPath } from '../utils/raw-data-utils.js'
-import { createVectorStore } from './common.js'
+import { createVectorStore, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions } from './options.js'
-import { resolveGlobalConfig, validatePath } from './options.js'
+import { consumeBaseDirArg, resolveGlobalConfig, validatePath } from './options.js'
 
 // ============================================
 // Types
 // ============================================
 
 interface ListCliOptions {
-  baseDir?: string | undefined
+  /**
+   * Collected `--base-dir` values in CLI order. Repeatable: each flag
+   * occurrence appends one entry. `undefined` means the flag was not
+   * provided.
+   */
+  baseDirs?: string[] | undefined
 }
 
 interface ParsedArgs {
@@ -51,7 +57,7 @@ const HELP_TEXT = `Usage: mcp-local-rag [global-options] list [options]
 List files and their ingestion status.
 
 Options:
-  --base-dir <path>      Base directory to scan for files (default: BASE_DIR env or cwd)
+  --base-dir <path>      Base directory to scan for files (repeatable: pass once per root; default: BASE_DIRS/BASE_DIR env or cwd)
   -h, --help             Show this help
 
 Global options (must appear before "list"):
@@ -83,13 +89,15 @@ export function parseArgs(args: string[]): ParsedArgs {
         i++
         break
       case '--base-dir': {
-        const value = args[++i]
-        if (value === undefined || value.startsWith('-')) {
-          console.error('Missing value for --base-dir')
-          process.exit(1)
+        // Repeatable: each `--base-dir <path>` occurrence appends one entry
+        // to `options.baseDirs`. The accumulator is lazily initialized so an
+        // absent flag leaves `options.baseDirs` as `undefined`, which the
+        // resolver treats as "fall through to env / cwd".
+        if (options.baseDirs === undefined) {
+          options.baseDirs = []
         }
-        options.baseDir = value
-        i++
+        const valueIndex = consumeBaseDirArg(args, i, options.baseDirs)
+        i = valueIndex + 1
         break
       }
       default:
@@ -129,15 +137,35 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
   // Resolve global config
   const globalConfig = resolveGlobalConfig(globalOptions)
 
-  // Resolve baseDir: CLI flag > BASE_DIR env > cwd
-  const baseDir = options.baseDir ?? process.env['BASE_DIR'] ?? process.cwd()
-
-  // Validate baseDir path
-  const baseDirError = validatePath(baseDir, '--base-dir')
-  if (baseDirError) {
-    console.error(baseDirError)
-    process.exit(1)
+  // Validate CLI-supplied paths against the sensitive-path policy BEFORE
+  // calling the resolver, so the user sees a `--base-dir`-attributed error
+  // without an unnecessary realpath round-trip on a rejected path.
+  const cliBaseDirs = options.baseDirs ?? []
+  for (const root of cliBaseDirs) {
+    const baseDirError = validatePath(root, '--base-dir')
+    if (baseDirError) {
+      console.error(baseDirError)
+      process.exit(1)
+    }
   }
+
+  // Resolve effective base directories via the shared CLI resolver
+  // (CLI > BASE_DIRS > BASE_DIR > cwd). Resolver errors (invalid BASE_DIRS,
+  // missing directory, ...) exit non-zero with a clear stderr message and
+  // do NOT fall back. Resolver warnings (`base-dirs-overrides-base-dir`,
+  // `nested-root-pruned`) are routed to stderr so the JSON-only stdout
+  // contract is preserved.
+  const { config: baseDirsConfig, warnings: baseDirsWarnings } =
+    await resolveCliBaseDirsOrExit(cliBaseDirs)
+  for (const warning of baseDirsWarnings) {
+    console.error(warning.message)
+  }
+
+  // The scan loop still walks a single directory in this task; P2-T2 will
+  // switch it to iterate every effective root. `legacyBaseDir` returns the
+  // first effective root, which under a single-root configuration is byte-
+  // identical to the previous `options.baseDir ?? BASE_DIR ?? cwd` chain.
+  const baseDir = legacyBaseDir(baseDirsConfig)
 
   try {
     // Initialize VectorStore only (no Embedder needed for list)

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -11,6 +11,27 @@ import type { GlobalOptions } from './options.js'
 import { consumeBaseDirArg, resolveGlobalConfig, validatePath } from './options.js'
 
 // ============================================
+// Helpers
+// ============================================
+
+/**
+ * Scan a single root with `readdir({ recursive: true })`, returning every
+ * supported file under it (absolute paths) after excluding paths under
+ * `excludePaths`. Mirrors the pre-P2-T2 single-root scan body so per-root
+ * behavior is byte-identical when exactly one root is configured.
+ */
+async function scanRoot(root: string, excludePaths: string[]): Promise<string[]> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true })
+  return entries
+    .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
+    .map((e) => {
+      const dir = e.parentPath
+      return join(dir, e.name)
+    })
+    .filter((filePath) => !excludePaths.some((ep) => filePath.startsWith(ep)))
+}
+
+// ============================================
 // Types
 // ============================================
 
@@ -161,10 +182,10 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     console.error(warning.message)
   }
 
-  // The scan loop still walks a single directory in this task; P2-T2 will
-  // switch it to iterate every effective root. `legacyBaseDir` returns the
-  // first effective root, which under a single-root configuration is byte-
-  // identical to the previous `options.baseDir ?? BASE_DIR ?? cwd` chain.
+  // Scan every effective root (P2-T2). `legacyBaseDir` still surfaces the
+  // first effective root as the JSON `baseDir` field for response back-compat;
+  // the `list_files` MCP response evolves to add `baseDirs` and per-file
+  // annotations in P3-T2, which is intentionally out of scope here.
   const baseDir = legacyBaseDir(baseDirsConfig)
 
   try {
@@ -172,7 +193,10 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     const vectorStore = createVectorStore(globalConfig)
     await vectorStore.initialize()
 
-    // Build exclude paths (resolved to absolute, platform-aware trailing separator)
+    // Build exclude paths (resolved to absolute, platform-aware trailing
+    // separator). Applied uniformly to every root so dbPath/cacheDir remain
+    // excluded under each root even when they happen to live below one of
+    // them (AC-011).
     const excludePaths = [
       `${resolve(globalConfig.dbPath)}${sep}`,
       `${resolve(globalConfig.cacheDir)}${sep}`,
@@ -182,16 +206,18 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     const ingested = await vectorStore.listFiles()
     const ingestedMap = new Map(ingested.map((f) => [f.filePath, f]))
 
-    // Scan baseDir recursively for supported files
-    const entries = await readdir(baseDir, { recursive: true, withFileTypes: true })
-    const baseDirFiles = entries
-      .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
-      .map((e) => {
-        const dir = e.parentPath
-        return join(dir, e.name)
-      })
-      .filter((filePath) => !excludePaths.some((ep) => filePath.startsWith(ep)))
-      .sort()
+    // Scan every effective root. Per-root file lists are concatenated, then
+    // deduped by absolute path string. Nested-root pruning already removes
+    // ancestor/descendant overlap at resolve time, but disjoint roots can
+    // still surface the same file through symlinks or bind mounts — dedup
+    // here guarantees no duplicate file entry under any configuration
+    // (AC-012).
+    const collected: string[] = []
+    for (const root of baseDirsConfig.baseDirs) {
+      const perRoot = await scanRoot(root, excludePaths)
+      collected.push(...perRoot)
+    }
+    const baseDirFiles = [...new Set(collected)].sort()
 
     const baseDirSet = new Set(baseDirFiles)
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,43 +1,20 @@
 // Shared CLI global options — parsed before subcommand routing
 
+import { checkSensitivePath } from '../utils/sensitive-path.js'
+
 // ============================================
 // Validation Helpers
 // ============================================
 
 /**
- * Sensitive system directories that should never be used as data paths.
- * Checked as path prefixes (after resolving ~ to $HOME).
- */
-const SENSITIVE_PATH_PREFIXES = ['/etc', '/usr', '/sys', '/proc', '/var']
-const SENSITIVE_HOME_PREFIXES = ['.ssh', '.gnupg']
-
-/**
  * Validate that a path is not a sensitive system directory.
+ * Delegates to the shared `checkSensitivePath` helper so the CLI and the
+ * MCP server entry point share one policy implementation.
+ *
  * Returns an error message if invalid, or undefined if valid.
  */
 export function validatePath(value: string, flagName: string): string | undefined {
-  const normalized = value.startsWith('~/')
-    ? `${process.env['HOME'] ?? ''}/${value.slice(2)}`
-    : value
-
-  for (const prefix of SENSITIVE_PATH_PREFIXES) {
-    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
-      return `Refusing to use sensitive system path for ${flagName}: ${value}`
-    }
-  }
-
-  for (const dir of SENSITIVE_HOME_PREFIXES) {
-    const homePath = `${process.env['HOME'] ?? ''}/${dir}`
-    if (normalized === homePath || normalized.startsWith(`${homePath}/`)) {
-      return `Refusing to use sensitive system path for ${flagName}: ${value}`
-    }
-    // Also check the unexpanded form
-    if (value === `~/${dir}` || value.startsWith(`~/${dir}/`)) {
-      return `Refusing to use sensitive system path for ${flagName}: ${value}`
-    }
-  }
-
-  return undefined
+  return checkSensitivePath(value, flagName)
 }
 
 /**

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -78,6 +78,39 @@ export function validateChunkMinLength(value: number): string | undefined {
 }
 
 // ============================================
+// Repeatable --base-dir parsing
+// ============================================
+
+/**
+ * Consume the value that follows a `--base-dir` flag and append it to
+ * `collected`. Designed to be called from each subcommand's argv loop so
+ * `--base-dir <path>` can be provided one or more times, with the order
+ * preserved.
+ *
+ * `argv` is the full argv slice the loop is iterating; `flagIndex` is the
+ * index of the `--base-dir` token itself. On success returns the index of
+ * the value (so the caller can advance past it). On failure prints
+ * `Missing value for --base-dir` to stderr and calls `process.exit(1)` —
+ * matching the existing single-value error path so callers don't have to
+ * special-case the new shape.
+ *
+ * Why a shared helper: both `ingest` and `list` parse `--base-dir` in
+ * identical fashion, so centralizing the accumulate-and-validate step keeps
+ * the two argv loops in lockstep when the contract evolves (e.g. P2-T2
+ * adding per-path validation).
+ */
+export function consumeBaseDirArg(argv: string[], flagIndex: number, collected: string[]): number {
+  const valueIndex = flagIndex + 1
+  const value = argv[valueIndex]
+  if (value === undefined || value.startsWith('-')) {
+    console.error('Missing value for --base-dir')
+    process.exit(1)
+  }
+  collected.push(value)
+  return valueIndex
+}
+
+// ============================================
 // Types
 // ============================================
 

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -1,6 +1,6 @@
 // CLI query subcommand — search ingested documents
 
-import { extractSourceFromPath, isRawDataPath } from '../utils/raw-data-utils.js'
+import { extractSourceFromPath, looksLikeRawDataPath } from '../utils/raw-data-utils.js'
 import { createEmbedder, createVectorStore } from './common.js'
 import type { GlobalOptions } from './options.js'
 import { resolveGlobalConfig } from './options.js'
@@ -186,8 +186,7 @@ export async function runQuery(args: string[], globalOptions: GlobalOptions = {}
         fileTitle: result.fileTitle ?? null,
       }
 
-      // Restore source for raw-data files (ingested via ingest_data)
-      if (isRawDataPath(result.filePath)) {
+      if (looksLikeRawDataPath(result.filePath)) {
         const source = extractSourceFromPath(result.filePath)
         if (source) {
           output.source = source

--- a/src/cli/read-neighbors.ts
+++ b/src/cli/read-neighbors.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 import {
   extractSourceFromPath,
   generateRawDataPath,
-  isRawDataPath,
+  looksLikeRawDataPath,
 } from '../utils/raw-data-utils.js'
 import { createVectorStore } from './common.js'
 import type { GlobalOptions } from './options.js'
@@ -225,7 +225,7 @@ export async function runReadNeighbors(
     const rows = await vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
 
     // Post-fetch marking: isTarget per item; source attached for raw-data rows.
-    const isRaw = isRawDataPath(targetPath)
+    const isRaw = looksLikeRawDataPath(targetPath)
     const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
     const items = rows.map((row) => {
       const item: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ if (firstArg !== undefined && isSubcommand(firstArg)) {
   if (Object.keys(globalOptions).length > 0) {
     console.error('Global CLI options are not supported when launching the MCP server directly.')
     console.error(
-      'Use environment variables like DB_PATH, CACHE_DIR, MODEL_NAME, BASE_DIR, and MAX_FILE_SIZE instead.'
+      'Use environment variables like DB_PATH, CACHE_DIR, MODEL_NAME, BASE_DIR, BASE_DIRS, and MAX_FILE_SIZE instead.'
     )
     process.exit(1)
   }

--- a/src/parser/__tests__/parser.test.ts
+++ b/src/parser/__tests__/parser.test.ts
@@ -132,7 +132,7 @@ describe('DocumentParser', () => {
       await expect(parser.validateFilePath('/etc/passwd')).rejects.toThrow(
         expect.objectContaining({
           name: 'ValidationError',
-          message: expect.stringMatching(/outside BASE_DIR/),
+          message: expect.stringMatching(/outside all configured roots/),
         })
       )
     })
@@ -270,14 +270,21 @@ describe('DocumentParser', () => {
       }
     })
 
-    it('should reject construction with an empty baseDirs array', () => {
-      // An empty allow-list would silently permit zero files; the constructor
-      // must surface this as a configuration error rather than build a parser
-      // that rejects every path with a confusing "outside BASE_DIR" message.
-      expect(() => new DocumentParser({ baseDirs: [], maxFileSize })).toThrow(
+    it('accepts construction with an empty baseDirs array (degraded mode) and fails closed on validateFilePath', async () => {
+      // Empty baseDirs is legitimate only when the MCP server is in degraded
+      // mode (resolveBaseDirs returned a configError). The parser must be
+      // constructible in that case so the rest of the wiring (status, etc.)
+      // works, but every path validation must fail closed with a structured
+      // error rather than silently permitting zero files OR silently
+      // permitting every file. See Finding #4 in the post-launch review.
+      const parser = new DocumentParser({ baseDirs: [], maxFileSize })
+      const probe = join(rootA, 'anything.txt')
+      await writeFile(probe, 'x')
+
+      await expect(parser.validateFilePath(probe)).rejects.toThrow(
         expect.objectContaining({
           name: 'ValidationError',
-          message: expect.stringMatching(/at least one base directory/),
+          message: expect.stringMatching(/No configured base directory/),
         })
       )
     })

--- a/src/parser/__tests__/parser.test.ts
+++ b/src/parser/__tests__/parser.test.ts
@@ -270,6 +270,18 @@ describe('DocumentParser', () => {
       }
     })
 
+    it('should reject construction with an empty baseDirs array', () => {
+      // An empty allow-list would silently permit zero files; the constructor
+      // must surface this as a configuration error rather than build a parser
+      // that rejects every path with a confusing "outside BASE_DIR" message.
+      expect(() => new DocumentParser({ baseDirs: [], maxFileSize })).toThrow(
+        expect.objectContaining({
+          name: 'ValidationError',
+          message: expect.stringMatching(/at least one base directory/),
+        })
+      )
+    })
+
     it('should produce identical behavior for { baseDir } and { baseDirs: [baseDir] } shapes', async () => {
       const legacy = new DocumentParser({ baseDir: rootA, maxFileSize })
       const modern = new DocumentParser({ baseDirs: [rootA], maxFileSize })

--- a/src/parser/__tests__/parser.test.ts
+++ b/src/parser/__tests__/parser.test.ts
@@ -184,6 +184,107 @@ describe('DocumentParser', () => {
     })
   })
 
+  describe('validateFilePath (multi-root)', () => {
+    const rootA = join(process.cwd(), 'tmp', 'test-parser-multi-a')
+    const rootB = join(process.cwd(), 'tmp', 'test-parser-multi-b')
+    const outsideDir = join(process.cwd(), 'tmp', 'test-parser-multi-outside')
+
+    beforeEach(async () => {
+      await mkdir(rootA, { recursive: true })
+      await mkdir(rootB, { recursive: true })
+    })
+
+    afterEach(async () => {
+      await rm(rootA, { recursive: true, force: true })
+      await rm(rootB, { recursive: true, force: true })
+      await rm(outsideDir, { recursive: true, force: true })
+    })
+
+    it('should accept files under either of two configured roots', async () => {
+      const multi = new DocumentParser({ baseDirs: [rootA, rootB], maxFileSize })
+      const fileInA = join(rootA, 'a.txt')
+      const fileInB = join(rootB, 'b.txt')
+      await writeFile(fileInA, 'a')
+      await writeFile(fileInB, 'b')
+
+      await expect(multi.validateFilePath(fileInA)).resolves.toBeUndefined()
+      await expect(multi.validateFilePath(fileInB)).resolves.toBeUndefined()
+    })
+
+    it('should reject files outside all configured roots', async () => {
+      const multi = new DocumentParser({ baseDirs: [rootA, rootB], maxFileSize })
+      await expect(multi.validateFilePath('/etc/passwd')).rejects.toThrow(
+        expect.objectContaining({
+          name: 'ValidationError',
+          message: expect.stringMatching(/BASE_DIR/),
+        })
+      )
+    })
+
+    it('should reject symlink under root A whose realpath resolves outside both roots', async () => {
+      if (process.platform === 'win32') return
+      await mkdir(outsideDir, { recursive: true })
+      const outsideFile = join(outsideDir, 'secret.txt')
+      await writeFile(outsideFile, 'secret')
+
+      const linkPath = join(rootA, 'escape.txt')
+      await symlink(outsideFile, linkPath)
+
+      const multi = new DocumentParser({ baseDirs: [rootA, rootB], maxFileSize })
+      await expect(multi.validateFilePath(linkPath)).rejects.toThrow(
+        expect.objectContaining({
+          name: 'ValidationError',
+          message: expect.stringMatching(/BASE_DIR/),
+        })
+      )
+    })
+
+    it('should accept symlink under root A whose realpath resolves into root B', async () => {
+      if (process.platform === 'win32') return
+      const targetInB = join(rootB, 'shared.txt')
+      await writeFile(targetInB, 'shared content')
+
+      const linkInA = join(rootA, 'shared-link.txt')
+      await symlink(targetInB, linkInA)
+
+      const multi = new DocumentParser({ baseDirs: [rootA, rootB], maxFileSize })
+      await expect(multi.validateFilePath(linkInA)).resolves.toBeUndefined()
+    })
+
+    it('should reject sibling-prefix path (e.g., /tmp/foo/bar vs /tmp/foo/barista)', async () => {
+      const siblingDir = `${rootA}ista`
+      await mkdir(siblingDir, { recursive: true })
+      try {
+        const filePath = join(siblingDir, 'x.txt')
+        await writeFile(filePath, 'sibling content')
+
+        const multi = new DocumentParser({ baseDirs: [rootA], maxFileSize })
+        await expect(multi.validateFilePath(filePath)).rejects.toThrow(
+          expect.objectContaining({
+            name: 'ValidationError',
+            message: expect.stringMatching(/BASE_DIR/),
+          })
+        )
+      } finally {
+        await rm(siblingDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should produce identical behavior for { baseDir } and { baseDirs: [baseDir] } shapes', async () => {
+      const legacy = new DocumentParser({ baseDir: rootA, maxFileSize })
+      const modern = new DocumentParser({ baseDirs: [rootA], maxFileSize })
+
+      const inside = join(rootA, 'inside.txt')
+      await writeFile(inside, 'x')
+
+      await expect(legacy.validateFilePath(inside)).resolves.toBeUndefined()
+      await expect(modern.validateFilePath(inside)).resolves.toBeUndefined()
+
+      await expect(legacy.validateFilePath('/etc/passwd')).rejects.toThrow(ValidationError)
+      await expect(modern.validateFilePath('/etc/passwd')).rejects.toThrow(ValidationError)
+    })
+  })
+
   describe('validateFileSize', () => {
     it('should accept file within size limit', async () => {
       const filePath = join(testDir, 'small.txt')

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -64,7 +64,7 @@ export type ParserConfig =
     }
   | {
       /** Security: one or more allowed base directories (multi-root shape). */
-      baseDirs: string[]
+      baseDirs: readonly string[]
       baseDir?: undefined
       /** Maximum file size (100MB). */
       maxFileSize: number
@@ -128,12 +128,14 @@ export class DocumentParser {
     // The type system already rejects supplying both fields simultaneously,
     // but defensively pick `baseDirs` first so a future relaxation does not
     // accidentally fall back to the legacy single-root field.
+    //
+    // Empty `baseDirs` is accepted here so the parser can be constructed in
+    // the MCP server's degraded mode (configError present); `validateFilePath`
+    // fails closed in that case so no file is accepted while the empty root
+    // list stands. This is the only legitimate way to reach empty
+    // `rawBaseDirs`; production wiring always supplies a non-empty list when
+    // `configError` is absent.
     if (config.baseDirs !== undefined) {
-      if (config.baseDirs.length === 0) {
-        throw new ValidationError(
-          'DocumentParser requires at least one base directory (baseDirs was empty).'
-        )
-      }
       this.rawBaseDirs = config.baseDirs
     } else {
       this.rawBaseDirs = [config.baseDir]
@@ -157,10 +159,23 @@ export class DocumentParser {
    * @throws ValidationError - When path is not absolute or outside all allowed roots
    */
   async validateFilePath(filePath: string): Promise<void> {
+    // Fail-closed in degraded mode: when the parser was constructed with an
+    // empty allow-list (only legitimate when the MCP server is in degraded
+    // mode with a configError set), reject every path with a structured
+    // error rather than performing the realpath check against an empty
+    // surviving-roots set. Server-level `assertConfigOk` should have fired
+    // first; this is a defense-in-depth fallback for code paths that
+    // bypass that gate.
+    if (this.rawBaseDirs.length === 0) {
+      throw new ValidationError(
+        'No configured base directory: file access is disabled. Resolve the BASE_DIR / BASE_DIRS configuration error reported by the `status` tool before retrying.'
+      )
+    }
+
     // Check if path is absolute (fast-fail without syscall)
     if (!isAbsolute(filePath)) {
       throw new ValidationError(
-        `File path must be absolute path (received: ${filePath}). Please provide an absolute path within BASE_DIR.`
+        `File path must be absolute path (received: ${filePath}). Please provide an absolute path within a configured base directory (BASE_DIR/BASE_DIRS/--base-dir).`
       )
     }
 
@@ -210,7 +225,7 @@ export class DocumentParser {
           ? this.resolvedBaseDirs[0]
           : this.resolvedBaseDirs.join(', ')
       throw new ValidationError(
-        `File path must be within BASE_DIR (${rootsDisplay}). Received path outside BASE_DIR: ${filePath}`
+        `File path must be within a configured base directory (BASE_DIR/BASE_DIRS/--base-dir). Allowed roots: ${rootsDisplay}. Received path outside all configured roots: ${filePath}`
       )
     }
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,10 +2,11 @@
 
 import { statSync } from 'node:fs'
 import { lstat, readFile, realpath } from 'node:fs/promises'
-import { basename, extname, isAbsolute, resolve, sep } from 'node:path'
+import { basename, extname, isAbsolute, resolve } from 'node:path'
 import mammoth from 'mammoth'
 import type { Document as MupdfDocument } from 'mupdf'
 import { SemanticChunker } from '../chunker/index.js'
+import { withTrailingSeparator } from '../utils/base-dirs.js'
 import { type EmbedderInterface, filterPageBoundarySentences, type PageData } from './pdf-filter.js'
 import {
   extractDocxTitle,
@@ -39,14 +40,35 @@ export interface ParseResult {
 }
 
 /**
- * DocumentParser configuration
+ * DocumentParser configuration.
+ *
+ * Accepts either a single `baseDir` (legacy single-root shape — preserved for
+ * backward compatibility with downstream callers that have not yet migrated
+ * to the multi-root model) or a `baseDirs` array (multi-root shape produced
+ * by `resolveBaseDirs`). Exactly one of the two MUST be supplied; supplying
+ * both is rejected by the constructor so misconfiguration cannot silently
+ * pick one source over the other.
+ *
+ * Behavior under a single allowed root (`{ baseDir }` or
+ * `{ baseDirs: [oneRoot] }`) is byte-identical to the previous single-root
+ * implementation — see `validateFilePath` for the iteration contract under
+ * multiple roots.
  */
-interface ParserConfig {
-  /** Security: allowed base directory */
-  baseDir: string
-  /** Maximum file size (100MB) */
-  maxFileSize: number
-}
+export type ParserConfig =
+  | {
+      /** Security: single allowed base directory (legacy shape). */
+      baseDir: string
+      baseDirs?: undefined
+      /** Maximum file size (100MB). */
+      maxFileSize: number
+    }
+  | {
+      /** Security: one or more allowed base directories (multi-root shape). */
+      baseDirs: string[]
+      baseDir?: undefined
+      /** Maximum file size (100MB). */
+      maxFileSize: number
+    }
 
 /**
  * Validation error (equivalent to 400)
@@ -88,18 +110,51 @@ export class FileOperationError extends Error {
  */
 export class DocumentParser {
   private readonly config: ParserConfig
-  /** Lazily cached realpath of baseDir. Assumes baseDir is stable for the process lifetime. */
-  private resolvedBaseDir: string | null = null
+  /** Raw allowed roots in input order (pre-realpath). Always non-empty. */
+  private readonly rawBaseDirs: readonly string[]
+  /**
+   * Lazily cached realpath-normalized allowed roots, each with a trailing
+   * path separator so the `startsWith` check is sibling-prefix safe (e.g.
+   * `/foo/bar/` must not match `/foo/barista/x.txt`). Order is preserved
+   * from `rawBaseDirs` so the legacy single-root rejection message keeps
+   * referencing the user-configured first root. Assumes the allowed roots
+   * are stable for the process lifetime.
+   */
+  private resolvedBaseDirs: string[] | null = null
 
   constructor(config: ParserConfig) {
     this.config = config
+    // Normalize the two accepted shapes into one internal raw-root list.
+    // The type system already rejects supplying both fields simultaneously,
+    // but defensively pick `baseDirs` first so a future relaxation does not
+    // accidentally fall back to the legacy single-root field.
+    if (config.baseDirs !== undefined) {
+      if (config.baseDirs.length === 0) {
+        throw new ValidationError(
+          'DocumentParser requires at least one base directory (baseDirs was empty).'
+        )
+      }
+      this.rawBaseDirs = config.baseDirs
+    } else {
+      this.rawBaseDirs = [config.baseDir]
+    }
   }
 
   /**
-   * File path validation (Absolute path requirement + Path traversal prevention)
+   * File path validation (Absolute path requirement + Path traversal prevention).
+   *
+   * Multi-root semantics: a file is accepted iff its realpath (or, for a
+   * non-symlink path that does not yet exist, its `resolve()`-normalized
+   * absolute path) is under ANY realpath-normalized allowed root using a
+   * trailing-separator prefix check. Broken symlinks are still rejected
+   * outright — the lstat-based detection mirrors the previous single-root
+   * behavior.
+   *
+   * Under a single allowed root the behavior is identical to the previous
+   * single-root implementation.
    *
    * @param filePath - File path to validate (must be absolute)
-   * @throws ValidationError - When path is not absolute or outside BASE_DIR
+   * @throws ValidationError - When path is not absolute or outside all allowed roots
    */
   async validateFilePath(filePath: string): Promise<void> {
     // Check if path is absolute (fast-fail without syscall)
@@ -109,11 +164,16 @@ export class DocumentParser {
       )
     }
 
-    // Lazily resolve and cache the real baseDir path (follows symlinks)
-    if (!this.resolvedBaseDir) {
-      const resolved = await realpath(resolve(this.config.baseDir))
-      // Ensure trailing separator for safe prefix comparison
-      this.resolvedBaseDir = resolved.endsWith(sep) ? resolved : resolved + sep
+    // Lazily resolve and cache the real path of each allowed root (follows
+    // symlinks). Each entry gets a trailing separator so subsequent
+    // `startsWith` checks are sibling-prefix safe.
+    if (!this.resolvedBaseDirs) {
+      const resolvedList: string[] = []
+      for (const raw of this.rawBaseDirs) {
+        const resolved = await realpath(resolve(raw))
+        resolvedList.push(withTrailingSeparator(resolved))
+      }
+      this.resolvedBaseDirs = resolvedList
     }
 
     // Resolve the real path of the file (follows symlinks)
@@ -142,10 +202,15 @@ export class DocumentParser {
       resolvedPath = resolve(filePath)
     }
 
-    // Check if resolved path is within BASE_DIR
-    if (!resolvedPath.startsWith(this.resolvedBaseDir)) {
+    // Check if resolved path is within any allowed root.
+    const allowed = this.resolvedBaseDirs.some((root) => resolvedPath.startsWith(root))
+    if (!allowed) {
+      const rootsDisplay =
+        this.resolvedBaseDirs.length === 1
+          ? this.resolvedBaseDirs[0]
+          : this.resolvedBaseDirs.join(', ')
       throw new ValidationError(
-        `File path must be within BASE_DIR (${this.resolvedBaseDir}). Received path outside BASE_DIR: ${filePath}`
+        `File path must be within BASE_DIR (${rootsDisplay}). Received path outside BASE_DIR: ${filePath}`
       )
     }
   }

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,6 +1,7 @@
 // MCP Server entry point
 import { resolveDevice } from './cli/options.js'
 import { RAGServer } from './server/index.js'
+import { type BaseDirsConfigError, resolveBaseDirs } from './utils/base-dirs.js'
 import type { GroupingMode } from './vectordb/index.js'
 
 // ============================================
@@ -93,17 +94,52 @@ export async function startServer(): Promise<void> {
     // VLM profile selection (`fast` vs `quality`) is a per-ingest parameter
     // on the `ingest_file` MCP tool and is not configured here.
     const device = resolveDevice(process.env['RAG_DEVICE'])
+
+    // Collect configuration warnings (resolver + parse* helpers all funnel
+    // into this single array so RAGServer.configWarnings stays the one
+    // source of truth surfaced via MCP content blocks — P3-T3).
+    const configWarnings: string[] = []
+
+    // Resolve effective base directories from env. The resolver is the
+    // single source of truth for BASE_DIRS / BASE_DIR / cwd precedence and
+    // never silently falls back on invalid BASE_DIRS (AC-010 — root-
+    // dependent tools will surface the error; `status` remains callable).
+    // Server startup does not consume CLI flags (env-only for MCP client
+    // compatibility), so `cliRoots` is intentionally omitted here.
+    const baseDirsResult = await resolveBaseDirs({
+      envBaseDirs: process.env['BASE_DIRS'],
+      envBaseDir: process.env['BASE_DIR'],
+      cwd: process.cwd(),
+    })
+
+    let baseDirsForServer: string[]
+    let configError: BaseDirsConfigError | undefined
+    if (baseDirsResult.ok) {
+      baseDirsForServer = baseDirsResult.config.baseDirs
+      for (const warning of baseDirsResult.warnings) {
+        configWarnings.push(warning.message)
+      }
+    } else {
+      // Degraded mode: fall back to cwd so the parser / server can still be
+      // constructed and `status` works, but stash the error so P3-T3 can
+      // surface it from root-dependent tool responses. AC-010: no silent
+      // fallback to BASE_DIR — the resolver already returned an error.
+      baseDirsForServer = [process.cwd()]
+      configError = baseDirsResult.error
+      configWarnings.push(baseDirsResult.error.message)
+    }
+
+    // Build the immutable config object. `baseDirs` carries the resolver
+    // output (or the degraded-mode cwd fallback); the discriminated union
+    // in RAGServerConfig forbids passing `baseDir` alongside `baseDirs`.
     const config: ConstructorParameters<typeof RAGServer>[0] = {
       dbPath: process.env['DB_PATH'] || './lancedb/',
       modelName: process.env['MODEL_NAME'] || 'Xenova/all-MiniLM-L6-v2',
       cacheDir: process.env['CACHE_DIR'] || './models/',
-      baseDir: process.env['BASE_DIR'] || process.cwd(),
+      baseDirs: baseDirsForServer,
       maxFileSize: Number.parseInt(process.env['MAX_FILE_SIZE'] || '104857600', 10), // 100MB
       device,
     }
-
-    // Collect configuration warnings
-    const configWarnings: string[] = []
 
     // Add quality filter settings only if defined
     const maxDistance = parseMaxDistance(process.env['RAG_MAX_DISTANCE'])
@@ -145,6 +181,9 @@ export async function startServer(): Promise<void> {
     if (configWarnings.length > 0) {
       config.configWarnings = configWarnings
       console.error('Configuration warnings:', configWarnings.join(' | '))
+    }
+    if (configError !== undefined) {
+      config.configError = configError
     }
 
     console.error('Starting RAG MCP Server...')

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,7 +1,8 @@
 // MCP Server entry point
 import { resolveDevice } from './cli/options.js'
 import { RAGServer } from './server/index.js'
-import { type BaseDirsConfigError, resolveBaseDirs } from './utils/base-dirs.js'
+import { BaseDirsConfigError, parseBaseDirsEnv, resolveBaseDirs } from './utils/base-dirs.js'
+import { checkSensitivePath } from './utils/sensitive-path.js'
 import type { GroupingMode } from './vectordb/index.js'
 
 // ============================================
@@ -106,6 +107,29 @@ export async function startServer(): Promise<void> {
     // dependent tools will surface the error; `status` remains callable).
     // Server startup does not consume CLI flags (env-only for MCP client
     // compatibility), so `cliRoots` is intentionally omitted here.
+    //
+    // Sensitive-path pre-check on the RAW user-supplied paths (Finding #3):
+    // run the policy against the values supplied via env before the resolver
+    // realpath-normalizes them. On platforms where `/etc` realpaths to
+    // `/private/etc` (macOS), checking only the post-realpath value would
+    // miss the sensitive prefix. Errors from this pre-check produce a
+    // configError mirroring the post-realpath path below.
+    const rawSensitiveErrors: string[] = []
+    if (process.env['BASE_DIRS'] !== undefined && process.env['BASE_DIRS'].length > 0) {
+      const parsed = parseBaseDirsEnv(process.env['BASE_DIRS'])
+      if (parsed.ok) {
+        for (const raw of parsed.value) {
+          const sensitive = checkSensitivePath(raw, 'BASE_DIRS')
+          if (sensitive) rawSensitiveErrors.push(sensitive)
+        }
+      }
+      // Malformed BASE_DIRS surfaces via resolveBaseDirs below; nothing
+      // additional to do here.
+    } else if (process.env['BASE_DIR'] !== undefined && process.env['BASE_DIR'].trim().length > 0) {
+      const sensitive = checkSensitivePath(process.env['BASE_DIR'], 'BASE_DIR')
+      if (sensitive) rawSensitiveErrors.push(sensitive)
+    }
+
     const baseDirsResult = await resolveBaseDirs({
       envBaseDirs: process.env['BASE_DIRS'],
       envBaseDir: process.env['BASE_DIR'],
@@ -115,16 +139,42 @@ export async function startServer(): Promise<void> {
     let baseDirsForServer: string[]
     let configError: BaseDirsConfigError | undefined
     if (baseDirsResult.ok) {
-      baseDirsForServer = baseDirsResult.config.baseDirs
-      for (const warning of baseDirsResult.warnings) {
-        configWarnings.push(warning.message)
+      // Apply the sensitive-path policy to every env-resolved root (post-
+      // realpath) as well as the pre-check above. A path that traversed a
+      // symlink into a sensitive directory only shows up in the realpath
+      // form. Attribute rejections to the env var that supplied the value.
+      const sourceFlag =
+        process.env['BASE_DIRS'] !== undefined && process.env['BASE_DIRS'].length > 0
+          ? 'BASE_DIRS'
+          : 'BASE_DIR'
+      const sensitiveErrors: string[] = [...rawSensitiveErrors]
+      for (const root of baseDirsResult.config.baseDirs) {
+        const sensitive = checkSensitivePath(root, sourceFlag)
+        if (sensitive) sensitiveErrors.push(sensitive)
+      }
+      if (sensitiveErrors.length > 0) {
+        // Treat the rejection as a config error: the server stays callable
+        // (so `status` works) but every root-dependent tool fails fast. No
+        // silent cwd fallback — see Finding #4.
+        baseDirsForServer = []
+        // Dedup identical messages so a path that matches the raw-form check
+        // AND the post-realpath check reports once.
+        configError = new BaseDirsConfigError([...new Set(sensitiveErrors)].join('; '))
+        configWarnings.push(configError.message)
+      } else {
+        baseDirsForServer = baseDirsResult.config.baseDirs
+        for (const warning of baseDirsResult.warnings) {
+          configWarnings.push(warning.message)
+        }
       }
     } else {
-      // Degraded mode: fall back to cwd so the parser / server can still be
-      // constructed and `status` works, but stash the error so P3-T3 can
-      // surface it from root-dependent tool responses. AC-010: no silent
-      // fallback to BASE_DIR — the resolver already returned an error.
-      baseDirsForServer = [process.cwd()]
+      // Degraded mode: pass an empty `baseDirs` so any code path that
+      // forgets the `assertConfigOk` guard fails closed (rather than
+      // operating against `cwd`). The `configError` is stashed on the
+      // server so root-dependent tools surface it; `status` remains callable
+      // and exposes the diagnostic content block (AC-010). Removed the
+      // pre-existing `[process.cwd()]` fallback per Finding #4.
+      baseDirsForServer = []
       configError = baseDirsResult.error
       configWarnings.push(baseDirsResult.error.message)
     }

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -138,27 +138,27 @@ export async function startServer(): Promise<void> {
 
     let baseDirsForServer: string[]
     let configError: BaseDirsConfigError | undefined
-    if (baseDirsResult.ok) {
-      // Apply the sensitive-path policy to every env-resolved root (post-
-      // realpath) as well as the pre-check above. A path that traversed a
-      // symlink into a sensitive directory only shows up in the realpath
-      // form. Attribute rejections to the env var that supplied the value.
+    // Raw sensitive-path matches take precedence over resolver errors — on
+    // platforms where the sensitive path does not exist (e.g. `/etc` on
+    // Windows) the resolver fails with a generic "Failed to resolve" before
+    // the post-realpath check runs, but the raw check has already flagged
+    // the security policy violation and that is the actionable message.
+    if (rawSensitiveErrors.length > 0) {
+      baseDirsForServer = []
+      configError = new BaseDirsConfigError([...new Set(rawSensitiveErrors)].join('; '))
+      configWarnings.push(configError.message)
+    } else if (baseDirsResult.ok) {
       const sourceFlag =
         process.env['BASE_DIRS'] !== undefined && process.env['BASE_DIRS'].length > 0
           ? 'BASE_DIRS'
           : 'BASE_DIR'
-      const sensitiveErrors: string[] = [...rawSensitiveErrors]
+      const sensitiveErrors: string[] = []
       for (const root of baseDirsResult.config.baseDirs) {
         const sensitive = checkSensitivePath(root, sourceFlag)
         if (sensitive) sensitiveErrors.push(sensitive)
       }
       if (sensitiveErrors.length > 0) {
-        // Treat the rejection as a config error: the server stays callable
-        // (so `status` works) but every root-dependent tool fails fast. No
-        // silent cwd fallback — see Finding #4.
         baseDirsForServer = []
-        // Dedup identical messages so a path that matches the raw-form check
-        // AND the post-realpath check reports once.
         configError = new BaseDirsConfigError([...new Set(sensitiveErrors)].join('; '))
         configWarnings.push(configError.message)
       } else {
@@ -168,12 +168,6 @@ export async function startServer(): Promise<void> {
         }
       }
     } else {
-      // Degraded mode: pass an empty `baseDirs` so any code path that
-      // forgets the `assertConfigOk` guard fails closed (rather than
-      // operating against `cwd`). The `configError` is stashed on the
-      // server so root-dependent tools surface it; `status` remains callable
-      // and exposes the diagnostic content block (AC-010). Removed the
-      // pre-existing `[process.cwd()]` fallback per Finding #4.
       baseDirsForServer = []
       configError = baseDirsResult.error
       configWarnings.push(baseDirsResult.error.message)

--- a/src/server/__tests__/multi-root-integration.test.ts
+++ b/src/server/__tests__/multi-root-integration.test.ts
@@ -586,10 +586,14 @@ describe('post-launch findings #3 + #4: server-main wiring rejects sensitive roo
     let baseDirs: string[]
     let configError: BaseDirsConfigError | undefined
 
-    if (baseDirsResult.ok) {
+    if (rawSensitiveErrors.length > 0) {
+      baseDirs = []
+      configError = new BaseDirsConfigError([...new Set(rawSensitiveErrors)].join('; '))
+      warnings.push(configError.message)
+    } else if (baseDirsResult.ok) {
       const sourceFlag =
         opts.envBaseDirs !== undefined && opts.envBaseDirs.length > 0 ? 'BASE_DIRS' : 'BASE_DIR'
-      const sensitiveErrors: string[] = [...rawSensitiveErrors]
+      const sensitiveErrors: string[] = []
       for (const root of baseDirsResult.config.baseDirs) {
         const sensitive = checkSensitivePath(root, sourceFlag)
         if (sensitive) sensitiveErrors.push(sensitive)

--- a/src/server/__tests__/multi-root-integration.test.ts
+++ b/src/server/__tests__/multi-root-integration.test.ts
@@ -32,7 +32,7 @@ import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { McpError } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { type BaseDirsConfigError, resolveBaseDirs } from '../../utils/base-dirs.js'
+import { type BaseDirsConfigError, displayPath, resolveBaseDirs } from '../../utils/base-dirs.js'
 import { RAGServer } from '../index.js'
 
 // =============================================================================
@@ -78,9 +78,10 @@ async function buildServerFromResolver(opts: {
     baseDirs = result.config.baseDirs
     for (const w of result.warnings) warnings.push(w.message)
   } else {
-    // Degraded mode mirror of server-main.ts: fall back to cwd for construction,
-    // surface the error via configError + warnings.
-    baseDirs = [opts.cwd]
+    // Degraded mode mirror of server-main.ts (post-Finding-#4): pass an empty
+    // `baseDirs` so any handler bypassing `assertConfigOk` fails closed at the
+    // parser level rather than silently operating against `cwd`.
+    baseDirs = []
     configError = result.error
     warnings.push(result.error.message)
   }
@@ -448,6 +449,223 @@ describe('AC-003/AC-013: real resolveBaseDirs warnings surface in MCP responses'
 })
 
 // =============================================================================
+// Finding #10 (post-launch review): list_files survives a permission-denied
+// error on one root and emits a per-root warning instead of failing the
+// whole call. Mocks `node:fs/promises.readdir` so this is deterministic
+// across CI environments — the production code under test is the new BFS
+// loop in `scanBaseDir`.
+// =============================================================================
+describe('post-launch finding #10: list_files per-root error tolerance', () => {
+  const testBase = resolve('./tmp/test-list-files-per-root-err')
+  const rootA = resolve(testBase, 'rootA')
+  const rootB = resolve(testBase, 'rootB')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  beforeAll(() => {
+    mkdirSync(rootA, { recursive: true })
+    mkdirSync(rootB, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(resolve(rootB, 'survives.md'), 'a small markdown file under the accessible root')
+  })
+
+  afterAll(() => {
+    // Restore permissions before tearing down so rmSync can recurse.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('node:fs').chmodSync(rootA, 0o755)
+    } catch {
+      // Ignore — chmod may fail if rootA was already removed.
+    }
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  it('list_files surfaces files from accessible roots when another root is inaccessible', async () => {
+    // Make rootA unreadable using chmod so `readdir(rootA)` throws EACCES
+    // at the syscall layer (Linux/macOS only; Windows skips this test).
+    // We rely on the bounded BFS new in Finding #10 to capture the error
+    // as a per-root warning and keep scanning rootB.
+    if (process.platform === 'win32') return
+
+    const { chmodSync } = await import('node:fs')
+    chmodSync(rootA, 0o000)
+
+    const server = new RAGServer({
+      dbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir,
+      baseDirs: [rootA, rootB],
+      maxFileSize: 100 * 1024 * 1024,
+    })
+    await server.initialize()
+    try {
+      const result = await server.handleListFiles()
+      const parsed = JSON.parse(result.content[0]?.text ?? '{}')
+      const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+      // rootB's file survives even though rootA failed.
+      expect(filePaths).toContain(resolve(rootB, 'survives.md'))
+      // Warning content block names the failing root via `displayPath`
+      // (HOME prefix is collapsed to `~` to avoid leaking the OS username
+      // through MCP responses; see Finding #10 sanitization).
+      const warningBlock = findBlock(
+        result.content as ContentBlock[],
+        `cannot read directory: ${displayPath(rootA)}`
+      )
+      expect(warningBlock).toBeDefined()
+      // The raw OS error message must not leak into the warning text.
+      expect(warningBlock?.text ?? '').not.toContain('permission denied')
+    } finally {
+      await server.close()
+      // Restore permissions so afterAll's rmSync can recurse.
+      chmodSync(rootA, 0o755)
+    }
+  }, 60000)
+})
+
+// =============================================================================
+// Finding #3 + Finding #4 (post-launch review): the MCP server entry point
+// must apply the sensitive-path policy to env-resolved roots and must not
+// fall back to cwd on a config error.
+//
+// These tests exercise `startServer`-equivalent wiring directly — we replicate
+// the relevant section of `server-main.ts` here so the assertion is anchored
+// to the same logic the production entry point runs.
+// =============================================================================
+describe('post-launch findings #3 + #4: server-main wiring rejects sensitive roots and never falls back to cwd', () => {
+  const testBase = resolve('./tmp/test-server-main-policy')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  beforeAll(() => {
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  /**
+   * Mirror of the env-resolution branch in `src/server-main.ts` so the test
+   * exercises the same wiring without invoking `startServer` (which calls
+   * `process.exit` on errors and starts the MCP transport — both unsafe
+   * inside a vitest worker). The body MUST stay in sync with `server-main.ts`.
+   */
+  async function buildServerLikeMain(opts: {
+    envBaseDirs?: string | undefined
+    envBaseDir?: string | undefined
+  }): Promise<{ server: RAGServer; configError: BaseDirsConfigError | undefined }> {
+    const { checkSensitivePath } = await import('../../utils/sensitive-path.js')
+    const { BaseDirsConfigError, parseBaseDirsEnv: parseEnv } = await import(
+      '../../utils/base-dirs.js'
+    )
+
+    // Pre-check raw user-supplied paths (mirrors server-main.ts, Finding #3).
+    const rawSensitiveErrors: string[] = []
+    if (opts.envBaseDirs !== undefined && opts.envBaseDirs.length > 0) {
+      const parsed = parseEnv(opts.envBaseDirs)
+      if (parsed.ok) {
+        for (const raw of parsed.value) {
+          const sensitive = checkSensitivePath(raw, 'BASE_DIRS')
+          if (sensitive) rawSensitiveErrors.push(sensitive)
+        }
+      }
+    } else if (opts.envBaseDir !== undefined && opts.envBaseDir.trim().length > 0) {
+      const sensitive = checkSensitivePath(opts.envBaseDir, 'BASE_DIR')
+      if (sensitive) rawSensitiveErrors.push(sensitive)
+    }
+
+    const baseDirsResult = await resolveBaseDirs({
+      envBaseDirs: opts.envBaseDirs,
+      envBaseDir: opts.envBaseDir,
+      cwd: testBase,
+    })
+
+    const warnings: string[] = []
+    let baseDirs: string[]
+    let configError: BaseDirsConfigError | undefined
+
+    if (baseDirsResult.ok) {
+      const sourceFlag =
+        opts.envBaseDirs !== undefined && opts.envBaseDirs.length > 0 ? 'BASE_DIRS' : 'BASE_DIR'
+      const sensitiveErrors: string[] = [...rawSensitiveErrors]
+      for (const root of baseDirsResult.config.baseDirs) {
+        const sensitive = checkSensitivePath(root, sourceFlag)
+        if (sensitive) sensitiveErrors.push(sensitive)
+      }
+      if (sensitiveErrors.length > 0) {
+        baseDirs = []
+        configError = new BaseDirsConfigError([...new Set(sensitiveErrors)].join('; '))
+        warnings.push(configError.message)
+      } else {
+        baseDirs = baseDirsResult.config.baseDirs
+        for (const w of baseDirsResult.warnings) warnings.push(w.message)
+      }
+    } else {
+      baseDirs = []
+      configError = baseDirsResult.error
+      warnings.push(baseDirsResult.error.message)
+    }
+
+    const server = new RAGServer({
+      dbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir,
+      baseDirs,
+      maxFileSize: 100 * 1024 * 1024,
+      configWarnings: warnings,
+      ...(configError !== undefined ? { configError } : {}),
+    })
+
+    return { server, configError }
+  }
+
+  // AC: BASE_DIRS=["/etc"] must NOT be silently accepted by server-main.
+  // The server enters degraded mode (configError set, baseDirs empty); root-
+  // dependent tools fail fast; `status` surfaces the diagnostic.
+  it('rejects BASE_DIRS=["/etc"] as a sensitive system path (degraded mode)', async () => {
+    const { server, configError } = await buildServerLikeMain({
+      envBaseDirs: JSON.stringify(['/etc']),
+    })
+
+    expect(configError).toBeDefined()
+    expect(configError?.message).toMatch(/sensitive system path/)
+    expect(configError?.message).toContain('BASE_DIRS')
+
+    // baseDirs MUST be empty: no silent cwd fallback.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDirs).toEqual([])
+
+    // Root-dependent tool: must fail fast.
+    await expect(server.handleListFiles()).rejects.toBeInstanceOf(McpError)
+
+    // status: must remain callable and expose the diagnostic.
+    await server.initialize()
+    try {
+      const status = await server.handleStatus()
+      const diagnostic = findBlock(status.content as ContentBlock[], 'Configuration error:')
+      expect(diagnostic).toBeDefined()
+      expect(diagnostic?.text).toMatch(/sensitive system path/)
+    } finally {
+      await server.close()
+    }
+  }, 60000)
+
+  // AC: BASE_DIR=/usr (single-root sensitive path) is likewise rejected and
+  // attributed to BASE_DIR (not BASE_DIRS).
+  it('rejects BASE_DIR=/usr as a sensitive system path attributed to BASE_DIR', async () => {
+    const { server, configError } = await buildServerLikeMain({ envBaseDir: '/usr' })
+
+    expect(configError).toBeDefined()
+    expect(configError?.message).toMatch(/sensitive system path/)
+    expect(configError?.message).toContain('BASE_DIR')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDirs).toEqual([])
+  })
+})
+
+// =============================================================================
 // AC-010: invalid BASE_DIRS end-to-end via real resolveBaseDirs.
 // `status` callable; root-dependent tools throw structured McpError.
 // =============================================================================
@@ -502,12 +720,16 @@ describe('AC-010: invalid BASE_DIRS end-to-end (real resolveBaseDirs)', () => {
     }
   }, 60000)
 
-  // AC interpretation: [AC-010] All root-dependent tools fail fast with the resolver's structured error end-to-end —
-  // not just list_files. Verifies the assertConfigOk() gate fires before any DB/embedder/parser access for the full
-  // set of root-dependent handlers when configError comes from the real resolver path.
-  // Validation: ingest_file, ingest_data, delete_file, read_chunk_neighbors, and query_documents all throw McpError
-  // whose message includes "BASE_DIRS".
-  it('every root-dependent tool fails fast with the resolver error message', async () => {
+  // AC interpretation: [AC-010] Root-dependent tools — the ones that read or
+  // write through `baseDirs` — fail fast with the resolver's structured error
+  // end-to-end. After the post-launch scope review, the fail-fast set is
+  // narrower than every tool: `query_documents` (DB only) and `ingest_data`
+  // (DB + dbPath/raw-data only) operate without reading any configured root,
+  // so they MUST remain callable in degraded mode. The `source`-mode branches
+  // of `delete_file` / `read_chunk_neighbors` likewise route around the
+  // configured roots and stay callable. `filePath` mode for either dual-mode
+  // tool, plus `ingest_file` and `list_files`, fail fast.
+  it('root-dependent tools (filePath/list/ingest_file) fail fast with the resolver error message', async () => {
     const { server } = await buildServerFromResolver({
       dbPath,
       cacheDir,
@@ -517,24 +739,19 @@ describe('AC-010: invalid BASE_DIRS end-to-end (real resolveBaseDirs)', () => {
 
     try {
       // No need to initialize — the assertConfigOk() guard fires before any
-      // DB access, so we can skip the heavy initialize() path for this case.
+      // DB access for the fail-fast set, so we can skip the heavy
+      // initialize() path for this case.
 
       await expect(server.handleIngestFile({ filePath: '/tmp/x.txt' })).rejects.toBeInstanceOf(
         McpError
       )
-      await expect(
-        server.handleIngestData({
-          content: 'x',
-          metadata: { source: 'clipboard://x', format: 'text' },
-        })
-      ).rejects.toBeInstanceOf(McpError)
       await expect(server.handleDeleteFile({ filePath: '/tmp/x.txt' })).rejects.toBeInstanceOf(
         McpError
       )
       await expect(
         server.handleReadChunkNeighbors({ filePath: '/tmp/x.txt', chunkIndex: 0 })
       ).rejects.toBeInstanceOf(McpError)
-      await expect(server.handleQueryDocuments({ query: 'x' })).rejects.toBeInstanceOf(McpError)
+      await expect(server.handleListFiles()).rejects.toBeInstanceOf(McpError)
     } finally {
       // Do not close — server was never initialized.
     }

--- a/src/server/__tests__/multi-root-integration.test.ts
+++ b/src/server/__tests__/multi-root-integration.test.ts
@@ -1,0 +1,542 @@
+// Multi-root MCP server integration tests (P3-T4).
+//
+// Scope: closes the remaining end-to-end gaps for Phase 3 not already covered
+// by P3-T2 (`rag-server.files.integration.test.ts`, multi-root list_files
+// shape) and P3-T3 (`rag-server.warning-visibility.test.ts`, content-block
+// warnings + configError fail-fast with stubbed warnings).
+//
+// What this file adds (and intentionally does not duplicate):
+//   - End-to-end multi-root ingest_file → list_files round-trip showing each
+//     file is annotated with its producing root and persists to one DB.
+//   - End-to-end multi-root delete_file scoped to one root, leaving other
+//     root's chunks intact.
+//   - End-to-end multi-root query_documents returning chunks from any root.
+//   - End-to-end multi-root read_chunk_neighbors against a file under a
+//     non-first root.
+//   - Raw-data ingest_data behavior unchanged in multi-root mode (response
+//     shape preserved; warnings additive only) — covers AC-009 raw-data path.
+//   - Precedence + nested-pruning warning content produced by REAL
+//     `resolveBaseDirs` (not stubbed strings), surfaced via RAGServer
+//     responses (AC-003, AC-013).
+//   - Invalid `BASE_DIRS` end-to-end via real `resolveBaseDirs`: degraded-mode
+//     RAGServer keeps `status` callable and root-dependent tools throw a
+//     structured McpError (AC-010 end-to-end).
+//
+// Construction style: this file wires RAGServer the same way `server-main.ts`
+// does (resolveBaseDirs → RAGServer({ baseDirs, configWarnings, configError }))
+// so the assertions exercise the real configuration pipeline rather than
+// stubbed values. We deliberately do NOT call `startServer()` because it
+// owns `process.exit` semantics that are unsafe inside a vitest worker.
+
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type BaseDirsConfigError, resolveBaseDirs } from '../../utils/base-dirs.js'
+import { RAGServer } from '../index.js'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+type ContentBlock = { type: string; text: string; annotations?: unknown }
+
+/** Find the first content block whose text contains `needle`. */
+function findBlock(content: ReadonlyArray<ContentBlock>, needle: string): ContentBlock | undefined {
+  return content.find((b) => b.type === 'text' && b.text.includes(needle))
+}
+
+/**
+ * Build a RAGServer the same way `server-main.ts` does, but with explicit
+ * inputs so tests can simulate env without mutating `process.env` (which
+ * vitest workers share). Returns the constructed (uninitialized) server plus
+ * the resolved warnings/error so callers can assert on the resolver output
+ * directly when useful.
+ */
+async function buildServerFromResolver(opts: {
+  dbPath: string
+  cacheDir: string
+  envBaseDirs?: string | undefined
+  envBaseDir?: string | undefined
+  cwd: string
+}): Promise<{
+  server: RAGServer
+  warnings: string[]
+  configError: BaseDirsConfigError | undefined
+}> {
+  const result = await resolveBaseDirs({
+    envBaseDirs: opts.envBaseDirs,
+    envBaseDir: opts.envBaseDir,
+    cwd: opts.cwd,
+  })
+
+  const warnings: string[] = []
+  let baseDirs: string[]
+  let configError: BaseDirsConfigError | undefined
+
+  if (result.ok) {
+    baseDirs = result.config.baseDirs
+    for (const w of result.warnings) warnings.push(w.message)
+  } else {
+    // Degraded mode mirror of server-main.ts: fall back to cwd for construction,
+    // surface the error via configError + warnings.
+    baseDirs = [opts.cwd]
+    configError = result.error
+    warnings.push(result.error.message)
+  }
+
+  const server = new RAGServer({
+    dbPath: opts.dbPath,
+    modelName: 'Xenova/all-MiniLM-L6-v2',
+    cacheDir: opts.cacheDir,
+    baseDirs,
+    maxFileSize: 100 * 1024 * 1024,
+    configWarnings: warnings,
+    ...(configError !== undefined ? { configError } : {}),
+  })
+
+  return { server, warnings, configError }
+}
+
+// =============================================================================
+// AC-008/AC-011/AC-012/AC-013: end-to-end multi-root workflows
+// =============================================================================
+describe('AC-008/AC-011: multi-root ingest -> list -> query -> delete workflow', () => {
+  const testBase = resolve('./tmp/test-multi-root-e2e')
+  const rootA = resolve(testBase, 'rootA')
+  const rootB = resolve(testBase, 'rootB')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  let server: RAGServer
+  let fileA: string
+  let fileB: string
+
+  beforeAll(async () => {
+    mkdirSync(rootA, { recursive: true })
+    mkdirSync(rootB, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+
+    fileA = resolve(rootA, 'doc-a.txt')
+    fileB = resolve(rootB, 'doc-b.txt')
+    writeFileSync(
+      fileA,
+      'Alpha root document about photosynthesis. ' +
+        'Photosynthesis is the process by which plants convert sunlight into chemical energy. ' +
+        'This sentence pads the document so it clears the minimum chunk filter for ingestion.'
+    )
+    writeFileSync(
+      fileB,
+      'Beta root document about gravitational waves. ' +
+        'Gravitational waves are ripples in spacetime predicted by general relativity. ' +
+        'This sentence pads the document so it clears the minimum chunk filter for ingestion.'
+    )
+
+    server = new RAGServer({
+      dbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir,
+      baseDirs: [rootA, rootB],
+      maxFileSize: 100 * 1024 * 1024,
+    })
+    await server.initialize()
+
+    await server.handleIngestFile({ filePath: fileA })
+    await server.handleIngestFile({ filePath: fileB })
+  }, 120000)
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-008] After ingesting files under different roots, `list_files` reports each file's producing root
+  // Validation: list_files annotates fileA with rootA and fileB with rootB, both ingested=true with chunkCount > 0
+  it('ingest_file under two roots produces per-root annotated list_files entries', async () => {
+    const result = await server.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const entryA = parsed.files.find((f: { filePath: string }) => f.filePath === fileA)
+    const entryB = parsed.files.find((f: { filePath: string }) => f.filePath === fileB)
+    expect(entryA).toBeDefined()
+    expect(entryB).toBeDefined()
+    expect(entryA.baseDir).toBe(rootA)
+    expect(entryB.baseDir).toBe(rootB)
+    expect(entryA.ingested).toBe(true)
+    expect(entryB.ingested).toBe(true)
+    expect(entryA.chunkCount).toBeGreaterThan(0)
+    expect(entryB.chunkCount).toBeGreaterThan(0)
+  })
+
+  // AC interpretation: [AC-008/AC-011] query_documents returns chunks ingested under any effective root through the single shared DB
+  // Validation: A query that semantically matches doc-b under rootB returns at least one chunk whose filePath equals fileB
+  it('query_documents returns chunks ingested from any effective root', async () => {
+    const result = await server.handleQueryDocuments({
+      query: 'gravitational waves spacetime ripples',
+      limit: 5,
+    })
+    const parsed = JSON.parse(result.content[0].text)
+    const fileBHits = parsed.filter((r: { filePath: string }) => r.filePath === fileB)
+    expect(fileBHits.length).toBeGreaterThan(0)
+  }, 30000)
+
+  // AC interpretation: [AC-008] read_chunk_neighbors works against a file ingested under a non-first root
+  // Validation: Calling read_chunk_neighbors on fileB (rootB) returns at least one item with isTarget=true at chunkIndex 0
+  it('read_chunk_neighbors returns chunks for a file ingested under a non-first root', async () => {
+    const result = await server.handleReadChunkNeighbors({ filePath: fileB, chunkIndex: 0 })
+    const parsed = JSON.parse(result.content[0].text)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBeGreaterThan(0)
+    const target = parsed.find((row: { isTarget: boolean }) => row.isTarget === true)
+    expect(target).toBeDefined()
+    expect(target.filePath).toBe(fileB)
+  }, 30000)
+
+  // AC interpretation: [AC-008] delete_file scoped to one root removes only that file's chunks; the other root's chunks remain
+  // Validation: After deleting fileA, list_files shows fileA with ingested=false (file still on disk under rootA) and fileB still ingested=true
+  it('delete_file under one root leaves the other root untouched', async () => {
+    await server.handleDeleteFile({ filePath: fileA })
+
+    const result = await server.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const entryA = parsed.files.find((f: { filePath: string }) => f.filePath === fileA)
+    const entryB = parsed.files.find((f: { filePath: string }) => f.filePath === fileB)
+    expect(entryA).toBeDefined()
+    expect(entryA.ingested).toBe(false)
+    expect(entryB).toBeDefined()
+    expect(entryB.ingested).toBe(true)
+    expect(entryB.chunkCount).toBeGreaterThan(0)
+  }, 30000)
+})
+
+// =============================================================================
+// AC-009 (raw-data path): ingest_data response shape unchanged in multi-root
+// =============================================================================
+describe('AC-009: ingest_data behavior unchanged in multi-root mode (warnings additive)', () => {
+  const testBase = resolve('./tmp/test-multi-root-raw-data')
+  const rootA = resolve(testBase, 'rootA')
+  const rootB = resolve(testBase, 'rootB')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  let server: RAGServer
+
+  // Mirrors the precedence-warning string emitted by resolveBaseDirs so the
+  // additive-warning assertion below is anchored to the real warning text.
+  const PRECEDENCE_WARNING =
+    'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.'
+
+  beforeAll(async () => {
+    mkdirSync(rootA, { recursive: true })
+    mkdirSync(rootB, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+
+    server = new RAGServer({
+      dbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir,
+      baseDirs: [rootA, rootB],
+      maxFileSize: 100 * 1024 * 1024,
+      configWarnings: [PRECEDENCE_WARNING],
+    })
+    await server.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-009] ingest_data preserves its single-root response shape (filePath/chunkCount/timestamp/fileTitle)
+  // even when the server is configured with multiple roots; warnings are an ADDITIVE content block.
+  // Validation: Primary content block parses to IngestResult-shaped JSON with chunkCount>0 and filePath under dbPath/raw-data;
+  // the warning block appears alongside but does not alter the primary block.
+  it('ingest_data raw-data response shape is unchanged; warning block is additive', async () => {
+    const result = await server.handleIngestData({
+      content:
+        'Raw-data ingestion in multi-root mode. ' +
+        'This content is long enough to clear the minimum chunk filter and produce at least one chunk. ' +
+        'It exists solely to confirm that ingest_data behavior is unaffected by multi-root configuration.',
+      metadata: {
+        source: 'clipboard://2026-05-23/multi-root-raw-data',
+        format: 'text',
+      },
+    })
+
+    // Primary block: same shape as single-root contract.
+    const primary = result.content[0]
+    expect(primary.type).toBe('text')
+    const parsed = JSON.parse(primary.text)
+    expect(parsed.chunkCount).toBeGreaterThan(0)
+    expect(typeof parsed.timestamp).toBe('string')
+    expect(typeof parsed.filePath).toBe('string')
+    // Raw-data path lives under dbPath/raw-data — confirms ingest_data did not
+    // accidentally route through any root's filesystem.
+    expect(parsed.filePath.startsWith(resolve(dbPath))).toBe(true)
+    expect(parsed.filePath).toContain('raw-data')
+
+    // Warning block is additive.
+    const warningBlock = findBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(warningBlock).toBeDefined()
+  }, 60000)
+
+  // AC interpretation: [AC-008] Raw-data ingested via ingest_data is reported under `sources`, not under per-root `files`,
+  // even when multiple roots are configured. Confirms the producing-root annotation is intentionally absent for raw-data.
+  // Validation: list_files response after ingest_data contains the source under `sources` (no `baseDir` annotation) and
+  // no raw-data filePath leaks into the per-root `files` array.
+  it('list_files routes raw-data under sources (no baseDir annotation) in multi-root mode', async () => {
+    // Idempotent — beforeAll might have ingested already in another test order;
+    // we re-ingest with a distinct source to keep this test independent.
+    await server.handleIngestData({
+      content:
+        'A second raw-data document for the multi-root sources routing assertion. ' +
+        'This sentence pads the document so it clears the minimum chunk filter.',
+      metadata: {
+        source: 'clipboard://2026-05-23/multi-root-raw-data-sources',
+        format: 'text',
+      },
+    })
+
+    const result = await server.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const sourceEntry = parsed.sources.find(
+      (s: { source?: string }) => s.source === 'clipboard://2026-05-23/multi-root-raw-data-sources'
+    )
+    expect(sourceEntry).toBeDefined()
+    expect(sourceEntry.baseDir).toBeUndefined()
+
+    const rawDataLeaks = parsed.files.filter((f: { filePath: string }) =>
+      f.filePath.includes('raw-data')
+    )
+    expect(rawDataLeaks).toHaveLength(0)
+  }, 60000)
+})
+
+// =============================================================================
+// AC-003 + AC-013: real `resolveBaseDirs` produces precedence + pruning
+// warnings that surface in tool responses end-to-end.
+// =============================================================================
+describe('AC-003/AC-013: real resolveBaseDirs warnings surface in MCP responses', () => {
+  const testBase = resolve('./tmp/test-multi-root-real-warnings')
+  const rootA = resolve(testBase, 'rootA')
+  const rootB = resolve(testBase, 'rootB')
+  const nestedChild = resolve(rootA, 'nested-child')
+  const legacyBase = resolve(testBase, 'legacy-base-dir')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  beforeAll(() => {
+    mkdirSync(rootA, { recursive: true })
+    mkdirSync(rootB, { recursive: true })
+    mkdirSync(nestedChild, { recursive: true })
+    mkdirSync(legacyBase, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-003] When BASE_DIRS and BASE_DIR are both set with no CLI override, BASE_DIRS wins and a
+  // precedence warning is surfaced via MCP responses (not only stderr).
+  // Validation: Real resolveBaseDirs run with both envs set produces a precedence-warning content block in status output,
+  // and the server's effective roots equal the BASE_DIRS value (BASE_DIR is ignored).
+  it('BASE_DIRS > BASE_DIR precedence warning is surfaced via status content (real resolver)', async () => {
+    const { server, warnings } = await buildServerFromResolver({
+      dbPath,
+      cacheDir,
+      envBaseDirs: JSON.stringify([rootA, rootB]),
+      envBaseDir: legacyBase,
+      cwd: testBase,
+    })
+
+    try {
+      await server.initialize()
+
+      // Resolver produced the precedence warning.
+      const precedence = warnings.find((w) => w.includes('BASE_DIRS is set; BASE_DIR is ignored'))
+      expect(precedence).toBeDefined()
+
+      // Effective baseDirs came from BASE_DIRS, not BASE_DIR.
+      const listed = await server.handleListFiles()
+      const parsed = JSON.parse(listed.content[0].text)
+      // realpath-normalized roots have a trailing separator — match prefix.
+      expect(parsed.baseDirs).toHaveLength(2)
+      expect(parsed.baseDirs[0].startsWith(realpathSync(rootA))).toBe(true)
+      expect(parsed.baseDirs[1].startsWith(realpathSync(rootB))).toBe(true)
+      // BASE_DIR was ignored.
+      expect(parsed.baseDirs.some((b: string) => b.startsWith(realpathSync(legacyBase)))).toBe(
+        false
+      )
+
+      // Warning content block visible on status response.
+      const status = await server.handleStatus()
+      const warnBlock = findBlock(
+        status.content as ContentBlock[],
+        'BASE_DIRS is set; BASE_DIR is ignored'
+      )
+      expect(warnBlock).toBeDefined()
+    } finally {
+      await server.close()
+    }
+  }, 60000)
+
+  // AC interpretation: [AC-013] Nested-root pruning warnings emitted by resolveBaseDirs are visible via tool response
+  // content blocks (not only CLI stderr).
+  // Validation: With BASE_DIRS=[parent, child-of-parent], the resolver prunes the child and emits a warning whose text
+  // appears in list_files content; the effective baseDirs contain only the parent root.
+  it('nested-root pruning warning surfaces via list_files content (real resolver)', async () => {
+    const { server, warnings } = await buildServerFromResolver({
+      dbPath,
+      cacheDir,
+      envBaseDirs: JSON.stringify([rootA, nestedChild]),
+      cwd: testBase,
+    })
+
+    try {
+      await server.initialize()
+
+      // Resolver produced a nested-pruned warning.
+      const pruned = warnings.find((w) => w.includes('Nested base directory pruned'))
+      expect(pruned).toBeDefined()
+
+      // Effective baseDirs include only the parent root.
+      const listed = await server.handleListFiles()
+      const parsed = JSON.parse(listed.content[0].text)
+      expect(parsed.baseDirs).toHaveLength(1)
+      expect(parsed.baseDirs[0].startsWith(realpathSync(rootA))).toBe(true)
+
+      // Warning content block visible on list_files response.
+      const warnBlock = findBlock(listed.content as ContentBlock[], 'Nested base directory pruned')
+      expect(warnBlock).toBeDefined()
+    } finally {
+      await server.close()
+    }
+  }, 60000)
+
+  // AC interpretation: [AC-011] dbPath/cacheDir auto-exclusion remains effective for MCP scans across every root configured via env.
+  // Validation: With two roots configured via real BASE_DIRS and a supported file placed inside dbPath, list_files does not
+  // include that file (exclusion applies uniformly across roots even when roots are env-resolved).
+  it('dbPath/cacheDir exclusion still applies across env-resolved roots', async () => {
+    // Place a supported file inside dbPath that would otherwise match the filter.
+    const dbInternal = join(dbPath, 'internal-supported.txt')
+    writeFileSync(dbInternal, 'should not appear')
+
+    const { server } = await buildServerFromResolver({
+      dbPath,
+      cacheDir,
+      envBaseDirs: JSON.stringify([rootA, rootB]),
+      cwd: testBase,
+    })
+
+    try {
+      await server.initialize()
+      const listed = await server.handleListFiles()
+      const parsed = JSON.parse(listed.content[0].text)
+      const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+      expect(filePaths).not.toContain(dbInternal)
+    } finally {
+      await server.close()
+      rmSync(dbInternal, { force: true })
+    }
+  }, 60000)
+})
+
+// =============================================================================
+// AC-010: invalid BASE_DIRS end-to-end via real resolveBaseDirs.
+// `status` callable; root-dependent tools throw structured McpError.
+// =============================================================================
+describe('AC-010: invalid BASE_DIRS end-to-end (real resolveBaseDirs)', () => {
+  const testBase = resolve('./tmp/test-multi-root-invalid')
+  const dbPath = resolve(testBase, 'lancedb')
+  const cacheDir = resolve(testBase, 'cache')
+
+  beforeAll(() => {
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(testBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-010] Invalid BASE_DIRS does not silently fall back: root-dependent tools must error with the
+  // resolver's structured message, while status remains callable and exposes the same message as a diagnostic block.
+  // Validation: With BASE_DIRS set to non-JSON garbage, list_files throws McpError carrying the resolver's error text,
+  // and status returns a content array containing a "Configuration error: ..." block with that same text.
+  it('list_files throws McpError; status remains callable and exposes the same diagnostic', async () => {
+    const { server, configError } = await buildServerFromResolver({
+      dbPath,
+      cacheDir,
+      envBaseDirs: 'not-a-valid-json-array',
+      cwd: testBase,
+    })
+
+    // Resolver returned a structured error and stashed it on the server.
+    expect(configError).toBeDefined()
+    expect(configError?.message).toMatch(/BASE_DIRS/)
+
+    try {
+      await server.initialize()
+
+      // Root-dependent tool: throws structured McpError with the resolver's message.
+      const listError = await server
+        .handleListFiles()
+        .then(() => null)
+        .catch((e) => e)
+      expect(listError).toBeInstanceOf(McpError)
+      expect((listError as Error).message).toMatch(/BASE_DIRS/)
+
+      // status remains callable and surfaces the configError as a diagnostic block.
+      const status = await server.handleStatus()
+      const diagnostic = findBlock(status.content as ContentBlock[], 'Configuration error:')
+      expect(diagnostic).toBeDefined()
+      expect(diagnostic?.text).toMatch(/BASE_DIRS/)
+    } finally {
+      await server.close()
+    }
+  }, 60000)
+
+  // AC interpretation: [AC-010] All root-dependent tools fail fast with the resolver's structured error end-to-end —
+  // not just list_files. Verifies the assertConfigOk() gate fires before any DB/embedder/parser access for the full
+  // set of root-dependent handlers when configError comes from the real resolver path.
+  // Validation: ingest_file, ingest_data, delete_file, read_chunk_neighbors, and query_documents all throw McpError
+  // whose message includes "BASE_DIRS".
+  it('every root-dependent tool fails fast with the resolver error message', async () => {
+    const { server } = await buildServerFromResolver({
+      dbPath,
+      cacheDir,
+      envBaseDirs: '{"not":"an array"}',
+      cwd: testBase,
+    })
+
+    try {
+      // No need to initialize — the assertConfigOk() guard fires before any
+      // DB access, so we can skip the heavy initialize() path for this case.
+
+      await expect(server.handleIngestFile({ filePath: '/tmp/x.txt' })).rejects.toBeInstanceOf(
+        McpError
+      )
+      await expect(
+        server.handleIngestData({
+          content: 'x',
+          metadata: { source: 'clipboard://x', format: 'text' },
+        })
+      ).rejects.toBeInstanceOf(McpError)
+      await expect(server.handleDeleteFile({ filePath: '/tmp/x.txt' })).rejects.toBeInstanceOf(
+        McpError
+      )
+      await expect(
+        server.handleReadChunkNeighbors({ filePath: '/tmp/x.txt', chunkIndex: 0 })
+      ).rejects.toBeInstanceOf(McpError)
+      await expect(server.handleQueryDocuments({ query: 'x' })).rejects.toBeInstanceOf(McpError)
+    } finally {
+      // Do not close — server was never initialized.
+    }
+  })
+})

--- a/src/server/__tests__/rag-server.config.test.ts
+++ b/src/server/__tests__/rag-server.config.test.ts
@@ -78,7 +78,11 @@ describe('RAGServerConfig shape compatibility (P3-T1)', () => {
     expect((server as any).configWarnings).toEqual(warnings)
   })
 
-  it('is constructible with configError in degraded mode (status still callable)', async () => {
+  it('is constructible with configError in degraded mode and exposes empty baseDirs', () => {
+    // Post-Finding-#4: server-main.ts no longer falls back to `[cwd()]` on
+    // configError. The server stays constructible with `baseDirs: []` so
+    // `status` remains callable, and downstream guards (`assertConfigOk`,
+    // parser fail-close) keep every root-dependent code path inert.
     const configError = new BaseDirsConfigError(
       'BASE_DIRS must be a JSON array of non-empty path strings.'
     )
@@ -86,15 +90,52 @@ describe('RAGServerConfig shape compatibility (P3-T1)', () => {
       dbPath: testDbPath,
       modelName: 'Xenova/all-MiniLM-L6-v2',
       cacheDir: './tmp/models',
-      // In the degraded-mode path, baseDirs falls back to [cwd()] so the
-      // parser can still be constructed, but configError flags the server
-      // as degraded so root-dependent tools surface it (handled in P3-T3).
-      baseDir: process.cwd(),
+      baseDirs: [],
       maxFileSize: 100 * 1024 * 1024,
       configError,
     })
     // The configError must be reachable from the instance.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((server as any).configError).toBe(configError)
+    // The internal baseDirs MUST be empty (no silent cwd fallback).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDirs).toEqual([])
+  })
+
+  it('rejects construction with an empty baseDirs array when configError is absent', () => {
+    // Without configError, empty `baseDirs` is misconfiguration: the
+    // constructor must throw rather than silently build a parser that
+    // rejects every path.
+    expect(
+      () =>
+        new RAGServer({
+          dbPath: testDbPath,
+          modelName: 'Xenova/all-MiniLM-L6-v2',
+          cacheDir: './tmp/models',
+          baseDirs: [],
+          maxFileSize: 100 * 1024 * 1024,
+        })
+    ).toThrow(/non-empty `baseDirs` array/)
+  })
+
+  it('parser constructed with empty baseDirs fails closed on validateFilePath', async () => {
+    // Defense-in-depth: even when a handler bypasses `assertConfigOk`, the
+    // parser must reject every path under degraded mode.
+    const configError = new BaseDirsConfigError(
+      'BASE_DIRS must be a JSON array of non-empty path strings.'
+    )
+    const server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDirs: [],
+      maxFileSize: 100 * 1024 * 1024,
+      configError,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parser = (server as any).parser
+    await expect(parser.validateFilePath('/tmp/anything.txt')).rejects.toThrow(
+      /No configured base directory/
+    )
   })
 })

--- a/src/server/__tests__/rag-server.config.test.ts
+++ b/src/server/__tests__/rag-server.config.test.ts
@@ -1,0 +1,100 @@
+// RAGServer configuration shape tests (P3-T1)
+//
+// Verifies that RAGServerConfig accepts both the legacy `{ baseDir }` shape
+// and the new `{ baseDirs }` shape, that resolver warnings are stored on the
+// server instance for later attachment (P3-T3), and that a config error
+// puts the server in a degraded mode where `status` is still callable.
+//
+// Note: these are pure construction tests (no DB or embedder traffic). They
+// only assert on the constructor wiring and on `handleStatus`, which avoids
+// the heavy initialize() / vectorStore.connect() path.
+
+import { mkdirSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { BaseDirsConfigError } from '../../utils/base-dirs.js'
+import { RAGServer } from '../index.js'
+
+describe('RAGServerConfig shape compatibility (P3-T1)', () => {
+  const testDbPath = resolve('./tmp/test-lancedb-config-shape')
+  const testDataDir = resolve('./tmp/test-data-config-shape')
+  const testDataDirB = resolve('./tmp/test-data-config-shape-b')
+
+  beforeAll(() => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+    mkdirSync(testDataDirB, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+    rmSync(testDataDirB, { recursive: true, force: true })
+  })
+
+  it('accepts the legacy { baseDir } shape', () => {
+    const server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDir: testDataDir,
+      maxFileSize: 100 * 1024 * 1024,
+    })
+    // Legacy single-root: baseDirs should expose [baseDir].
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDirs).toEqual([testDataDir])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDir).toBe(testDataDir)
+  })
+
+  it('accepts the new { baseDirs } shape (multi-root)', () => {
+    const server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDirs: [testDataDir, testDataDirB],
+      maxFileSize: 100 * 1024 * 1024,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDirs).toEqual([testDataDir, testDataDirB])
+    // Legacy baseDir field is the first effective root.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).baseDir).toBe(testDataDir)
+  })
+
+  it('stores configWarnings on the instance for later attachment', () => {
+    const warnings = [
+      'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.',
+    ]
+    const server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDirs: [testDataDir],
+      maxFileSize: 100 * 1024 * 1024,
+      configWarnings: warnings,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).configWarnings).toEqual(warnings)
+  })
+
+  it('is constructible with configError in degraded mode (status still callable)', async () => {
+    const configError = new BaseDirsConfigError(
+      'BASE_DIRS must be a JSON array of non-empty path strings.'
+    )
+    const server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      // In the degraded-mode path, baseDirs falls back to [cwd()] so the
+      // parser can still be constructed, but configError flags the server
+      // as degraded so root-dependent tools surface it (handled in P3-T3).
+      baseDir: process.cwd(),
+      maxFileSize: 100 * 1024 * 1024,
+      configError,
+    })
+    // The configError must be reachable from the instance.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((server as any).configError).toBe(configError)
+  })
+})

--- a/src/server/__tests__/rag-server.files.integration.test.ts
+++ b/src/server/__tests__/rag-server.files.integration.test.ts
@@ -1,7 +1,7 @@
 // RAG MCP Server Integration Test - Format Support & File Management
 // Split from: rag-server.integration.test.ts (AC-006, AC-007)
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RAGServer } from '../index.js'
@@ -345,5 +345,212 @@ describe('AC-007: File Management', () => {
         rmSync(siblingBase, { recursive: true, force: true })
       }
     })
+  })
+})
+
+// AC-008, AC-011, AC-012, AC-013 — list_files multi-root contract (P3-T2)
+//
+// Covers the multi-root response shape produced by `handleListFiles` when
+// the server is configured with `baseDirs`: top-level `baseDirs`, preserved
+// legacy `baseDir`, per-file `baseDir` annotation, sources without root
+// annotation, dbPath/cacheDir exclusion across every root, and exact-path
+// de-duplication across roots.
+describe('AC-008: list_files multi-root contract', () => {
+  const multiRootBase = resolve('./tmp/test-list-multi-root')
+  const rootA = resolve(multiRootBase, 'rootA')
+  const rootB = resolve(multiRootBase, 'rootB')
+  const multiDbPath = resolve(multiRootBase, 'lancedb')
+  const multiCacheDir = resolve(multiRootBase, 'cache-models')
+
+  let multiServer: RAGServer
+
+  beforeAll(async () => {
+    mkdirSync(rootA, { recursive: true })
+    mkdirSync(rootB, { recursive: true })
+    mkdirSync(multiDbPath, { recursive: true })
+    mkdirSync(multiCacheDir, { recursive: true })
+
+    writeFileSync(resolve(rootA, 'a-file.txt'), 'Content in root A')
+    writeFileSync(resolve(rootB, 'b-file.txt'), 'Content in root B')
+
+    // System-managed files inside dbPath/cacheDir — must be excluded across
+    // all roots (these live outside any base dir, but ensure exclusion logic
+    // is still applied uniformly).
+    writeFileSync(resolve(multiDbPath, 'db-internal.txt'), 'DB internal')
+    writeFileSync(resolve(multiCacheDir, 'cache-internal.txt'), 'Cache internal')
+
+    multiServer = new RAGServer({
+      dbPath: multiDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: multiCacheDir,
+      baseDirs: [rootA, rootB],
+      maxFileSize: 100 * 1024 * 1024,
+    })
+
+    await multiServer.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await multiServer.close()
+    rmSync(multiRootBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-008] list_files scans every effective root and annotates each file entry with the root that produced it
+  // Validation: With two roots, each scanned file appears in `files` and its `baseDir` matches the configured root
+  it('returns files from every effective root with per-file baseDir annotation', async () => {
+    const result = await multiServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const aPath = resolve(rootA, 'a-file.txt')
+    const bPath = resolve(rootB, 'b-file.txt')
+
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    expect(filePaths).toContain(aPath)
+    expect(filePaths).toContain(bPath)
+
+    const aEntry = parsed.files.find((f: { filePath: string }) => f.filePath === aPath)
+    const bEntry = parsed.files.find((f: { filePath: string }) => f.filePath === bPath)
+    expect(aEntry.baseDir).toBe(rootA)
+    expect(bEntry.baseDir).toBe(rootB)
+  })
+
+  // AC interpretation: [AC-008/AC-011] Top-level `baseDirs` exposes the resolved effective roots in configured order
+  // Validation: Parsed response `baseDirs` deep-equals `[rootA, rootB]` matching `RAGServer` configuration order
+  it('top-level baseDirs equals the resolved effective roots in order', async () => {
+    const result = await multiServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    expect(parsed.baseDirs).toEqual([rootA, rootB])
+  })
+
+  // AC interpretation: [AC-008/AC-012] Legacy single-root `baseDir` field preserved and equal to `baseDirs[0]` for backward compatibility
+  // Validation: `parsed.baseDir` equals `rootA` and equals `parsed.baseDirs[0]`
+  it('top-level baseDir equals baseDirs[0] (legacy compatibility)', async () => {
+    const result = await multiServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    expect(parsed.baseDir).toBe(rootA)
+    expect(parsed.baseDir).toBe(parsed.baseDirs[0])
+  })
+
+  // AC interpretation: [AC-008/AC-013] System-managed `dbPath` and `cacheDir` paths must be excluded from every root's scan
+  // Validation: Files placed inside `dbPath` and `cacheDir` are absent from `parsed.files` even with multi-root configuration
+  it('dbPath and cacheDir are excluded across all roots', async () => {
+    const result = await multiServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    expect(filePaths).not.toContain(resolve(multiDbPath, 'db-internal.txt'))
+    expect(filePaths).not.toContain(resolve(multiCacheDir, 'cache-internal.txt'))
+  })
+
+  // AC interpretation: [AC-008] Raw-data ingested via `ingest_data` is reported under `sources` and carries no producing-root annotation
+  // Validation: Ingested raw source appears in `parsed.sources`, its `baseDir` is undefined, and no raw-data path leaks into `parsed.files`
+  it('raw-data ingested via ingest_data appears under sources without baseDir', async () => {
+    await multiServer.handleIngestData({
+      content:
+        'Multi-root raw-data source test content. ' +
+        'Long enough to produce at least one chunk for the integration verification.',
+      metadata: {
+        source: 'https://example.com/multi-root-source',
+        format: 'text',
+      },
+    })
+
+    const result = await multiServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    const sourceEntry = parsed.sources.find(
+      (s: { source?: string }) => s.source === 'https://example.com/multi-root-source'
+    )
+    expect(sourceEntry).toBeDefined()
+    // sources carry no producing-root annotation
+    expect(sourceEntry.baseDir).toBeUndefined()
+
+    // raw-data files do not leak into `files`
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    const rawDataLeaks = filePaths.filter((fp) => fp.includes('raw-data'))
+    expect(rawDataLeaks).toHaveLength(0)
+  }, 30000)
+
+  // AC interpretation: [AC-008] When the same underlying file is reachable from multiple roots (via a symlink under rootB pointing at a file in rootA),
+  // exact-path de-duplication produces exactly one entry whose `baseDir` is the first root in `baseDirs` order (first-occurrence wins).
+  // Validation: Create a symlink under rootB targeting an existing file in rootA, then call `handleListFiles` and assert (a) exactly one entry
+  // exists for the shared file and (b) its `baseDir` equals rootA (the first configured root). This exercises the seenPaths logic at
+  // src/server/index.ts:651-671 and documents the first-occurrence-wins acceptance criterion across roots.
+  it('de-duplicates files reachable from multiple roots via symlink, keeping the first root in baseDirs order', async () => {
+    const sharedTargetPath = resolve(rootA, 'a-file.txt')
+    const symlinkPath = resolve(rootB, 'a-file.txt')
+
+    try {
+      symlinkSync(sharedTargetPath, symlinkPath)
+    } catch (error) {
+      // Symlink creation can fail on platforms without filesystem-link
+      // privileges; in that environment the cross-root dedup contract is not
+      // observable so we surface the failure rather than silently skipping.
+      throw new Error(
+        `symlink creation failed for cross-root dedup test: ${(error as Error).message}`
+      )
+    }
+
+    try {
+      const result = await multiServer.handleListFiles()
+      const parsed = JSON.parse(result.content[0].text)
+
+      const entries = parsed.files.filter(
+        (f: { filePath: string }) => f.filePath === sharedTargetPath || f.filePath === symlinkPath
+      )
+      expect(entries).toHaveLength(1)
+      expect(entries[0].filePath).toBe(sharedTargetPath)
+      expect(entries[0].baseDir).toBe(rootA)
+    } finally {
+      rmSync(symlinkPath, { force: true })
+    }
+  })
+})
+
+describe('AC-008: list_files single-root regression (legacy shape preserved)', () => {
+  const singleBase = resolve('./tmp/test-list-single-root-regression')
+  const singleData = resolve(singleBase, 'data')
+  const singleDb = resolve(singleBase, 'db')
+  const singleCache = resolve(singleBase, 'cache')
+
+  let singleServer: RAGServer
+
+  beforeAll(async () => {
+    mkdirSync(singleData, { recursive: true })
+    mkdirSync(singleDb, { recursive: true })
+    mkdirSync(singleCache, { recursive: true })
+    writeFileSync(resolve(singleData, 'only-file.txt'), 'single-root content')
+
+    singleServer = new RAGServer({
+      dbPath: singleDb,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: singleCache,
+      baseDir: singleData,
+      maxFileSize: 100 * 1024 * 1024,
+    })
+
+    await singleServer.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await singleServer.close()
+    rmSync(singleBase, { recursive: true, force: true })
+  })
+
+  // AC interpretation: [AC-008/AC-012] Single-root legacy configuration still produces the legacy `baseDir` plus the additive `baseDirs` and per-file `baseDir` fields
+  // Validation: `parsed.baseDir` equals the single root, `parsed.baseDirs` equals `[singleData]`, and each file entry's `baseDir` equals `singleData`
+  it('preserves baseDir, adds baseDirs and per-file baseDir for single-root configs', async () => {
+    const result = await singleServer.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+
+    expect(parsed.baseDir).toBe(singleData)
+    expect(parsed.baseDirs).toEqual([singleData])
+
+    const filePath = resolve(singleData, 'only-file.txt')
+    const entry = parsed.files.find((f: { filePath: string }) => f.filePath === filePath)
+    expect(entry).toBeDefined()
+    expect(entry.baseDir).toBe(singleData)
   })
 })

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -19,7 +19,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { isRawDataPath } from '../../utils/raw-data-utils.js'
+import { looksLikeRawDataPath } from '../../utils/raw-data-utils.js'
 import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
 import { RAGServer } from '../index.js'
 import type { ReadChunkNeighborsInput, ReadChunkNeighborsResultItem } from '../types.js'
@@ -470,7 +470,7 @@ describe('read_chunk_neighbors integration', () => {
   //   - Response is a non-empty array
   //   - All returned items share the same filePath value
   //   - The shared filePath is under the raw-data storage directory
-  //     (isRawDataPath(filePath) === true)
+  //     (looksLikeRawDataPath(filePath) === true)
   //   - Exactly one item has isTarget: true with chunkIndex === 1
   //
   // Pass criteria:
@@ -520,7 +520,7 @@ describe('read_chunk_neighbors integration', () => {
       const filePaths = new Set(items.map((i) => i.filePath))
       expect(filePaths.size).toBe(1)
       const sharedPath = items[0]?.filePath ?? ''
-      expect(isRawDataPath(sharedPath)).toBe(true)
+      expect(looksLikeRawDataPath(sharedPath)).toBe(true)
 
       const targets = items.filter((i) => i.isTarget)
       expect(targets).toHaveLength(1)
@@ -1089,7 +1089,7 @@ describe('read_chunk_neighbors integration', () => {
       expect(items.length).toBeGreaterThan(0)
       const filePaths = new Set(items.map((i) => i.filePath))
       expect(filePaths.size).toBe(1)
-      expect(isRawDataPath(items[0]?.filePath ?? '')).toBe(true)
+      expect(looksLikeRawDataPath(items[0]?.filePath ?? '')).toBe(true)
       for (const item of items) {
         expect(item.source).toBe(SOURCE)
       }

--- a/src/server/__tests__/rag-server.warning-visibility.test.ts
+++ b/src/server/__tests__/rag-server.warning-visibility.test.ts
@@ -39,10 +39,15 @@ function findWarningBlock(
 
 // =============================================================================
 // Construction-only tests (no initialize/DB). Cover the early-error path that
-// fires BEFORE any I/O — root-dependent tools must reject when configError is
-// present, regardless of whether the server has been initialized.
+// fires BEFORE any I/O — root-dependent tools (the ones that touch
+// `baseDirs` directly, plus the user-supplied-filePath branches of dual-mode
+// tools) must reject when configError is present. Tools that do NOT touch
+// `baseDirs` (`query_documents`, `ingest_data`, and the source-mode branches
+// of `delete_file` / `read_chunk_neighbors`) MUST remain callable so MCP
+// users can still query, capture raw data, and operate by `source` while
+// they fix the config error visible from `status`.
 // =============================================================================
-describe('P3-T3: root-dependent tools fail fast on configError', () => {
+describe('root-dependent tools fail fast on configError; non-root-dependent stay callable', () => {
   const testDbPath = resolve('./tmp/test-lancedb-warning-visibility-err')
   const testDataDir = resolve('./tmp/test-data-warning-visibility-err')
 
@@ -70,28 +75,12 @@ describe('P3-T3: root-dependent tools fail fast on configError', () => {
     })
   }
 
-  it('query_documents rejects with the configError message', async () => {
-    const server = newServerWithConfigError()
-    await expect(server.handleQueryDocuments({ query: 'anything' })).rejects.toThrow(
-      /BASE_DIRS must be a JSON array of non-empty path strings/
-    )
-  })
-
+  // Fail-fast set: tools whose work requires `baseDirs` to be valid.
   it('ingest_file rejects with the configError message', async () => {
     const server = newServerWithConfigError()
     await expect(server.handleIngestFile({ filePath: '/tmp/anything.txt' })).rejects.toThrow(
       /BASE_DIRS must be a JSON array of non-empty path strings/
     )
-  })
-
-  it('ingest_data rejects with the configError message', async () => {
-    const server = newServerWithConfigError()
-    await expect(
-      server.handleIngestData({
-        content: 'hello',
-        metadata: { source: 'clipboard://2026-05-23', format: 'text' },
-      })
-    ).rejects.toThrow(/BASE_DIRS must be a JSON array of non-empty path strings/)
   })
 
   it('list_files rejects with the configError message', async () => {
@@ -101,18 +90,33 @@ describe('P3-T3: root-dependent tools fail fast on configError', () => {
     )
   })
 
-  it('delete_file rejects with the configError message', async () => {
+  it('delete_file (filePath mode) rejects with the configError message', async () => {
     const server = newServerWithConfigError()
     await expect(server.handleDeleteFile({ filePath: '/tmp/x.txt' })).rejects.toThrow(
       /BASE_DIRS must be a JSON array of non-empty path strings/
     )
   })
 
-  it('read_chunk_neighbors rejects with the configError message', async () => {
+  it('read_chunk_neighbors (filePath mode) rejects with the configError message', async () => {
     const server = newServerWithConfigError()
     await expect(
       server.handleReadChunkNeighbors({ filePath: '/tmp/x.txt', chunkIndex: 0 })
     ).rejects.toThrow(/BASE_DIRS must be a JSON array of non-empty path strings/)
+  })
+
+  it('ingest_file rejects raw-data-shaped path traversal in degraded mode', async () => {
+    const server = newServerWithConfigError()
+    const traversal = `${testDbPath}/raw-data/../../../etc/passwd`
+    await expect(server.handleIngestFile({ filePath: traversal })).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
+  })
+
+  it('ingest_file rejects a raw-data substring in an unrelated path', async () => {
+    const server = newServerWithConfigError()
+    await expect(server.handleIngestFile({ filePath: '/foo/raw-data/bar.md' })).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
   })
 })
 
@@ -161,6 +165,72 @@ describe('P3-T3: status callable with configError and exposes diagnostic', () =>
     )
     expect(errorBlock).toBeDefined()
   })
+
+  // Non-root-dependent tools must stay callable in degraded mode. The
+  // contract for these tools is "operates against the LanceDB or the
+  // raw-data store, never against the configured roots", so a configError
+  // is informational here, surfaced as a warning content block via
+  // `withWarnings` but never converted into a thrown McpError.
+
+  it('query_documents remains callable in degraded mode (operates on DB only)', async () => {
+    // An uninitialized vector store returns an empty result set — the
+    // contract under test is that the handler does not throw an
+    // assertConfigOk error before the DB call. The handler attaches the
+    // configError-derived warning via `configWarnings` only when the caller
+    // also supplied them; this test fixture passes only `configError`, so we
+    // assert on callability + primary content shape, not on the warning
+    // block content (covered by the configWarnings suite below).
+    const result = await server.handleQueryDocuments({ query: 'no-op', limit: 1 })
+    expect(result.content.length).toBeGreaterThanOrEqual(1)
+    expect(result.content[0]?.type).toBe('text')
+  }, 30000)
+
+  it('ingest_data remains callable in degraded mode (writes to dbPath/raw-data only)', async () => {
+    const result = await server.handleIngestData({
+      content:
+        'A small markdown document used solely to confirm ingest_data does not fail-fast on configError. ' +
+        'It is long enough to clear the minimum chunk filter so the raw-data write produces a real row.',
+      metadata: {
+        source: 'clipboard://2026-05-23/degraded-mode-callable',
+        format: 'markdown',
+      },
+    })
+    const parsed = JSON.parse(result.content[0]?.text ?? '{}')
+    expect(parsed.chunkCount).toBeGreaterThan(0)
+    expect(typeof parsed.filePath).toBe('string')
+  }, 60000)
+
+  it('delete_file (source mode) remains callable in degraded mode', async () => {
+    // Source mode operates on the raw-data path generated from `source` and
+    // does not touch the configured roots. Even when no chunks exist for the
+    // source yet, the call must not throw the configError.
+    const result = await server.handleDeleteFile({
+      source: 'clipboard://2026-05-23/degraded-mode-callable-delete',
+    })
+    expect(result.content.length).toBeGreaterThanOrEqual(1)
+    expect(result.content[0]?.type).toBe('text')
+  }, 30000)
+
+  it('read_chunk_neighbors (source mode) remains callable in degraded mode', async () => {
+    // First seed a raw-data row by source so chunkIndex 0 is reachable.
+    await server.handleIngestData({
+      content:
+        'A markdown document used to seed the source-mode read_chunk_neighbors test. ' +
+        'It must produce at least one chunk so the neighbors lookup has a target row.',
+      metadata: {
+        source: 'clipboard://2026-05-23/degraded-mode-callable-neighbors',
+        format: 'markdown',
+      },
+    })
+
+    const result = await server.handleReadChunkNeighbors({
+      source: 'clipboard://2026-05-23/degraded-mode-callable-neighbors',
+      chunkIndex: 0,
+    })
+    const parsed = JSON.parse(result.content[0]?.text ?? '[]')
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBeGreaterThan(0)
+  }, 60000)
 })
 
 // =============================================================================

--- a/src/server/__tests__/rag-server.warning-visibility.test.ts
+++ b/src/server/__tests__/rag-server.warning-visibility.test.ts
@@ -1,0 +1,331 @@
+// RAG MCP Server warning-visibility tests (P3-T3, AC-003 / AC-009 / AC-010 / AC-013)
+//
+// Verifies that config warnings stored on the server are surfaced in EVERY
+// MCP tool response (not only `query_documents` / `status`), and that a
+// `configError` (invalid `BASE_DIRS`) makes root-dependent tools fail fast
+// while keeping `status` callable and exposing the error message.
+//
+// Most assertions use the early-validation path (configError throws before
+// any DB/embedder traffic) so the suite stays fast; the `status` callable
+// case uses an initialized server because `vectorStore.getStatus()` is
+// exercised. The warning-block shape (text content + annotations) is
+// asserted directly on handler return values — the protocol layer just
+// forwards the array, so per-handler assertions cover the MCP contract.
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { BaseDirsConfigError } from '../../utils/base-dirs.js'
+import { RAGServer } from '../index.js'
+
+const PRECEDENCE_WARNING =
+  'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.'
+const NESTED_PRUNED_WARNING =
+  'Nested base directory pruned: /tmp/child/ is inside /tmp/. Keeping /tmp/ only.'
+
+/**
+ * Type helper: every MCP handler returns at least
+ *   { content: Array<{ type: 'text'; text: string; annotations?: ... }> }
+ * Tests inspect the content array directly, so a structural type is enough.
+ */
+type ContentBlock = { type: string; text: string; annotations?: unknown }
+
+function findWarningBlock(
+  content: ReadonlyArray<ContentBlock>,
+  needle: string
+): ContentBlock | undefined {
+  return content.find((b) => b.type === 'text' && b.text.includes(needle))
+}
+
+// =============================================================================
+// Construction-only tests (no initialize/DB). Cover the early-error path that
+// fires BEFORE any I/O — root-dependent tools must reject when configError is
+// present, regardless of whether the server has been initialized.
+// =============================================================================
+describe('P3-T3: root-dependent tools fail fast on configError', () => {
+  const testDbPath = resolve('./tmp/test-lancedb-warning-visibility-err')
+  const testDataDir = resolve('./tmp/test-data-warning-visibility-err')
+
+  beforeAll(() => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+  })
+
+  afterAll(() => {
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+  })
+
+  function newServerWithConfigError(): RAGServer {
+    const configError = new BaseDirsConfigError(
+      'BASE_DIRS must be a JSON array of non-empty path strings.'
+    )
+    return new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDir: testDataDir, // degraded-mode fallback root
+      maxFileSize: 100 * 1024 * 1024,
+      configError,
+    })
+  }
+
+  it('query_documents rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(server.handleQueryDocuments({ query: 'anything' })).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
+  })
+
+  it('ingest_file rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(server.handleIngestFile({ filePath: '/tmp/anything.txt' })).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
+  })
+
+  it('ingest_data rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(
+      server.handleIngestData({
+        content: 'hello',
+        metadata: { source: 'clipboard://2026-05-23', format: 'text' },
+      })
+    ).rejects.toThrow(/BASE_DIRS must be a JSON array of non-empty path strings/)
+  })
+
+  it('list_files rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(server.handleListFiles()).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
+  })
+
+  it('delete_file rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(server.handleDeleteFile({ filePath: '/tmp/x.txt' })).rejects.toThrow(
+      /BASE_DIRS must be a JSON array of non-empty path strings/
+    )
+  })
+
+  it('read_chunk_neighbors rejects with the configError message', async () => {
+    const server = newServerWithConfigError()
+    await expect(
+      server.handleReadChunkNeighbors({ filePath: '/tmp/x.txt', chunkIndex: 0 })
+    ).rejects.toThrow(/BASE_DIRS must be a JSON array of non-empty path strings/)
+  })
+})
+
+// =============================================================================
+// status remains callable even with configError, and exposes the error in
+// content blocks (so MCP clients can diagnose without inspecting stderr).
+// =============================================================================
+describe('P3-T3: status callable with configError and exposes diagnostic', () => {
+  let server: RAGServer
+  const testDbPath = resolve('./tmp/test-lancedb-warning-visibility-status-err')
+  const testDataDir = resolve('./tmp/test-data-warning-visibility-status-err')
+
+  beforeAll(async () => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+
+    const configError = new BaseDirsConfigError(
+      'BASE_DIRS must be a JSON array of non-empty path strings.'
+    )
+    server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDir: testDataDir,
+      maxFileSize: 100 * 1024 * 1024,
+      configError,
+    })
+    await server.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+  })
+
+  it('status returns a content response that exposes the configError message', async () => {
+    const result = await server.handleStatus()
+    expect(result.content.length).toBeGreaterThanOrEqual(2)
+    // Primary status JSON block is still present.
+    expect(result.content[0]?.type).toBe('text')
+    // configError diagnostic must be visible in content (not only stderr).
+    const errorBlock = findWarningBlock(
+      result.content as ContentBlock[],
+      'BASE_DIRS must be a JSON array of non-empty path strings'
+    )
+    expect(errorBlock).toBeDefined()
+  })
+})
+
+// =============================================================================
+// Warnings present on every tool when configWarnings is non-empty.
+// We use the configError path to short-circuit root-dependent handlers and
+// inspect the rejection — but for that path the tool returns an error, not
+// content. So this block uses warnings WITHOUT a configError: the handler
+// must perform its normal flow AND attach warnings. For tools that need DB
+// state (query/ingest/...) we initialize a real server.
+// =============================================================================
+describe('P3-T3: warnings appear in every tool response when warnings exist', () => {
+  let server: RAGServer
+  const testDbPath = resolve('./tmp/test-lancedb-warning-visibility-warn')
+  const testDataDir = resolve('./tmp/test-data-warning-visibility-warn')
+  const sampleFile = resolve(testDataDir, 'sample.txt')
+
+  beforeAll(async () => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+    writeFileSync(
+      sampleFile,
+      'This is a small but valid sample document used for warning-visibility tests. ' +
+        'It contains enough characters to clear the default minimum-chunk filter so ' +
+        'ingest_file produces at least one chunk for the assertion below.'
+    )
+
+    server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDir: testDataDir,
+      maxFileSize: 100 * 1024 * 1024,
+      configWarnings: [PRECEDENCE_WARNING, NESTED_PRUNED_WARNING],
+    })
+
+    await server.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+  })
+
+  // status: warning content block must include the precedence warning.
+  it('status response includes warning content block', async () => {
+    const result = await server.handleStatus()
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // list_files: nested-root pruning warning is exposed here too.
+  it('list_files response includes nested-root pruning warning', async () => {
+    const result = await server.handleListFiles()
+    const block = findWarningBlock(result.content as ContentBlock[], NESTED_PRUNED_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // query_documents must include warnings on EVERY call (not only the first
+  // — the legacy "first call only" gate is removed per AC-009).
+  it('query_documents includes warnings on every call (not only the first)', async () => {
+    const first = await server.handleQueryDocuments({ query: 'sample', limit: 1 })
+    const second = await server.handleQueryDocuments({ query: 'sample', limit: 1 })
+    const firstBlock = findWarningBlock(first.content as ContentBlock[], PRECEDENCE_WARNING)
+    const secondBlock = findWarningBlock(second.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(firstBlock).toBeDefined()
+    expect(secondBlock).toBeDefined()
+  })
+
+  // ingest_file: warning block accompanies the ingest result.
+  it('ingest_file response includes warning content block', async () => {
+    const result = await server.handleIngestFile({ filePath: sampleFile })
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // ingest_data: warning block accompanies the raw-data ingest result.
+  it('ingest_data response includes warning content block', async () => {
+    const result = await server.handleIngestData({
+      content:
+        'A short markdown document used solely to confirm warning visibility on ingest_data.',
+      metadata: { source: 'clipboard://2026-05-23/warning-visibility', format: 'markdown' },
+    })
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // read_chunk_neighbors: warning block accompanies the neighbors result.
+  it('read_chunk_neighbors response includes warning content block', async () => {
+    // Ingest a file first so chunkIndex 0 exists.
+    await server.handleIngestFile({ filePath: sampleFile })
+    const result = await server.handleReadChunkNeighbors({ filePath: sampleFile, chunkIndex: 0 })
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // delete_file: warning block accompanies the delete result.
+  it('delete_file response includes warning content block', async () => {
+    // Ensure something exists to delete (idempotent for delete semantics).
+    await server.handleIngestFile({ filePath: sampleFile })
+    const result = await server.handleDeleteFile({ filePath: sampleFile })
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+  })
+
+  // Annotations remain on the warning block (assistant/user audience, priority 0.3).
+  it('warning content blocks carry MCP annotations', async () => {
+    const result = await server.handleStatus()
+    const block = findWarningBlock(result.content as ContentBlock[], PRECEDENCE_WARNING)
+    expect(block).toBeDefined()
+    const annotations = (block as { annotations?: { audience?: string[]; priority?: number } })
+      .annotations
+    expect(annotations).toBeDefined()
+    expect(annotations?.audience).toEqual(['user', 'assistant'])
+    expect(annotations?.priority).toBe(0.3)
+  })
+})
+
+// =============================================================================
+// No spurious blocks when no warnings and no configError exist.
+// =============================================================================
+describe('P3-T3: no spurious blocks when warnings absent', () => {
+  let server: RAGServer
+  const testDbPath = resolve('./tmp/test-lancedb-warning-visibility-clean')
+  const testDataDir = resolve('./tmp/test-data-warning-visibility-clean')
+  const sampleFile = resolve(testDataDir, 'sample.txt')
+
+  beforeAll(async () => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+    writeFileSync(
+      sampleFile,
+      'A small sample document used to confirm that responses contain only the primary content block when no warnings are configured.'
+    )
+
+    server = new RAGServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: './tmp/models',
+      baseDir: testDataDir,
+      maxFileSize: 100 * 1024 * 1024,
+      // No configWarnings, no configError.
+    })
+
+    await server.initialize()
+  }, 60000)
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+  })
+
+  it('status response has exactly one content block when no warnings', async () => {
+    const result = await server.handleStatus()
+    expect(result.content.length).toBe(1)
+  })
+
+  it('list_files response has exactly one content block when no warnings', async () => {
+    const result = await server.handleListFiles()
+    expect(result.content.length).toBe(1)
+  })
+
+  it('query_documents response has exactly one content block when no warnings', async () => {
+    const result = await server.handleQueryDocuments({ query: 'sample', limit: 1 })
+    expect(result.content.length).toBe(1)
+  })
+})

--- a/src/server/error-utils.ts
+++ b/src/server/error-utils.ts
@@ -1,3 +1,91 @@
+import type { Annotations } from '@modelcontextprotocol/sdk/types.js'
+
+/**
+ * Shape of a single MCP content block used by RAG server handlers. Mirrors
+ * the SDK's `TextContent` minus the strictly internal fields — defined here
+ * (rather than imported) because the SDK exposes the type through a
+ * widely-imported union; using a local alias keeps handler signatures stable
+ * if the SDK widens the union later.
+ */
+export type RagContentBlock = {
+  type: 'text'
+  text: string
+  annotations?: Annotations
+}
+
+/**
+ * Annotations applied to config-warning blocks. The audience covers both
+ * the assistant (so it can decide to mention the warning to the user) and
+ * the user (so MCP clients that render annotations visibly know to surface
+ * it). Priority 0.3 keeps the block secondary to the primary tool result.
+ */
+const WARNING_ANNOTATIONS: Annotations = {
+  audience: ['user', 'assistant'],
+  priority: 0.3,
+}
+
+/**
+ * Annotations applied to the config-error diagnostic block on `status`. The
+ * priority is raised relative to a warning because a config error means the
+ * server is degraded — `status` is the only tool still callable, and the
+ * user needs to see the error message to recover.
+ */
+const CONFIG_ERROR_ANNOTATIONS: Annotations = {
+  audience: ['user', 'assistant'],
+  priority: 0.9,
+}
+
+/**
+ * Build the (zero or one) warning content block for the supplied warnings.
+ *
+ * Returns `[]` when no warnings exist so the caller can spread the result
+ * unconditionally without producing a spurious block. The single emitted
+ * block joins all warnings with ` | ` so MCP clients display them together
+ * — the per-warning structured form lives in the configuration layer
+ * (`BaseDirsConfigWarning`); here we render a single user-facing string.
+ *
+ * Centralizing this in one helper is the design-doc-mandated countermeasure
+ * for the "warning shape changes touch many handlers" risk (P3-T3). Every
+ * handler must use this helper — do not inline the content shape.
+ */
+export function buildConfigWarningBlocks(warnings: readonly string[]): RagContentBlock[] {
+  if (warnings.length === 0) return []
+  return [
+    {
+      type: 'text',
+      text: `Warning: ${warnings.join(' | ')}`,
+      annotations: WARNING_ANNOTATIONS,
+    },
+  ]
+}
+
+/**
+ * Append config-warning blocks to an existing content array. Returns the
+ * same `content` reference for chainability (handlers typically build the
+ * array first, then call this once before returning).
+ */
+export function appendConfigWarnings(
+  content: RagContentBlock[],
+  warnings: readonly string[]
+): RagContentBlock[] {
+  content.push(...buildConfigWarningBlocks(warnings))
+  return content
+}
+
+/**
+ * Build a diagnostic content block exposing the supplied config-error
+ * message. Used by `status` when the server is in degraded mode (invalid
+ * `BASE_DIRS`) so the user can read the error via the MCP response without
+ * inspecting stderr.
+ */
+export function buildConfigErrorBlock(message: string): RagContentBlock {
+  return {
+    type: 'text',
+    text: `Configuration error: ${message}`,
+    annotations: CONFIG_ERROR_ANNOTATIONS,
+  }
+}
+
 /**
  * Format error message based on environment.
  * Shows stack trace in development mode for debugging.

--- a/src/server/error-utils.ts
+++ b/src/server/error-utils.ts
@@ -53,7 +53,7 @@ export function buildConfigWarningBlocks(warnings: readonly string[]): RagConten
   return [
     {
       type: 'text',
-      text: `Warning: ${warnings.join(' | ')}`,
+      text: `Warning: Tell the user about this configuration issue. ${warnings.join(' | ')}`,
       annotations: WARNING_ANNOTATIONS,
     },
   ]
@@ -81,7 +81,7 @@ export function appendConfigWarnings(
 export function buildConfigErrorBlock(message: string): RagContentBlock {
   return {
     type: 'text',
-    text: `Configuration error: ${message}`,
+    text: `Configuration error: Tell the user to fix this. ${message}`,
     annotations: CONFIG_ERROR_ANNOTATIONS,
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,7 @@ import { prepareVisualPdfChunks } from '../ingest/visual.js'
 import { parseHtml } from '../parser/html-parser.js'
 import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { extractMarkdownTitle, extractTxtTitle } from '../parser/title-extractor.js'
+import type { BaseDirsConfigError } from '../utils/base-dirs.js'
 import {
   type ContentFormat,
   extractSourceFromPath,
@@ -56,20 +57,54 @@ export class RAGServer {
   private readonly chunker: SemanticChunker
   private readonly parser: DocumentParser
   private readonly dbPath: string
+  /**
+   * One or more allowed document base directories. The single source of
+   * truth for both the security boundary (passed to `DocumentParser`) and
+   * for scan iteration in `list_files` (P3-T2). Normalized from either the
+   * legacy `{ baseDir }` config shape or the new `{ baseDirs }` shape so
+   * downstream readers do not need to branch on shape.
+   */
+  private readonly baseDirs: string[]
+  /**
+   * Legacy single-root accessor. Derived from `baseDirs[0]`. Preserved so
+   * the legacy `ListFilesResult.baseDir` field and any direct readers of
+   * `this.baseDir` continue to work; multi-root iteration uses `baseDirs`.
+   */
   private readonly baseDir: string
   private readonly cacheDir: string
   // Used by handleListFiles filter to exclude system-managed directories
   private readonly excludePaths: string[]
   private readonly configWarnings: string[]
+  /**
+   * Structured base-dirs resolution error. When non-null, the server is in
+   * degraded mode: `status` remains callable so the user can diagnose the
+   * problem via MCP, while root-dependent tools should surface this error
+   * (wired in P3-T3). See `resolveBaseDirs` for the error semantics.
+   */
+  private readonly configError: BaseDirsConfigError | null
   private readonly minChunkLength: number
   private readonly device: string | undefined
   private queryWarningsShown = false
 
   constructor(config: RAGServerConfig) {
     this.dbPath = config.dbPath
-    this.baseDir = config.baseDir
+    // Normalize both config shapes into a single `baseDirs: string[]`.
+    // Exactly one of `baseDir` / `baseDirs` is supplied (enforced by the
+    // discriminated union in `RAGServerConfig`); the runtime check below
+    // catches misuse from JS-only callers and degraded-mode bugs.
+    const normalizedBaseDirs =
+      config.baseDirs !== undefined ? [...config.baseDirs] : [config.baseDir]
+    const firstBaseDir = normalizedBaseDirs[0]
+    if (firstBaseDir === undefined) {
+      throw new Error(
+        'RAGServerConfig must provide either `baseDir` or a non-empty `baseDirs` array.'
+      )
+    }
+    this.baseDirs = normalizedBaseDirs
+    this.baseDir = firstBaseDir
     this.cacheDir = config.cacheDir
     this.configWarnings = config.configWarnings ?? []
+    this.configError = config.configError ?? null
     this.minChunkLength = config.chunkMinLength ?? DEFAULT_MIN_CHUNK_LENGTH
     this.device = config.device
     this.excludePaths = [`${resolve(this.dbPath)}${sep}`, `${resolve(this.cacheDir)}${sep}`]
@@ -109,12 +144,26 @@ export class RAGServer {
     this.chunker = new SemanticChunker(
       config.chunkMinLength !== undefined ? { minChunkLength: config.chunkMinLength } : {}
     )
+    // Always construct the parser with the multi-root shape — the parser
+    // accepts a single-element `baseDirs` array as the byte-equivalent of
+    // the legacy `baseDir` shape, so passing `this.baseDirs` covers both
+    // config inputs without branching here.
     this.parser = new DocumentParser({
-      baseDir: config.baseDir,
+      baseDirs: this.baseDirs,
       maxFileSize: config.maxFileSize,
     })
 
     this.setupHandlers()
+  }
+
+  /**
+   * Expose the base-dirs resolution error (if any) for the warning/error
+   * attachment layer added in P3-T3. Returns `null` when configuration
+   * resolved cleanly. Kept as a method so the field stays `private readonly`
+   * — only the handler layer that wires error responses needs read access.
+   */
+  getConfigError(): BaseDirsConfigError | null {
+    return this.configError
   }
 
   /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,14 +18,16 @@ import { prepareVisualPdfChunks } from '../ingest/visual.js'
 import { parseHtml } from '../parser/html-parser.js'
 import { DocumentParser, SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { extractMarkdownTitle, extractTxtTitle } from '../parser/title-extractor.js'
-import type { BaseDirsConfigError } from '../utils/base-dirs.js'
+import { type BaseDirsConfigError, displayPath } from '../utils/base-dirs.js'
 import {
   type ContentFormat,
   extractSourceFromPath,
   generateMetaJsonPath,
   generateRawDataPath,
-  isRawDataPath,
+  isPathInRawDataDir,
+  isPathInRawDataDirLexical,
   loadMetaJson,
+  looksLikeRawDataPath,
   saveMetaJson,
   saveRawData,
 } from '../utils/raw-data-utils.js'
@@ -68,7 +70,7 @@ export class RAGServer {
    * legacy `{ baseDir }` config shape or the new `{ baseDirs }` shape so
    * downstream readers do not need to branch on shape.
    */
-  private readonly baseDirs: string[]
+  private readonly baseDirs: readonly string[]
   /**
    * Legacy single-root accessor. Derived from `baseDirs[0]`. Preserved so
    * the legacy `ListFilesResult.baseDir` field and any direct readers of
@@ -98,13 +100,22 @@ export class RAGServer {
     const normalizedBaseDirs =
       config.baseDirs !== undefined ? [...config.baseDirs] : [config.baseDir]
     const firstBaseDir = normalizedBaseDirs[0]
-    if (firstBaseDir === undefined) {
+    // Empty `baseDirs` is accepted ONLY in degraded mode (configError set).
+    // In that case the server stays constructible so `status` remains
+    // callable, but every root-dependent tool fails fast via
+    // `assertConfigOk` before any baseDirs-dependent work. Without
+    // configError, an empty array is a misuse: reject up front rather than
+    // build a parser that silently rejects every path.
+    if (firstBaseDir === undefined && config.configError === undefined) {
       throw new Error(
-        'RAGServerConfig must provide either `baseDir` or a non-empty `baseDirs` array.'
+        'RAGServerConfig must provide either `baseDir` or a non-empty `baseDirs` array (empty `baseDirs` is allowed only in degraded mode with `configError` set).'
       )
     }
     this.baseDirs = normalizedBaseDirs
-    this.baseDir = firstBaseDir
+    // Legacy single-root accessor — empty-string when in degraded mode with
+    // an empty `baseDirs` array. `baseDir` is never consulted in degraded
+    // mode because `assertConfigOk` fires before any handler reaches it.
+    this.baseDir = firstBaseDir ?? ''
     this.cacheDir = config.cacheDir
     this.configWarnings = config.configWarnings ?? []
     this.configError = config.configError ?? null
@@ -255,8 +266,10 @@ export class RAGServer {
    * query_documents tool handler
    */
   async handleQueryDocuments(args: QueryDocumentsInput): Promise<{ content: RagContentBlock[] }> {
-    // Root-dependent tool: fail fast on configError BEFORE any embedder/DB access.
-    this.assertConfigOk()
+    // query_documents operates over the LanceDB only (no baseDirs access), so
+    // it stays callable in degraded mode (configError present). The warning
+    // and error blocks attached via `withWarnings` / status remain the user-
+    // visible diagnostic surface for the config problem.
     try {
       // Generate query embedding
       const queryVector = await this.embedder.embed(args.query)
@@ -274,8 +287,7 @@ export class RAGServer {
           fileTitle: result.fileTitle ?? null,
         }
 
-        // Restore source for raw-data files (ingested via ingest_data)
-        if (isRawDataPath(result.filePath)) {
+        if (looksLikeRawDataPath(result.filePath)) {
           const source = extractSourceFromPath(result.filePath)
           if (source) {
             queryResult.source = source
@@ -306,8 +318,11 @@ export class RAGServer {
    * ingest_file tool handler (re-ingestion support, transaction processing, rollback capability)
    */
   async handleIngestFile(args: IngestFileInput): Promise<{ content: RagContentBlock[] }> {
-    // Root-dependent tool: fail fast on configError BEFORE any work.
-    this.assertConfigOk()
+    // Skip the configError gate only for paths structurally inside
+    // `<dbPath>/raw-data/` (internal invocation from handleIngestData).
+    if (!(await isPathInRawDataDir(args.filePath, this.dbPath))) {
+      this.assertConfigOk()
+    }
     // Runtime validation (AC-012): the MCP JSON Schema declares `visual` as a
     // boolean and `IngestFileInput.visual` types it as `boolean | undefined`,
     // but tool arguments arrive as `unknown` at the SDK boundary so the
@@ -346,8 +361,8 @@ export class RAGServer {
       let title: string | null = null
       let chunks: Awaited<ReturnType<typeof buildChunksAndEmbeddings>>['chunks']
       let embeddings: Awaited<ReturnType<typeof buildChunksAndEmbeddings>>['embeddings']
-      if (isRawDataPath(args.filePath)) {
-        // Raw-data files: skip validation, read directly
+      if (await isPathInRawDataDir(args.filePath, this.dbPath)) {
+        // Raw-data files: skip parser validation, read directly.
         text = await readFile(args.filePath, 'utf-8')
         const meta = await loadMetaJson(args.filePath)
         title = meta?.title ?? null
@@ -536,8 +551,12 @@ export class RAGServer {
    * - Saves as .md file
    */
   async handleIngestData(args: IngestDataInput): Promise<{ content: RagContentBlock[] }> {
-    // Root-dependent tool: fail fast on configError BEFORE any I/O.
-    this.assertConfigOk()
+    // ingest_data writes only to `dbPath`/raw-data — it never reads from a
+    // configured `baseDir`. Keeping it callable in degraded mode means a user
+    // with invalid BASE_DIRS can still capture raw-data via MCP while they
+    // diagnose the config error from `status`. The internal `handleIngestFile`
+    // call below operates on a generated raw-data path, which routes
+    // around `parser.validateFilePath`, so no baseDirs access happens.
     try {
       let contentToSave = args.content
       let formatToSave: ContentFormat = args.metadata.format
@@ -611,22 +630,82 @@ export class RAGServer {
   }
 
   /**
-   * Scan a single base directory recursively for supported files, excluding
-   * system-managed paths (dbPath, cacheDir). Returns sorted absolute paths.
+   * Bounded BFS scan of a single base directory for supported files,
+   * excluding system-managed paths (dbPath, cacheDir). Returns sorted
+   * absolute paths plus a list of non-fatal warnings (Finding #10).
    *
-   * Extracted from `handleListFiles` so multi-root iteration stays readable
-   * and each root applies the exact same exclusion + extension filter. Errors
-   * propagate: a `readdir` failure for any root is fatal for `list_files`
-   * (the same as the legacy single-root behavior).
+   * Behavior contract:
+   *  - Depth is bounded by {@link RAGServer.LIST_MAX_DEPTH}, mirroring the
+   *    CLI ingest walker so the same "how deep do we look under a root"
+   *    boundary applies to every list/ingest surface.
+   *  - A `readdir` failure under one directory is captured as a warning
+   *    rather than aborting the whole list call. Pre-Finding-#10 behavior
+   *    propagated the error, which meant one unreadable root could hide
+   *    files under the other roots — the multi-root contract makes this
+   *    asymmetry user-visible, so the policy is now best-effort per root.
+   *  - Symlinks are skipped (mirrors the CLI ingest walker).
    */
-  private async scanBaseDir(baseDir: string): Promise<string[]> {
-    const entries = await readdir(baseDir, { recursive: true, withFileTypes: true })
-    return entries
-      .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
-      .map((e) => join(e.parentPath, e.name))
-      .filter((filePath) => !this.excludePaths.some((ep) => filePath.startsWith(ep)))
-      .sort()
+  private async scanBaseDir(baseDir: string): Promise<{ files: string[]; warnings: string[] }> {
+    const files: string[] = []
+    const warnings: string[] = []
+    let depthLimited = false
+
+    const queue: { dirPath: string; depth: number }[] = [{ dirPath: baseDir, depth: 0 }]
+
+    while (queue.length > 0) {
+      const { dirPath, depth } = queue.shift()!
+
+      if (depth >= RAGServer.LIST_MAX_DEPTH) {
+        depthLimited = true
+        continue
+      }
+
+      // TypeScript's `readdir` has overloads keyed on the options shape;
+      // pin the encoding to `'utf8'` and cast so the loop body operates on
+      // string-encoded Dirent entries (matches the rest of the codebase).
+      let entries: import('node:fs').Dirent<string>[]
+      try {
+        entries = (await readdir(dirPath, {
+          withFileTypes: true,
+          encoding: 'utf8',
+        })) as import('node:fs').Dirent<string>[]
+      } catch (error) {
+        const code =
+          error && typeof error === 'object' && 'code' in error
+            ? ((error as NodeJS.ErrnoException).code ?? 'UNKNOWN')
+            : 'UNKNOWN'
+        warnings.push(`cannot read directory: ${displayPath(dirPath)} (${code})`)
+        continue
+      }
+
+      for (const entry of entries) {
+        const fullPath = join(dirPath, entry.name)
+        if (entry.isSymbolicLink()) continue
+        if (this.excludePaths.some((ep) => fullPath.startsWith(ep))) continue
+        if (entry.isDirectory()) {
+          queue.push({ dirPath: fullPath, depth: depth + 1 })
+        } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+          files.push(fullPath)
+        }
+      }
+    }
+
+    if (depthLimited) {
+      warnings.push(
+        `some directories under ${displayPath(baseDir)} were skipped because they exceed the maximum depth (${RAGServer.LIST_MAX_DEPTH})`
+      )
+    }
+
+    files.sort()
+    return { files, warnings }
   }
+
+  /**
+   * Maximum directory recursion depth for `list_files` scans. Mirrors the
+   * CLI ingest walker's `MAX_DEPTH` so the same boundary applies across
+   * every list/ingest surface.
+   */
+  private static readonly LIST_MAX_DEPTH = 10
 
   /**
    * list_files tool handler
@@ -657,10 +736,16 @@ export class RAGServer {
       // root. Deduplicate exact duplicate file paths across roots; the first
       // occurrence wins so iteration order in `this.baseDirs` determines the
       // recorded producing root for files reachable from multiple roots.
+      // Per-root scan warnings (Finding #10) are aggregated and surfaced
+      // alongside the primary content block via `withWarnings` below.
       const files: FileEntry[] = []
       const seenPaths = new Set<string>()
+      const scanWarnings: string[] = []
       for (const baseDir of this.baseDirs) {
-        const scanned = await this.scanBaseDir(baseDir)
+        const { files: scanned, warnings: rootWarnings } = await this.scanBaseDir(baseDir)
+        for (const w of rootWarnings) {
+          scanWarnings.push(`[${baseDir}] ${w}`)
+        }
         for (const filePath of scanned) {
           if (seenPaths.has(filePath)) continue
           seenPaths.add(filePath)
@@ -686,7 +771,7 @@ export class RAGServer {
       const sources: SourceEntry[] = ingested
         .filter((f) => !seenPaths.has(f.filePath))
         .map((f) => {
-          if (isRawDataPath(f.filePath)) {
+          if (looksLikeRawDataPath(f.filePath)) {
             const source = extractSourceFromPath(f.filePath)
             if (source) return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
           }
@@ -699,9 +784,16 @@ export class RAGServer {
         files,
         sources,
       }
-      return {
-        content: this.withWarnings([{ type: 'text', text: JSON.stringify(result, null, 2) }]),
+      // Build the response with the primary JSON block first, then any
+      // per-root scan warnings (Finding #10) as additional text blocks so
+      // clients see the warnings alongside the file list without needing
+      // to inspect stderr. Config-level warnings (`configWarnings`) are
+      // still appended via `withWarnings`.
+      const content: RagContentBlock[] = [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+      for (const w of scanWarnings) {
+        content.push({ type: 'text', text: `Warning: ${w}` })
       }
+      return { content: this.withWarnings(content) }
     } catch (error) {
       console.error('Failed to list files:', error)
       throw error
@@ -744,18 +836,23 @@ export class RAGServer {
    * Supports both filePath (for ingest_file) and source (for ingest_data)
    */
   async handleDeleteFile(args: DeleteFileInput): Promise<{ content: RagContentBlock[] }> {
-    // Root-dependent tool: fail fast on configError BEFORE any DB / FS access.
-    this.assertConfigOk()
     try {
       let targetPath: string
       let skipValidation = false
 
       if (args.source) {
         // Generate raw-data path from source (extension is always .md)
-        // Internal path generation is secure, skip baseDir validation
+        // Internal path generation is secure, skip baseDir validation.
+        // The `source` branch never touches `baseDirs`, so it stays callable
+        // in degraded mode (configError present).
         targetPath = generateRawDataPath(this.dbPath, args.source, 'markdown')
         skipValidation = true
       } else if (args.filePath) {
+        // Root-dependent branch: a user-supplied filePath is validated against
+        // the configured roots, so we must fail fast when the config is
+        // invalid. Placed AFTER the `source` branch so source-mode requests
+        // continue to work in degraded mode.
+        this.assertConfigOk()
         targetPath = args.filePath
       } else {
         throw new Error('Either filePath or source must be provided')
@@ -770,8 +867,8 @@ export class RAGServer {
       await this.vectorStore.deleteChunks(targetPath)
       await this.vectorStore.optimize()
 
-      // Also delete physical raw-data file if applicable
-      if (isRawDataPath(targetPath)) {
+      // Also delete physical raw-data file if applicable.
+      if (isPathInRawDataDirLexical(targetPath, this.dbPath)) {
         try {
           await unlink(targetPath)
           console.error(`Deleted raw-data file: ${targetPath}`)
@@ -802,6 +899,13 @@ export class RAGServer {
         ]),
       }
     } catch (error) {
+      // Re-throw McpError as-is so structured tool errors (e.g. from
+      // `assertConfigOk` in the filePath branch) preserve their code at the
+      // MCP boundary instead of being wrapped in a generic Error.
+      if (error instanceof McpError) {
+        console.error('Failed to delete file:', error.message)
+        throw error
+      }
       const errorMessage = formatErrorMessage(error)
 
       console.error('Failed to delete file:', errorMessage)
@@ -819,8 +923,6 @@ export class RAGServer {
   async handleReadChunkNeighbors(
     args: ReadChunkNeighborsInput
   ): Promise<{ content: RagContentBlock[] }> {
-    // Root-dependent tool: fail fast on configError BEFORE any DB access.
-    this.assertConfigOk()
     try {
       // Validation (all before DB access, per Design Doc §Main Components → Handler).
       // Intentional: use McpError(InvalidParams) (upgrade from handleDeleteFile's plain Error).
@@ -858,6 +960,12 @@ export class RAGServer {
       // Dual-input resolution (mirrors handleDeleteFile).
       // Use the same non-empty predicates as the XOR check above so an empty
       // string ('' / whitespace-only) is ignored here too, not just in validation.
+      //
+      // configError gating happens AFTER the input-shape validation but BEFORE
+      // any parser/DB access on the user-supplied filePath. The `source` branch
+      // never touches `baseDirs`, so it stays callable in degraded mode; the
+      // `filePath` branch must fail fast because `parser.validateFilePath`
+      // depends on the configured roots being valid.
       let targetPath: string
       let skipValidation = false
       if (hasSource) {
@@ -865,6 +973,7 @@ export class RAGServer {
         skipValidation = true
       } else {
         // XOR + hasSource === false guarantees filePath is a non-empty string here.
+        this.assertConfigOk()
         targetPath = args.filePath as string
       }
       if (!skipValidation) {
@@ -879,7 +988,7 @@ export class RAGServer {
       const rows = await this.vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
 
       // Post-fetch marking: isTarget per item; source attached for raw-data rows.
-      const isRaw = isRawDataPath(targetPath)
+      const isRaw = looksLikeRawDataPath(targetPath)
       const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
       const items: ReadChunkNeighborsResultItem[] = rows.map((row) => {
         const item: ReadChunkNeighborsResultItem = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,6 @@ import { basename, extname, join, resolve, sep } from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
-  type Annotations,
   CallToolRequestSchema,
   ErrorCode,
   ListToolsRequestSchema,
@@ -32,7 +31,12 @@ import {
 } from '../utils/raw-data-utils.js'
 import { type VectorChunk, VectorStore } from '../vectordb/index.js'
 import { DatabaseError } from '../vectordb/types.js'
-import { formatErrorMessage } from './error-utils.js'
+import {
+  appendConfigWarnings,
+  buildConfigErrorBlock,
+  formatErrorMessage,
+  type RagContentBlock,
+} from './error-utils.js'
 import { toolDefinitions } from './tool-definitions.js'
 import type {
   DeleteFileInput,
@@ -84,7 +88,6 @@ export class RAGServer {
   private readonly configError: BaseDirsConfigError | null
   private readonly minChunkLength: number
   private readonly device: string | undefined
-  private queryWarningsShown = false
 
   constructor(config: RAGServerConfig) {
     this.dbPath = config.dbPath
@@ -167,25 +170,32 @@ export class RAGServer {
   }
 
   /**
-   * Build warning content blocks with MCP annotations.
-   * Returns an empty array if no warnings exist.
+   * Fail-fast guard for root-dependent tools. When a {@link BaseDirsConfigError}
+   * is stored on the instance the server is in degraded mode (invalid
+   * `BASE_DIRS` — see `resolveBaseDirs`) and every root-dependent tool MUST
+   * reject BEFORE any DB / embedder / parser access so the user sees the
+   * configuration problem unambiguously. Surfaces the error as an
+   * `McpError(InvalidParams)` so MCP clients render it as a structured tool
+   * error (per AC-009).
+   *
+   * `status` deliberately does NOT call this helper; it remains callable in
+   * degraded mode and exposes the error via a diagnostic content block so
+   * the user can recover via MCP without inspecting stderr.
    */
-  private buildWarningContentBlocks(): Array<{
-    type: 'text'
-    text: string
-    annotations: Annotations
-  }> {
-    if (this.configWarnings.length === 0) return []
-    return [
-      {
-        type: 'text' as const,
-        text: `Warning: ${this.configWarnings.join(' | ')}`,
-        annotations: {
-          audience: ['user', 'assistant'] as const,
-          priority: 0.3,
-        },
-      },
-    ]
+  private assertConfigOk(): void {
+    if (this.configError !== null) {
+      throw new McpError(ErrorCode.InvalidParams, this.configError.message)
+    }
+  }
+
+  /**
+   * Append the centralized config-warning blocks to a handler response.
+   * Every tool handler funnels through this method so the warning shape
+   * stays in exactly one place (design-doc-mandated countermeasure for the
+   * "warning shape changes touch many handlers" risk).
+   */
+  private withWarnings(content: RagContentBlock[]): RagContentBlock[] {
+    return appendConfigWarnings(content, this.configWarnings)
   }
 
   /**
@@ -244,9 +254,9 @@ export class RAGServer {
   /**
    * query_documents tool handler
    */
-  async handleQueryDocuments(
-    args: QueryDocumentsInput
-  ): Promise<{ content: Array<{ type: 'text'; text: string; annotations?: Annotations }> }> {
+  async handleQueryDocuments(args: QueryDocumentsInput): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any embedder/DB access.
+    this.assertConfigOk()
     try {
       // Generate query embedding
       const queryVector = await this.embedder.embed(args.query)
@@ -275,20 +285,17 @@ export class RAGServer {
         return queryResult
       })
 
-      const content: Array<{ type: 'text'; text: string; annotations?: Annotations }> = [
+      const content: RagContentBlock[] = [
         {
           type: 'text',
           text: JSON.stringify(results, null, 2),
         },
       ]
 
-      // Append config warnings on first query call only
-      if (!this.queryWarningsShown) {
-        content.push(...this.buildWarningContentBlocks())
-        this.queryWarningsShown = true
-      }
-
-      return { content }
+      // Append config warnings on every call. AC-009 requires visibility on
+      // every tool response because MCP clients may hide stderr and may not
+      // retain context across calls.
+      return { content: this.withWarnings(content) }
     } catch (error) {
       console.error('Failed to query documents:', error)
       throw error
@@ -298,9 +305,9 @@ export class RAGServer {
   /**
    * ingest_file tool handler (re-ingestion support, transaction processing, rollback capability)
    */
-  async handleIngestFile(
-    args: IngestFileInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  async handleIngestFile(args: IngestFileInput): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any work.
+    this.assertConfigOk()
     // Runtime validation (AC-012): the MCP JSON Schema declares `visual` as a
     // boolean and `IngestFileInput.visual` types it as `boolean | undefined`,
     // but tool arguments arrive as `unknown` at the SDK boundary so the
@@ -497,12 +504,12 @@ export class RAGServer {
       }
 
       return {
-        content: [
+        content: this.withWarnings([
           {
             type: 'text',
             text: JSON.stringify(result, null, 2),
           },
-        ],
+        ]),
       }
     } catch (error) {
       // Re-throw McpError as-is to preserve error code
@@ -528,9 +535,9 @@ export class RAGServer {
    * - Converts to Markdown for better chunking
    * - Saves as .md file
    */
-  async handleIngestData(
-    args: IngestDataInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  async handleIngestData(args: IngestDataInput): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any I/O.
+    this.assertConfigOk()
     try {
       let contentToSave = args.content
       let formatToSave: ContentFormat = args.metadata.format
@@ -638,7 +645,9 @@ export class RAGServer {
    *   producing-root annotation.
    * - Excludes `dbPath` and `cacheDir` uniformly across every root.
    */
-  async handleListFiles(): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  async handleListFiles(): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any DB / FS access.
+    this.assertConfigOk()
     try {
       // Get all ingested entries from the vector store
       const ingested = await this.vectorStore.listFiles()
@@ -691,7 +700,7 @@ export class RAGServer {
         sources,
       }
       return {
-        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        content: this.withWarnings([{ type: 'text', text: JSON.stringify(result, null, 2) }]),
       }
     } catch (error) {
       console.error('Failed to list files:', error)
@@ -702,22 +711,27 @@ export class RAGServer {
   /**
    * status tool handler (Phase 1: basic implementation)
    */
-  async handleStatus(): Promise<{
-    content: Array<{ type: 'text'; text: string; annotations?: Annotations }>
-  }> {
+  async handleStatus(): Promise<{ content: RagContentBlock[] }> {
+    // `status` remains callable in degraded mode (configError set) so the
+    // user can diagnose the root configuration via MCP without inspecting
+    // stderr. Do NOT call `assertConfigOk` here.
     try {
       const status = await this.vectorStore.getStatus()
-      const content: Array<{ type: 'text'; text: string; annotations?: Annotations }> = [
+      const content: RagContentBlock[] = [
         {
           type: 'text',
           text: JSON.stringify(status, null, 2),
         },
       ]
 
-      // Always append config warnings to status responses
-      content.push(...this.buildWarningContentBlocks())
+      // Surface the configError as a diagnostic content block when present.
+      // Placed BEFORE warning blocks so it appears with the primary status
+      // payload at a higher priority annotation.
+      if (this.configError !== null) {
+        content.push(buildConfigErrorBlock(this.configError.message))
+      }
 
-      return { content }
+      return { content: this.withWarnings(content) }
     } catch (error) {
       console.error('Failed to get status:', error)
       throw error
@@ -729,9 +743,9 @@ export class RAGServer {
    * Deletes chunks from VectorDB and physical raw-data files
    * Supports both filePath (for ingest_file) and source (for ingest_data)
    */
-  async handleDeleteFile(
-    args: DeleteFileInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  async handleDeleteFile(args: DeleteFileInput): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any DB / FS access.
+    this.assertConfigOk()
     try {
       let targetPath: string
       let skipValidation = false
@@ -780,12 +794,12 @@ export class RAGServer {
       }
 
       return {
-        content: [
+        content: this.withWarnings([
           {
             type: 'text',
             text: JSON.stringify(result, null, 2),
           },
-        ],
+        ]),
       }
     } catch (error) {
       const errorMessage = formatErrorMessage(error)
@@ -804,7 +818,9 @@ export class RAGServer {
    */
   async handleReadChunkNeighbors(
     args: ReadChunkNeighborsInput
-  ): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  ): Promise<{ content: RagContentBlock[] }> {
+    // Root-dependent tool: fail fast on configError BEFORE any DB access.
+    this.assertConfigOk()
     try {
       // Validation (all before DB access, per Design Doc §Main Components → Handler).
       // Intentional: use McpError(InvalidParams) (upgrade from handleDeleteFile's plain Error).
@@ -878,12 +894,12 @@ export class RAGServer {
       })
 
       return {
-        content: [
+        content: this.withWarnings([
           {
             type: 'text',
             text: JSON.stringify(items, null, 2),
           },
-        ],
+        ]),
       }
     } catch (error) {
       // Re-throw McpError / DatabaseError as-is to preserve semantics.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -604,8 +604,39 @@ export class RAGServer {
   }
 
   /**
+   * Scan a single base directory recursively for supported files, excluding
+   * system-managed paths (dbPath, cacheDir). Returns sorted absolute paths.
+   *
+   * Extracted from `handleListFiles` so multi-root iteration stays readable
+   * and each root applies the exact same exclusion + extension filter. Errors
+   * propagate: a `readdir` failure for any root is fatal for `list_files`
+   * (the same as the legacy single-root behavior).
+   */
+  private async scanBaseDir(baseDir: string): Promise<string[]> {
+    const entries = await readdir(baseDir, { recursive: true, withFileTypes: true })
+    return entries
+      .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
+      .map((e) => join(e.parentPath, e.name))
+      .filter((filePath) => !this.excludePaths.some((ep) => filePath.startsWith(ep)))
+      .sort()
+  }
+
+  /**
    * list_files tool handler
-   * Scans BASE_DIR for supported files and cross-references with ingested documents
+   *
+   * Scans every effective base directory (`this.baseDirs`) for supported
+   * files and cross-references with ingested documents. Multi-root contract
+   * (P3-T2, AC-008):
+   * - Returns top-level `baseDirs` (all effective roots, already realpath-
+   *   normalized and nested-root-pruned by `resolveBaseDirs`).
+   * - Preserves legacy top-level `baseDir = baseDirs[0]` for clients written
+   *   against the single-root shape.
+   * - Annotates each file entry with the producing `baseDir`.
+   * - De-duplicates exact duplicate file paths across roots (first occurrence
+   *   wins, preserving root iteration order).
+   * - Preserves raw-data / orphaned DB entries under `sources` with no
+   *   producing-root annotation.
+   * - Excludes `dbPath` and `cacheDir` uniformly across every root.
    */
   async handleListFiles(): Promise<{ content: [{ type: 'text'; text: string }] }> {
     try {
@@ -613,33 +644,38 @@ export class RAGServer {
       const ingested = await this.vectorStore.listFiles()
       const ingestedMap = new Map(ingested.map((f) => [f.filePath, f]))
 
-      // Scan BASE_DIR recursively for supported files.
-      // Errors propagate to the outer catch: if readdir fails, ingest_file and
-      // delete_file won't work either, so surfacing the error is appropriate.
-      const entries = await readdir(this.baseDir, { recursive: true, withFileTypes: true })
-      const baseDirFiles = entries
-        .filter((e) => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()))
-        .map((e) => {
-          const dir = e.parentPath
-          return join(dir, e.name)
-        })
-        .filter((filePath) => !this.excludePaths.some((ep) => filePath.startsWith(ep)))
-        .sort()
-
-      const baseDirSet = new Set(baseDirFiles)
-
-      // Files in BASE_DIR with ingestion status
-      const files: FileEntry[] = baseDirFiles.map((filePath) => {
-        const entry = ingestedMap.get(filePath)
-        return entry
-          ? { filePath, ingested: true, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
-          : { filePath, ingested: false }
-      })
+      // Iterate every effective root and collect entries with their producing
+      // root. Deduplicate exact duplicate file paths across roots; the first
+      // occurrence wins so iteration order in `this.baseDirs` determines the
+      // recorded producing root for files reachable from multiple roots.
+      const files: FileEntry[] = []
+      const seenPaths = new Set<string>()
+      for (const baseDir of this.baseDirs) {
+        const scanned = await this.scanBaseDir(baseDir)
+        for (const filePath of scanned) {
+          if (seenPaths.has(filePath)) continue
+          seenPaths.add(filePath)
+          const entry = ingestedMap.get(filePath)
+          files.push(
+            entry
+              ? {
+                  filePath,
+                  baseDir,
+                  ingested: true,
+                  chunkCount: entry.chunkCount,
+                  timestamp: entry.timestamp,
+                }
+              : { filePath, baseDir, ingested: false }
+          )
+        }
+      }
 
       // Content ingested via ingest_data (web pages, clipboard, etc.) plus any
-      // orphaned DB entries whose files no longer exist on disk
+      // orphaned DB entries whose files no longer exist on disk. `seenPaths`
+      // is the union across every scanned root, so a DB entry is only a
+      // source when it is not reachable from any effective root.
       const sources: SourceEntry[] = ingested
-        .filter((f) => !baseDirSet.has(f.filePath))
+        .filter((f) => !seenPaths.has(f.filePath))
         .map((f) => {
           if (isRawDataPath(f.filePath)) {
             const source = extractSourceFromPath(f.filePath)
@@ -648,7 +684,12 @@ export class RAGServer {
           return { filePath: f.filePath, chunkCount: f.chunkCount, timestamp: f.timestamp }
         })
 
-      const result: ListFilesResult = { baseDir: this.baseDir, files, sources }
+      const result: ListFilesResult = {
+        baseDir: this.baseDir,
+        baseDirs: [...this.baseDirs],
+        files,
+        sources,
+      }
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,20 +1,21 @@
 // Type definitions for RAGServer
 
+import type { BaseDirsConfigError } from '../utils/base-dirs.js'
 import type { ContentFormat } from '../utils/raw-data-utils.js'
 import type { GroupingMode } from '../vectordb/index.js'
 
 /**
- * RAGServer configuration
+ * Fields shared by both `RAGServerConfig` shapes (legacy single-root and
+ * multi-root). Extracted so the union below only needs to describe the
+ * `baseDir` / `baseDirs` axis.
  */
-export interface RAGServerConfig {
+interface RAGServerConfigBase {
   /** LanceDB database path */
   dbPath: string
   /** Transformers.js model path */
   modelName: string
   /** Model cache directory */
   cacheDir: string
-  /** Document base directory */
-  baseDir: string
   /** Maximum file size (100MB) */
   maxFileSize: number
   /** Compute device (cpu, webgpu, dml, etc) */
@@ -31,7 +32,36 @@ export interface RAGServerConfig {
   chunkMinLength?: number
   /** Configuration validation warnings to surface to users via MCP annotations */
   configWarnings?: string[]
+  /**
+   * Structured base-dirs resolution error. When present, the server is in
+   * degraded mode: `status` remains callable so the user can diagnose the
+   * problem via MCP, while root-dependent tools surface the error (handled
+   * in P3-T3). See `resolveBaseDirs` for the error semantics.
+   */
+  configError?: BaseDirsConfigError
 }
+
+/**
+ * RAGServer configuration.
+ *
+ * Accepts either a single `baseDir` (legacy shape — preserved so existing
+ * direct callers and tests that pass `{ baseDir }` continue to work) or
+ * `baseDirs` (multi-root shape produced by `resolveBaseDirs`). Exactly one
+ * of the two MUST be supplied. The constructor normalizes both into a single
+ * `baseDirs: string[]` internally and derives the legacy `baseDir` accessor
+ * as `baseDirs[0]`.
+ */
+export type RAGServerConfig =
+  | (RAGServerConfigBase & {
+      /** Document base directory (legacy single-root shape). */
+      baseDir: string
+      baseDirs?: undefined
+    })
+  | (RAGServerConfigBase & {
+      /** One or more allowed document base directories (multi-root shape). */
+      baseDirs: string[]
+      baseDir?: undefined
+    })
 
 /**
  * query_documents tool input

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -143,11 +143,23 @@ export interface IngestResult {
 }
 
 /**
- * list_files tool output — entry for a file found in BASE_DIR
+ * list_files tool output — entry for a file found under one of the effective
+ * base directories.
+ *
+ * `baseDir` identifies the producing root (one of `ListFilesResult.baseDirs`).
+ * Always present, including in single-root configurations — the field is
+ * additive over the legacy shape, so existing clients that ignore it continue
+ * to work. (P3-T2, AC-008)
  */
 export type FileEntry =
-  | { filePath: string; ingested: true; chunkCount: number; timestamp: string }
-  | { filePath: string; ingested: false }
+  | {
+      filePath: string
+      baseDir: string
+      ingested: true
+      chunkCount: number
+      timestamp: string
+    }
+  | { filePath: string; baseDir: string; ingested: false }
 
 /**
  * list_files tool output — entry for content ingested via ingest_data,
@@ -158,10 +170,24 @@ export type SourceEntry =
   | { filePath: string; chunkCount: number; timestamp: string }
 
 /**
- * list_files tool output
+ * list_files tool output.
+ *
+ * Multi-root contract (P3-T2, AC-008):
+ * - `baseDirs`: all effective roots (post realpath normalization and
+ *   nested-root pruning).
+ * - `baseDir`: the first effective root (`baseDirs[0]`). Preserved as a
+ *   legacy field so clients written against the single-root shape continue to
+ *   work.
+ * - `files`: union across roots, each annotated with its producing `baseDir`.
+ *   Exact duplicate paths across roots are de-duplicated (first occurrence
+ *   wins, preserving root iteration order).
+ * - `sources`: raw-data entries (from `ingest_data`) and orphaned DB entries
+ *   whose files no longer exist on disk. Sources are not produced by any
+ *   root, so they carry no `baseDir` annotation.
  */
 export interface ListFilesResult {
   baseDir: string
+  baseDirs: string[]
   files: FileEntry[]
   sources: SourceEntry[]
 }

--- a/src/utils/__tests__/base-dirs-resolver.test.ts
+++ b/src/utils/__tests__/base-dirs-resolver.test.ts
@@ -425,3 +425,63 @@ describe('resolveBaseDirs — parity with current single-root BASE_DIR behavior'
     }
   })
 })
+
+// ============================================
+// User-visible message hygiene ($HOME redaction)
+// ============================================
+
+describe('resolveBaseDirs — $HOME redaction in user-visible messages', () => {
+  // These tests pin the post-Finding-#8 contract: errors and warnings flow
+  // out through MCP responses to clients, so they must not embed the
+  // operating user's literal $HOME path. We assert against the literal
+  // current $HOME so a regression that leaks "/Users/<name>/..." fails here.
+  let savedHome: string | undefined
+
+  beforeAll(() => {
+    savedHome = process.env['HOME']
+  })
+
+  afterAll(() => {
+    if (savedHome === undefined) {
+      delete process.env['HOME']
+    } else {
+      process.env['HOME'] = savedHome
+    }
+  })
+
+  it('omits $HOME from a missing-directory error message', async () => {
+    // The missing-directory error message is built BEFORE realpath
+    // resolution succeeds, so the pre-realpath form is what flows out.
+    // Pin HOME to the raw tmpRoot (matches the value `normalizeRealpath`
+    // passes to the error message) and assert the substitution kicks in.
+    process.env['HOME'] = tmpRoot
+    const missing = join(tmpRoot, 'does-not-exist-leak-check')
+    const result = await resolveBaseDirs({ cliRoots: [missing], cwd: tmpRoot })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      // The substituted form uses `~`; the literal HOME must not appear.
+      expect(result.error.message).toContain('~')
+      expect(result.error.message).not.toContain(tmpRoot)
+    }
+  })
+
+  it('omits $HOME from the nested-root-pruned warning message', async () => {
+    // The pruning warning is emitted AFTER realpath normalization, so the
+    // displayPath substitution operates against the realpath form. Pin HOME
+    // to the realpath of tmpRoot (on macOS, `/var/folders/...` realpaths to
+    // `/private/var/folders/...`) so the substitution fires deterministically.
+    const realTmpRoot = realpathSync(tmpRoot)
+    process.env['HOME'] = realTmpRoot
+    const result = await resolveBaseDirs({
+      cliRoots: [nestedParent, nestedChild],
+      cwd: tmpRoot,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      const pruned = result.warnings.find((w) => w.kind === 'nested-root-pruned')
+      expect(pruned).toBeDefined()
+      expect(pruned?.message).toContain('~')
+      expect(pruned?.message).not.toContain(realTmpRoot)
+    }
+  })
+})

--- a/src/utils/__tests__/base-dirs-resolver.test.ts
+++ b/src/utils/__tests__/base-dirs-resolver.test.ts
@@ -14,6 +14,12 @@ import { join, sep } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type BaseDirsConfigWarning, resolveBaseDirs, withTrailingSeparator } from '../base-dirs.js'
 
+// Windows uses DOS-8.3 short names in TEMP (e.g. RUNNER~1). `realpathSync`
+// (pure JS) returns the short form; production's `fs/promises.realpath` is
+// libuv-native and returns the long form. Use the native sync variant in
+// fixtures so expected and actual canonicalize identically.
+const realpathNative: (p: string) => string = realpathSync.native ?? realpathSync
+
 // ============================================
 // Shared temp directory fixture
 // ============================================
@@ -41,9 +47,9 @@ beforeAll(() => {
   mkdirSync(dirA, { recursive: true })
   mkdirSync(dirB, { recursive: true })
   mkdirSync(nestedChild, { recursive: true })
-  realA = realpathSync(dirA)
-  realB = realpathSync(dirB)
-  realNestedParent = realpathSync(nestedParent)
+  realA = realpathNative(dirA)
+  realB = realpathNative(dirB)
+  realNestedParent = realpathNative(nestedParent)
 })
 
 afterAll(() => {
@@ -470,7 +476,7 @@ describe('resolveBaseDirs — $HOME redaction in user-visible messages', () => {
     // displayPath substitution operates against the realpath form. Pin HOME
     // to the realpath of tmpRoot (on macOS, `/var/folders/...` realpaths to
     // `/private/var/folders/...`) so the substitution fires deterministically.
-    const realTmpRoot = realpathSync(tmpRoot)
+    const realTmpRoot = realpathNative(tmpRoot)
     process.env['HOME'] = realTmpRoot
     const result = await resolveBaseDirs({
       cliRoots: [nestedParent, nestedChild],

--- a/src/utils/__tests__/base-dirs-resolver.test.ts
+++ b/src/utils/__tests__/base-dirs-resolver.test.ts
@@ -281,6 +281,41 @@ describe('resolveBaseDirs — cwd fallback', () => {
     expect(result.ok).toBe(false)
   })
 
+  it('treats an empty-string envBaseDirs as unset and falls through to BASE_DIR', async () => {
+    // BASE_DIRS being an empty string (e.g. `BASE_DIRS=` with no value) is
+    // distinguishable from "set to invalid JSON" — the resolver should treat
+    // it the same as "not set" so existing single-root users who export an
+    // empty BASE_DIRS alongside their BASE_DIR are not broken.
+    const result = await resolveBaseDirs({
+      envBaseDirs: '',
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      // Empty envBaseDirs means "not set", so no precedence warning.
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('falls back to cwd when both envBaseDirs and envBaseDir are empty strings', async () => {
+    // Both env vars exported but empty — e.g., `BASE_DIRS= BASE_DIR=` — must
+    // resolve to cwd, matching the behavior of fully unset env vars.
+    const result = await resolveBaseDirs({
+      envBaseDirs: '',
+      envBaseDir: '',
+      cwd: dirA,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
   it('treats an explicitly empty cliRoots array as "no CLI override"', async () => {
     // The CLI parser will pass `cliRoots: undefined` when no --base-dir flag
     // is present, but defensively the resolver should also accept an empty

--- a/src/utils/__tests__/base-dirs-resolver.test.ts
+++ b/src/utils/__tests__/base-dirs-resolver.test.ts
@@ -1,0 +1,392 @@
+// Unit tests for `resolveBaseDirs` — the CLI/env → effective-roots resolver.
+//
+// Covers the precedence rules required by the multi-base-dirs feature plan:
+//   CLI roots > BASE_DIRS > BASE_DIR > cwd
+//
+// The resolver returns a discriminated union so callers do not need try/catch
+// for routine config validation branches. Realpath-dependent scenarios use a
+// real temp directory so the helpers exercise the same code path as
+// production (mocking `realpath` would only verify wiring).
+
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { type BaseDirsConfigWarning, resolveBaseDirs, withTrailingSeparator } from '../base-dirs.js'
+
+// ============================================
+// Shared temp directory fixture
+// ============================================
+
+let tmpRoot: string
+let dirA: string
+let dirB: string
+let nestedParent: string
+let nestedChild: string
+
+// realpath-resolved (without trailing sep) versions, computed once after
+// fixture creation. macOS `tmpdir()` is `/var/folders/...` but realpath
+// resolves to `/private/var/folders/...`, so we cannot use the raw paths in
+// equality assertions.
+let realA: string
+let realB: string
+let realNestedParent: string
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'base-dirs-resolver-test-'))
+  dirA = join(tmpRoot, 'dir-a')
+  dirB = join(tmpRoot, 'dir-b')
+  nestedParent = join(tmpRoot, 'nested-parent')
+  nestedChild = join(nestedParent, 'child')
+  mkdirSync(dirA, { recursive: true })
+  mkdirSync(dirB, { recursive: true })
+  mkdirSync(nestedChild, { recursive: true })
+  realA = realpathSync(dirA)
+  realB = realpathSync(dirB)
+  realNestedParent = realpathSync(nestedParent)
+})
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+// ============================================
+// CLI roots precedence
+// ============================================
+
+describe('resolveBaseDirs — CLI roots precedence', () => {
+  it('uses a single --base-dir value as the only root', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [dirA],
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('preserves order for two --base-dir values', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [dirA, dirB],
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([
+        withTrailingSeparator(realA),
+        withTrailingSeparator(realB),
+      ])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('ignores env vars when CLI roots are provided (no precedence warning)', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [dirA],
+      envBaseDirs: JSON.stringify([dirB]),
+      envBaseDir: dirB,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      // No `base-dirs-overrides-base-dir` warning because CLI took precedence.
+      const precedenceWarnings = result.warnings.filter(
+        (w: BaseDirsConfigWarning) => w.kind === 'base-dirs-overrides-base-dir'
+      )
+      expect(precedenceWarnings).toEqual([])
+    }
+  })
+
+  it('does not merge CLI roots with env roots', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [dirA],
+      envBaseDirs: JSON.stringify([dirB]),
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // dirB must NOT appear in the resolved roots — CLI replaces env.
+      expect(result.config.baseDirs).not.toContain(withTrailingSeparator(realB))
+    }
+  })
+})
+
+// ============================================
+// BASE_DIRS precedence
+// ============================================
+
+describe('resolveBaseDirs — BASE_DIRS precedence', () => {
+  it('uses BASE_DIRS when CLI roots are absent', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: JSON.stringify([dirA, dirB]),
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([
+        withTrailingSeparator(realA),
+        withTrailingSeparator(realB),
+      ])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('emits a precedence warning when both BASE_DIRS and BASE_DIR are set (no CLI)', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: JSON.stringify([dirA]),
+      envBaseDir: dirB,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // BASE_DIR is ignored — only BASE_DIRS roots appear.
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      const precedenceWarnings = result.warnings.filter(
+        (w: BaseDirsConfigWarning) => w.kind === 'base-dirs-overrides-base-dir'
+      )
+      expect(precedenceWarnings).toHaveLength(1)
+      expect(precedenceWarnings[0]?.message).toMatch(/BASE_DIRS/)
+      expect(precedenceWarnings[0]?.message).toMatch(/BASE_DIR/)
+    }
+  })
+
+  it('returns a config error for invalid BASE_DIRS and does NOT fall back', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: 'not json',
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.name).toBe('BaseDirsConfigError')
+      expect(result.error.message).toMatch(/BASE_DIRS/)
+    }
+  })
+
+  it('returns a config error for empty BASE_DIRS array and does NOT fall back', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: '[]',
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/empty/i)
+    }
+  })
+
+  it('returns a config error for BASE_DIRS containing an empty string', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: `["${dirA}", ""]`,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns a config error when a BASE_DIRS path does not exist', async () => {
+    const missing = join(tmpRoot, 'does-not-exist')
+    const result = await resolveBaseDirs({
+      envBaseDirs: JSON.stringify([missing]),
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.name).toBe('BaseDirsConfigError')
+    }
+  })
+})
+
+// ============================================
+// BASE_DIR precedence
+// ============================================
+
+describe('resolveBaseDirs — BASE_DIR precedence', () => {
+  it('uses BASE_DIR when CLI and BASE_DIRS are absent', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('treats an empty BASE_DIR as unset and falls back to cwd', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDir: '',
+      cwd: dirA,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+    }
+  })
+
+  it('treats a whitespace-only BASE_DIR as unset and falls back to cwd', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDir: '   ',
+      cwd: dirA,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+    }
+  })
+})
+
+// ============================================
+// cwd fallback
+// ============================================
+
+describe('resolveBaseDirs — cwd fallback', () => {
+  it('uses cwd when nothing else is set', async () => {
+    const result = await resolveBaseDirs({ cwd: dirA })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('treats a whitespace-only envBaseDirs as unset and falls back to BASE_DIR', async () => {
+    // Whitespace-only BASE_DIRS is rejected by parseBaseDirsEnv (returns
+    // error). The resolver MUST propagate that error rather than falling
+    // back to BASE_DIR — the parser already documented this as a config
+    // error rather than as "not provided".
+    const result = await resolveBaseDirs({
+      envBaseDirs: '   ',
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('treats an explicitly empty cliRoots array as "no CLI override"', async () => {
+    // The CLI parser will pass `cliRoots: undefined` when no --base-dir flag
+    // is present, but defensively the resolver should also accept an empty
+    // array as "no CLI override" rather than as "user wants zero roots".
+    const result = await resolveBaseDirs({
+      cliRoots: [],
+      envBaseDir: dirA,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+    }
+  })
+})
+
+// ============================================
+// Deduplication and nested-root pruning
+// ============================================
+
+describe('resolveBaseDirs — dedup and nested pruning', () => {
+  it('deduplicates exact duplicate CLI roots silently', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [dirA, dirA],
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realA)])
+      // No warning for exact dedup.
+      expect(result.warnings).toEqual([])
+    }
+  })
+
+  it('prunes nested CLI roots and emits a pruning warning', async () => {
+    const result = await resolveBaseDirs({
+      cliRoots: [nestedParent, nestedChild],
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realNestedParent)])
+      const pruningWarnings = result.warnings.filter(
+        (w: BaseDirsConfigWarning) => w.kind === 'nested-root-pruned'
+      )
+      expect(pruningWarnings).toHaveLength(1)
+    }
+  })
+
+  it('prunes nested BASE_DIRS roots and emits a pruning warning', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: JSON.stringify([nestedParent, nestedChild]),
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realNestedParent)])
+      const pruningWarnings = result.warnings.filter(
+        (w: BaseDirsConfigWarning) => w.kind === 'nested-root-pruned'
+      )
+      expect(pruningWarnings).toHaveLength(1)
+    }
+  })
+
+  it('combines the precedence warning and pruning warnings when both apply', async () => {
+    const result = await resolveBaseDirs({
+      envBaseDirs: JSON.stringify([nestedParent, nestedChild]),
+      envBaseDir: dirB,
+      cwd: tmpRoot,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs).toEqual([withTrailingSeparator(realNestedParent)])
+      const kinds = result.warnings.map((w: BaseDirsConfigWarning) => w.kind)
+      expect(kinds).toContain('base-dirs-overrides-base-dir')
+      expect(kinds).toContain('nested-root-pruned')
+    }
+  })
+})
+
+// ============================================
+// Single-root BASE_DIR parity with current server-main.ts behavior
+// ============================================
+
+describe('resolveBaseDirs — parity with current single-root BASE_DIR behavior', () => {
+  it('resolves BASE_DIR=A identically to "cwd fallback" when cwd === A', async () => {
+    const withEnv = await resolveBaseDirs({ envBaseDir: dirA, cwd: tmpRoot })
+    const withCwd = await resolveBaseDirs({ cwd: dirA })
+
+    expect(withEnv.ok).toBe(true)
+    expect(withCwd.ok).toBe(true)
+    if (withEnv.ok && withCwd.ok) {
+      expect(withEnv.config.baseDirs).toEqual(withCwd.config.baseDirs)
+    }
+  })
+
+  it('produces a root with trailing path separator suitable for prefix checks', async () => {
+    const result = await resolveBaseDirs({ envBaseDir: dirA, cwd: tmpRoot })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.baseDirs[0]?.endsWith(sep)).toBe(true)
+    }
+  })
+})

--- a/src/utils/__tests__/base-dirs.test.ts
+++ b/src/utils/__tests__/base-dirs.test.ts
@@ -19,6 +19,7 @@ import {
   BaseDirsConfigError,
   type BaseDirsConfigWarning,
   dedupAndPruneRoots,
+  displayPath,
   legacyBaseDir,
   normalizeRealpath,
   parseBaseDirsEnv,
@@ -286,5 +287,53 @@ describe('legacyBaseDir', () => {
   it('returns the only element for a single-root config', () => {
     const config: BaseDirsConfig = { baseDirs: ['/only/'] }
     expect(legacyBaseDir(config)).toBe('/only/')
+  })
+})
+
+// ============================================
+// displayPath — $HOME substitution for user-visible messages
+// ============================================
+
+describe('displayPath', () => {
+  // Save+restore $HOME so the assertions stay deterministic even when the
+  // test runner inherits the developer's actual home directory.
+  let originalHome: string | undefined
+
+  beforeAll(() => {
+    originalHome = process.env['HOME']
+  })
+
+  afterAll(() => {
+    if (originalHome === undefined) {
+      delete process.env['HOME']
+    } else {
+      process.env['HOME'] = originalHome
+    }
+  })
+
+  it('substitutes the exact $HOME prefix with ~', () => {
+    process.env['HOME'] = '/Users/jdoe'
+    expect(displayPath('/Users/jdoe/work/docs')).toBe('~/work/docs')
+  })
+
+  it('returns the exact $HOME path as ~', () => {
+    process.env['HOME'] = '/Users/jdoe'
+    expect(displayPath('/Users/jdoe')).toBe('~')
+  })
+
+  it('leaves sibling paths that merely share a prefix unchanged', () => {
+    // `/Users/jdoe-other/...` MUST NOT collapse to `~-other/...`.
+    process.env['HOME'] = '/Users/jdoe'
+    expect(displayPath('/Users/jdoe-other/docs')).toBe('/Users/jdoe-other/docs')
+  })
+
+  it('returns the path unchanged when $HOME is unset', () => {
+    delete process.env['HOME']
+    expect(displayPath('/Users/jdoe/work/docs')).toBe('/Users/jdoe/work/docs')
+  })
+
+  it('returns the path unchanged when $HOME does not match', () => {
+    process.env['HOME'] = '/Users/jdoe'
+    expect(displayPath('/var/lib/data')).toBe('/var/lib/data')
   })
 })

--- a/src/utils/__tests__/base-dirs.test.ts
+++ b/src/utils/__tests__/base-dirs.test.ts
@@ -209,8 +209,8 @@ describe('dedupAndPruneRoots', () => {
     expect(warnings).toHaveLength(1)
     const warning = warnings[0] as BaseDirsConfigWarning
     expect(warning.kind).toBe('nested-root-pruned')
-    expect(warning.message).toContain(resolvedParent)
-    expect(warning.message).toContain(resolvedChild)
+    expect(warning.message).toContain(displayPath(resolvedParent))
+    expect(warning.message).toContain(displayPath(resolvedChild))
   })
 
   it('prunes a nested child even when listed before its parent', async () => {

--- a/src/utils/__tests__/base-dirs.test.ts
+++ b/src/utils/__tests__/base-dirs.test.ts
@@ -224,6 +224,40 @@ describe('dedupAndPruneRoots', () => {
     expect(warnings).toHaveLength(1)
   })
 
+  it('prunes both child and grandchild in a 3-level chain, keeping only the grandparent', async () => {
+    // Chain: grandparent / parent / child — the implementation documents that
+    // both descendants get pruned and each warning references the closest
+    // surviving ancestor (the grandparent, since `parent` is itself pruned).
+    const grandparent = join(tmpRoot, 'chain-grand')
+    const parent = join(grandparent, 'middle')
+    const child = join(parent, 'leaf')
+    mkdirSync(child, { recursive: true })
+    const resolvedGrand = await normalizeRealpath(grandparent)
+    const resolvedParent = await normalizeRealpath(parent)
+    const resolvedChild = await normalizeRealpath(child)
+
+    const { roots, warnings } = dedupAndPruneRoots([resolvedGrand, resolvedParent, resolvedChild])
+
+    expect(roots).toEqual([resolvedGrand])
+    expect(warnings).toHaveLength(2)
+    // Both pruned entries should reference the grandparent as the closest
+    // surviving ancestor, not the (also-pruned) parent.
+    for (const warning of warnings) {
+      expect(warning.kind).toBe('nested-root-pruned')
+      if (warning.kind === 'nested-root-pruned') {
+        expect(warning.parent).toBe(resolvedGrand)
+      }
+    }
+    const prunedPaths = warnings
+      .filter(
+        (w): w is Extract<BaseDirsConfigWarning, { kind: 'nested-root-pruned' }> =>
+          w.kind === 'nested-root-pruned'
+      )
+      .map((w) => w.pruned)
+    expect(prunedPaths).toContain(resolvedParent)
+    expect(prunedPaths).toContain(resolvedChild)
+  })
+
   it('keeps unrelated sibling roots that share a prefix but are not nested', async () => {
     // /foo/bar should NOT be considered nested under /foo/barista.
     const bar = join(tmpRoot, 'bar')

--- a/src/utils/__tests__/base-dirs.test.ts
+++ b/src/utils/__tests__/base-dirs.test.ts
@@ -1,0 +1,256 @@
+// Unit tests for the shared base-dirs module.
+//
+// Covers the pure helpers consumed by both CLI and server entry points:
+// - JSON-array parser for the `BASE_DIRS` environment variable
+// - Realpath normalization + trailing-separator prefix safety
+// - Exact deduplication and nested-root pruning
+// - Legacy single-root accessor compatibility
+//
+// Realpath-dependent scenarios use a real temp directory so the helpers
+// exercise the same behavior they will hit in production (mocking `realpath`
+// would only verify wiring, not correctness).
+
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  type BaseDirsConfig,
+  BaseDirsConfigError,
+  type BaseDirsConfigWarning,
+  dedupAndPruneRoots,
+  legacyBaseDir,
+  normalizeRealpath,
+  parseBaseDirsEnv,
+  withTrailingSeparator,
+} from '../base-dirs.js'
+
+// ============================================
+// Shared temp directory fixture
+// ============================================
+
+let tmpRoot: string
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'base-dirs-test-'))
+})
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+// ============================================
+// parseBaseDirsEnv — JSON-array parser
+// ============================================
+
+describe('parseBaseDirsEnv', () => {
+  it('parses a valid JSON array of non-empty strings', () => {
+    const result = parseBaseDirsEnv('["/a","/b","/c"]')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toEqual(['/a', '/b', '/c'])
+    }
+  })
+
+  it('rejects non-JSON input', () => {
+    const result = parseBaseDirsEnv('not json')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(BaseDirsConfigError)
+      expect(result.error.message).toMatch(/BASE_DIRS/)
+    }
+  })
+
+  it('rejects delimiter syntax like /a:/b', () => {
+    const result = parseBaseDirsEnv('/a:/b')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(BaseDirsConfigError)
+    }
+  })
+
+  it('rejects an empty array', () => {
+    const result = parseBaseDirsEnv('[]')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/empty/i)
+    }
+  })
+
+  it('rejects an array containing an empty string', () => {
+    const result = parseBaseDirsEnv('[""]')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(BaseDirsConfigError)
+    }
+  })
+
+  it('rejects an array containing a non-string element', () => {
+    const result = parseBaseDirsEnv('[1, 2]')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(BaseDirsConfigError)
+    }
+  })
+
+  it('rejects a JSON object (must be an array)', () => {
+    const result = parseBaseDirsEnv('{"a":"/a"}')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a JSON string scalar', () => {
+    const result = parseBaseDirsEnv('"/a"')
+    expect(result.ok).toBe(false)
+  })
+
+  it('trims whitespace around the JSON payload', () => {
+    const result = parseBaseDirsEnv('  ["/a"]  ')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toEqual(['/a'])
+    }
+  })
+
+  it('rejects an array containing a whitespace-only string', () => {
+    const result = parseBaseDirsEnv('["   "]')
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ============================================
+// withTrailingSeparator — prefix safety helper
+// ============================================
+
+describe('withTrailingSeparator', () => {
+  it('appends a path separator when one is missing', () => {
+    expect(withTrailingSeparator(`${sep}foo${sep}bar`)).toBe(`${sep}foo${sep}bar${sep}`)
+  })
+
+  it('leaves an already-suffixed path unchanged', () => {
+    expect(withTrailingSeparator(`${sep}foo${sep}bar${sep}`)).toBe(`${sep}foo${sep}bar${sep}`)
+  })
+
+  it('produces a prefix that does not match a sibling like /foo/barista', () => {
+    const root = withTrailingSeparator(`${sep}foo${sep}bar`)
+    const sibling = `${sep}foo${sep}barista`
+    expect(sibling.startsWith(root)).toBe(false)
+  })
+
+  it('produces a prefix that does match a true child like /foo/bar/baz', () => {
+    const root = withTrailingSeparator(`${sep}foo${sep}bar`)
+    const child = `${sep}foo${sep}bar${sep}baz`
+    expect(child.startsWith(root)).toBe(true)
+  })
+})
+
+// ============================================
+// normalizeRealpath — realpath + trailing separator
+// ============================================
+
+describe('normalizeRealpath', () => {
+  it('resolves a real directory to its realpath with a trailing separator', async () => {
+    const dir = join(tmpRoot, 'real-dir')
+    mkdirSync(dir)
+    const result = await normalizeRealpath(dir)
+    expect(result.endsWith(sep)).toBe(true)
+    // realpath may add /private prefix on macOS — only assert tail invariants.
+    expect(result).toMatch(/real-dir[\\/]$/)
+  })
+
+  it('follows symlinks to the target directory', async () => {
+    const target = join(tmpRoot, 'sym-target')
+    const link = join(tmpRoot, 'sym-link')
+    mkdirSync(target)
+    symlinkSync(target, link, 'dir')
+    const resolved = await normalizeRealpath(link)
+    expect(resolved).toMatch(/sym-target[\\/]$/)
+  })
+
+  it('rejects when the path does not exist', async () => {
+    await expect(normalizeRealpath(join(tmpRoot, 'does-not-exist'))).rejects.toBeInstanceOf(
+      BaseDirsConfigError
+    )
+  })
+})
+
+// ============================================
+// dedupAndPruneRoots — exact dedup + nested pruning
+// ============================================
+
+describe('dedupAndPruneRoots', () => {
+  it('returns a single root unchanged with no warnings', async () => {
+    const root = join(tmpRoot, 'single')
+    mkdirSync(root, { recursive: true })
+    const resolved = await normalizeRealpath(root)
+    const { roots, warnings } = dedupAndPruneRoots([resolved])
+    expect(roots).toEqual([resolved])
+    expect(warnings).toEqual([])
+  })
+
+  it('deduplicates exact duplicate realpath roots without emitting a warning', async () => {
+    const root = join(tmpRoot, 'dup')
+    mkdirSync(root, { recursive: true })
+    const resolved = await normalizeRealpath(root)
+    const { roots, warnings } = dedupAndPruneRoots([resolved, resolved])
+    expect(roots).toEqual([resolved])
+    expect(warnings).toEqual([])
+  })
+
+  it('prunes a nested child root and emits a warning referencing parent and child', async () => {
+    const parent = join(tmpRoot, 'parent')
+    const child = join(parent, 'child')
+    mkdirSync(child, { recursive: true })
+    const resolvedParent = await normalizeRealpath(parent)
+    const resolvedChild = await normalizeRealpath(child)
+
+    const { roots, warnings } = dedupAndPruneRoots([resolvedParent, resolvedChild])
+    expect(roots).toEqual([resolvedParent])
+    expect(warnings).toHaveLength(1)
+    const warning = warnings[0] as BaseDirsConfigWarning
+    expect(warning.kind).toBe('nested-root-pruned')
+    expect(warning.message).toContain(resolvedParent)
+    expect(warning.message).toContain(resolvedChild)
+  })
+
+  it('prunes a nested child even when listed before its parent', async () => {
+    const parent = join(tmpRoot, 'order-parent')
+    const child = join(parent, 'inner')
+    mkdirSync(child, { recursive: true })
+    const resolvedParent = await normalizeRealpath(parent)
+    const resolvedChild = await normalizeRealpath(child)
+
+    const { roots, warnings } = dedupAndPruneRoots([resolvedChild, resolvedParent])
+    expect(roots).toEqual([resolvedParent])
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('keeps unrelated sibling roots that share a prefix but are not nested', async () => {
+    // /foo/bar should NOT be considered nested under /foo/barista.
+    const bar = join(tmpRoot, 'bar')
+    const barista = join(tmpRoot, 'barista')
+    mkdirSync(bar, { recursive: true })
+    mkdirSync(barista, { recursive: true })
+    const resolvedBar = await normalizeRealpath(bar)
+    const resolvedBarista = await normalizeRealpath(barista)
+
+    const { roots, warnings } = dedupAndPruneRoots([resolvedBar, resolvedBarista])
+    expect(roots).toEqual([resolvedBar, resolvedBarista])
+    expect(warnings).toEqual([])
+  })
+})
+
+// ============================================
+// legacyBaseDir — single-root accessor
+// ============================================
+
+describe('legacyBaseDir', () => {
+  it('returns the first effective root as the legacy baseDir', () => {
+    const config: BaseDirsConfig = { baseDirs: ['/first/', '/second/'] }
+    expect(legacyBaseDir(config)).toBe('/first/')
+  })
+
+  it('returns the only element for a single-root config', () => {
+    const config: BaseDirsConfig = { baseDirs: ['/only/'] }
+    expect(legacyBaseDir(config)).toBe('/only/')
+  })
+})

--- a/src/utils/__tests__/sensitive-path.test.ts
+++ b/src/utils/__tests__/sensitive-path.test.ts
@@ -1,0 +1,42 @@
+// Sensitive-path policy unit tests
+// Test Type: Unit Test
+
+import { describe, expect, it } from 'vitest'
+
+import { buildSensitivePrefixes } from '../sensitive-path.js'
+
+describe('buildSensitivePrefixes', () => {
+  it('keeps both the literal and the realpath-resolved form', () => {
+    const fakeRealpath = (p: string) => (p === '/etc' ? '/private/etc' : p)
+    const prefixes = buildSensitivePrefixes(fakeRealpath)
+    expect(prefixes).toContain('/etc')
+    expect(prefixes).toContain('/private/etc')
+  })
+
+  it('retains the literal when realpath throws (fail-closed)', () => {
+    const failing = (_p: string) => {
+      throw new Error('ENOENT')
+    }
+    const prefixes = buildSensitivePrefixes(failing)
+    expect(prefixes).toContain('/etc')
+    expect(prefixes).toContain('/var')
+  })
+
+  it('ignores realpath results that are empty or non-strings', () => {
+    const empty = (_p: string) => ''
+    const prefixes = buildSensitivePrefixes(empty)
+    // Only the literals remain.
+    for (const literal of ['/etc', '/usr', '/sys', '/proc', '/var']) {
+      expect(prefixes).toContain(literal)
+    }
+    expect(prefixes.some((p) => p === '')).toBe(false)
+  })
+
+  it('deduplicates when realpath returns the literal itself', () => {
+    const identity = (p: string) => p
+    const prefixes = buildSensitivePrefixes(identity)
+    const counts = new Map<string, number>()
+    for (const p of prefixes) counts.set(p, (counts.get(p) ?? 0) + 1)
+    for (const [, n] of counts) expect(n).toBe(1)
+  })
+})

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -13,6 +13,7 @@
 // currently inlines.
 
 import { realpath, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { resolve, sep } from 'node:path'
 
 // ============================================
@@ -91,14 +92,11 @@ export type ParseBaseDirsResult =
  * supported; other paths pass through unchanged.
  */
 export function displayPath(path: string): string {
-  const home = process.env['HOME']
-  if (home === undefined || home.length === 0) return path
+  const home = process.env['HOME'] || homedir()
+  if (home.length === 0) return path
   if (path === home) return '~'
-  // Match `${home}/...` only — guard against `/Users/me-other/...` colliding
-  // with a literal substring check.
   if (path.startsWith(home + sep) || path.startsWith(`${home}/`)) {
-    const tail = path.slice(home.length)
-    return `~${tail}`
+    return `~${path.slice(home.length)}`
   }
   return path
 }

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -74,6 +74,36 @@ export type ParseBaseDirsResult =
   | { ok: false; error: BaseDirsConfigError }
 
 // ============================================
+// Path display helpers
+// ============================================
+
+/**
+ * Render an absolute path for inclusion in user-visible error/warning
+ * messages, substituting the current `$HOME` prefix with `~`. The substitution
+ * keeps the message useful for debugging while avoiding leaking the operating
+ * username when warnings/errors flow out through MCP responses to clients.
+ *
+ * `$HOME` resolution is read once at call time, so processes that mutate
+ * `HOME` between invocations still see the current value (no caching).
+ *
+ * Exact-match on the home directory itself (`/Users/me` → `~`) and prefix
+ * match with a trailing separator (`/Users/me/work` → `~/work`) are both
+ * supported; other paths pass through unchanged.
+ */
+export function displayPath(path: string): string {
+  const home = process.env['HOME']
+  if (home === undefined || home.length === 0) return path
+  if (path === home) return '~'
+  // Match `${home}/...` only — guard against `/Users/me-other/...` colliding
+  // with a literal substring check.
+  if (path.startsWith(home + sep) || path.startsWith(`${home}/`)) {
+    const tail = path.slice(home.length)
+    return `~${tail}`
+  }
+  return path
+}
+
+// ============================================
 // JSON-array parser for BASE_DIRS
 // ============================================
 
@@ -182,7 +212,7 @@ export async function normalizeRealpath(path: string): Promise<string> {
     resolved = await realpath(resolve(path))
   } catch (error) {
     throw new BaseDirsConfigError(
-      `Failed to resolve base directory: ${path}. The directory may not exist or is inaccessible.`,
+      `Failed to resolve base directory: ${displayPath(path)}. The directory may not exist or is inaccessible.`,
       error as Error
     )
   }
@@ -192,14 +222,14 @@ export async function normalizeRealpath(path: string): Promise<string> {
     stats = await stat(resolved)
   } catch (error) {
     throw new BaseDirsConfigError(
-      `Failed to stat resolved base directory: ${resolved}.`,
+      `Failed to stat resolved base directory: ${displayPath(resolved)}.`,
       error as Error
     )
   }
 
   if (!stats.isDirectory()) {
     throw new BaseDirsConfigError(
-      `Base directory is not a directory: ${path} (resolved: ${resolved}).`
+      `Base directory is not a directory: ${displayPath(path)} (resolved: ${displayPath(resolved)}).`
     )
   }
 
@@ -288,7 +318,7 @@ export function dedupAndPruneRoots(inputs: string[]): DedupAndPruneResult {
     }
     warnings.push({
       kind: 'nested-root-pruned',
-      message: `Nested base directory pruned: ${candidate} is inside ${survivingAncestor}. Keeping ${survivingAncestor} only.`,
+      message: `Nested base directory pruned: ${displayPath(candidate)} is inside ${displayPath(survivingAncestor)}. Keeping ${displayPath(survivingAncestor)} only.`,
       parent: survivingAncestor,
       pruned: candidate,
     })

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -94,8 +94,12 @@ export type ParseBaseDirsResult =
 export function displayPath(path: string): string {
   const home = process.env['HOME'] || homedir()
   if (home.length === 0) return path
-  if (path === home) return '~'
-  if (path.startsWith(home + sep) || path.startsWith(`${home}/`)) {
+  const isWin = process.platform === 'win32'
+  const cmp = (s: string) => (isWin ? s.toLowerCase() : s)
+  const homeCmp = cmp(home)
+  const pathCmp = cmp(path)
+  if (pathCmp === homeCmp) return '~'
+  if (pathCmp.startsWith(homeCmp + sep) || pathCmp.startsWith(`${homeCmp}/`)) {
     return `~${path.slice(home.length)}`
   }
   return path

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -260,20 +260,36 @@ export function dedupAndPruneRoots(inputs: string[]): DedupAndPruneResult {
   //
   // When a chain like `[grandparent, parent, child]` is provided, both
   // `parent` and `child` are pruned and each emits a warning referencing the
-  // closest surviving ancestor (the grandparent). This is the same result the
-  // user would have gotten by passing only the grandparent.
+  // closest SURVIVING ancestor (the grandparent). This is the same result the
+  // user would have gotten by passing only the grandparent, and avoids the
+  // confusing case where a warning points at another path that was itself
+  // pruned. Implementation note: a single pass over `deduped` in input order
+  // works because exact-prefix ancestors of a candidate must precede it in
+  // the realpath-sorted-by-discovery order only when shorter; we therefore
+  // compute the closest ancestor against the surviving `roots` set so the
+  // reported parent is always a surviving root.
   const roots: string[] = []
   const warnings: BaseDirsConfigWarning[] = []
+  // Pre-pass: identify every candidate that has any ancestor in `deduped`
+  // (these are the pruned candidates). The candidates that do NOT have any
+  // ancestor in `deduped` are the surviving roots.
+  const survivors: string[] = []
   for (const candidate of deduped) {
-    const parent = findParent(candidate, deduped)
-    if (parent === undefined) {
+    if (findParent(candidate, deduped) === undefined) {
+      survivors.push(candidate)
+    }
+  }
+  for (const candidate of deduped) {
+    const survivingAncestor = findParent(candidate, survivors)
+    if (survivingAncestor === undefined) {
+      // This candidate is itself a surviving root.
       roots.push(candidate)
       continue
     }
     warnings.push({
       kind: 'nested-root-pruned',
-      message: `Nested base directory pruned: ${candidate} is inside ${parent}. Keeping ${parent} only.`,
-      parent,
+      message: `Nested base directory pruned: ${candidate} is inside ${survivingAncestor}. Keeping ${survivingAncestor} only.`,
+      parent: survivingAncestor,
       pruned: candidate,
     })
   }

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -1,0 +1,346 @@
+// Shared base-dirs module.
+//
+// Provides one internal representation of the effective document roots used
+// by both the CLI (`ingest`, `list`, ...) and the MCP server entry point
+// (`server-main.ts`), plus the pure helpers needed to derive it from raw
+// configuration inputs (env vars, CLI flags).
+//
+// Scope: this file ships only pure helpers and the types. Wiring into
+// `DocumentParser`, `RAGServer`, and CLI subcommands is performed by later
+// tasks (P1-T2 / P1-T3 / P2-T1 / P3-T1). Keeping the wiring out of this
+// module lets every consumer adopt the same realpath/prefix-safety semantics
+// without duplicating the trailing-separator pattern that `DocumentParser`
+// currently inlines.
+
+import { realpath, stat } from 'node:fs/promises'
+import { resolve, sep } from 'node:path'
+
+// ============================================
+// Types
+// ============================================
+
+/**
+ * Internal representation of the effective document roots.
+ *
+ * `baseDirs` is the post-normalization, post-deduplication, post-nested-prune
+ * list of realpath-resolved directories used as the security boundary for
+ * file access. Order is preserved from the original configuration input so
+ * the first element is meaningful as the legacy single-root accessor (see
+ * {@link legacyBaseDir}).
+ */
+export interface BaseDirsConfig {
+  baseDirs: string[]
+}
+
+/**
+ * Discriminated union of configuration warnings surfaced by helpers in this
+ * module. Both CLI (stderr) and MCP (tool response content block) paths
+ * consume these — the consumer decides how to render them.
+ */
+export type BaseDirsConfigWarning =
+  | {
+      kind: 'nested-root-pruned'
+      message: string
+      parent: string
+      pruned: string
+    }
+  | {
+      kind: 'base-dirs-overrides-base-dir'
+      message: string
+    }
+
+/**
+ * Configuration error raised by parsers and the realpath helper. Modeled as
+ * a dedicated subclass so consumers can distinguish configuration problems
+ * from other I/O errors (e.g. `ValidationError` from `DocumentParser`).
+ */
+export class BaseDirsConfigError extends Error {
+  constructor(
+    message: string,
+    public override readonly cause?: Error
+  ) {
+    super(message)
+    this.name = 'BaseDirsConfigError'
+  }
+}
+
+/**
+ * Result of {@link parseBaseDirsEnv}. A discriminated union avoids forcing
+ * callers to use `try/catch` for what is a routine configuration-validation
+ * branch (invalid input → structured error → user-facing message).
+ */
+export type ParseBaseDirsResult =
+  | { ok: true; value: string[] }
+  | { ok: false; error: BaseDirsConfigError }
+
+// ============================================
+// JSON-array parser for BASE_DIRS
+// ============================================
+
+/**
+ * Parse the `BASE_DIRS` environment variable.
+ *
+ * Accepts only a JSON array of one or more non-empty, non-whitespace-only
+ * strings — e.g. `'["/Users/me/work","/Users/me/specs"]'`. Anything else
+ * (delimiter syntax such as `'/a:/b'`, an empty array, an array containing
+ * empty strings, non-string elements, JSON scalars, JSON objects, ...)
+ * produces a {@link BaseDirsConfigError}.
+ *
+ * This helper performs only syntactic validation. It does not resolve
+ * realpaths or check that the directories exist — that is the job of
+ * {@link normalizeRealpath} after the resolver picks a source.
+ */
+export function parseBaseDirsEnv(raw: string): ParseBaseDirsResult {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      error: new BaseDirsConfigError(
+        'BASE_DIRS must be a JSON array of non-empty path strings (received empty value).'
+      ),
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (error) {
+    return {
+      ok: false,
+      error: new BaseDirsConfigError(
+        `BASE_DIRS must be a JSON array of non-empty path strings. Failed to parse as JSON: ${truncate(raw)}`,
+        error as Error
+      ),
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: new BaseDirsConfigError(
+        `BASE_DIRS must be a JSON array (received ${describeJsonShape(parsed)}).`
+      ),
+    }
+  }
+
+  if (parsed.length === 0) {
+    return {
+      ok: false,
+      error: new BaseDirsConfigError('BASE_DIRS must not be an empty array.'),
+    }
+  }
+
+  const value: string[] = []
+  for (let i = 0; i < parsed.length; i++) {
+    const item = parsed[i]
+    if (typeof item !== 'string') {
+      return {
+        ok: false,
+        error: new BaseDirsConfigError(
+          `BASE_DIRS[${i}] must be a string (received ${describeJsonShape(item)}).`
+        ),
+      }
+    }
+    if (item.trim().length === 0) {
+      return {
+        ok: false,
+        error: new BaseDirsConfigError(
+          `BASE_DIRS[${i}] must be a non-empty, non-whitespace path string.`
+        ),
+      }
+    }
+    value.push(item)
+  }
+
+  return { ok: true, value }
+}
+
+// ============================================
+// Realpath normalization
+// ============================================
+
+/**
+ * Append a trailing path separator if the input does not already end with
+ * one. This is the prefix-safety pattern used throughout the parser
+ * (`/foo/bar` must not match `/foo/barista`).
+ */
+export function withTrailingSeparator(path: string): string {
+  return path.endsWith(sep) ? path : path + sep
+}
+
+/**
+ * Resolve a directory to its realpath form and append a trailing separator
+ * so the result can be used directly as a prefix in security checks.
+ *
+ * Throws {@link BaseDirsConfigError} when the directory does not exist or
+ * is not a directory — root configuration must point at real directories
+ * the process is allowed to read.
+ */
+export async function normalizeRealpath(path: string): Promise<string> {
+  let resolved: string
+  try {
+    resolved = await realpath(resolve(path))
+  } catch (error) {
+    throw new BaseDirsConfigError(
+      `Failed to resolve base directory: ${path}. The directory may not exist or is inaccessible.`,
+      error as Error
+    )
+  }
+
+  let stats: Awaited<ReturnType<typeof stat>>
+  try {
+    stats = await stat(resolved)
+  } catch (error) {
+    throw new BaseDirsConfigError(
+      `Failed to stat resolved base directory: ${resolved}.`,
+      error as Error
+    )
+  }
+
+  if (!stats.isDirectory()) {
+    throw new BaseDirsConfigError(
+      `Base directory is not a directory: ${path} (resolved: ${resolved}).`
+    )
+  }
+
+  return withTrailingSeparator(resolved)
+}
+
+// ============================================
+// Deduplication and nested-root pruning
+// ============================================
+
+/**
+ * Output of {@link dedupAndPruneRoots}.
+ */
+export interface DedupAndPruneResult {
+  /** Effective roots in input order, after exact dedup and nested pruning. */
+  roots: string[]
+  /** Warnings describing pruned nested roots, in pruning order. */
+  warnings: BaseDirsConfigWarning[]
+}
+
+/**
+ * Reduce a list of realpath-normalized roots to the effective set.
+ *
+ * Behavior:
+ *  - Exact duplicates (`A === B` after realpath normalization) are silently
+ *    deduplicated. This is treated as user convenience rather than a
+ *    configuration mistake, so no warning is emitted.
+ *  - Nested roots (`B` lives under `A` after realpath normalization) are
+ *    pruned: the parent `A` is kept, the child `B` is dropped, and a
+ *    `nested-root-pruned` warning describes both paths. This avoids
+ *    duplicate `list_files` / CLI scan output without widening the security
+ *    boundary beyond the parent root the user already configured.
+ *
+ * Input order is preserved for the surviving roots so the first element
+ * remains a meaningful legacy `baseDir` (see {@link legacyBaseDir}).
+ *
+ * All inputs MUST already have a trailing separator (see
+ * {@link normalizeRealpath}) — that is what makes the `startsWith`-based
+ * nested check safe against sibling-prefix paths like `/foo/barista`.
+ */
+export function dedupAndPruneRoots(inputs: string[]): DedupAndPruneResult {
+  // Phase 1: exact dedup, preserving order.
+  const deduped: string[] = []
+  const seen = new Set<string>()
+  for (const root of inputs) {
+    if (!seen.has(root)) {
+      seen.add(root)
+      deduped.push(root)
+    }
+  }
+
+  // Phase 2: nested-root pruning.
+  //
+  // A root `child` is pruned when some other root `parent` (parent !== child)
+  // is a strict prefix of `child`. Because every input ends with `sep`, the
+  // prefix check correctly distinguishes `/foo/bar/` (parent of `/foo/bar/baz/`)
+  // from `/foo/barista/` (sibling, not a parent).
+  //
+  // When a chain like `[grandparent, parent, child]` is provided, both
+  // `parent` and `child` are pruned and each emits a warning referencing the
+  // closest surviving ancestor (the grandparent). This is the same result the
+  // user would have gotten by passing only the grandparent.
+  const roots: string[] = []
+  const warnings: BaseDirsConfigWarning[] = []
+  for (const candidate of deduped) {
+    const parent = findParent(candidate, deduped)
+    if (parent === undefined) {
+      roots.push(candidate)
+      continue
+    }
+    warnings.push({
+      kind: 'nested-root-pruned',
+      message: `Nested base directory pruned: ${candidate} is inside ${parent}. Keeping ${parent} only.`,
+      parent,
+      pruned: candidate,
+    })
+  }
+
+  return { roots, warnings }
+}
+
+/**
+ * Return the closest ancestor of `candidate` in `all` (excluding `candidate`
+ * itself), or `undefined` if no ancestor exists. Closest is measured by
+ * prefix length — longer prefix wins so we report the most specific
+ * surviving parent.
+ */
+function findParent(candidate: string, all: string[]): string | undefined {
+  let best: string | undefined
+  for (const other of all) {
+    if (other === candidate) continue
+    // `other` ends with `sep` (precondition), so this prefix check is
+    // sibling-prefix safe.
+    if (candidate.startsWith(other)) {
+      if (best === undefined || other.length > best.length) {
+        best = other
+      }
+    }
+  }
+  return best
+}
+
+// ============================================
+// Legacy single-root accessor
+// ============================================
+
+/**
+ * Return the legacy single-root `baseDir` value for a {@link BaseDirsConfig}.
+ *
+ * Used for backward compatibility with consumers (and response fields) that
+ * pre-date the multi-root model. The contract is "first effective root after
+ * normalization and nested-root pruning"; callers must build the config via
+ * {@link dedupAndPruneRoots} for this to hold.
+ */
+export function legacyBaseDir(config: BaseDirsConfig): string {
+  const first = config.baseDirs[0]
+  if (first === undefined) {
+    throw new BaseDirsConfigError('BaseDirsConfig must contain at least one base directory.')
+  }
+  return first
+}
+
+// ============================================
+// Private helpers
+// ============================================
+
+/**
+ * Describe a JSON value's shape for error messages without dumping its full
+ * (possibly large) content.
+ */
+function describeJsonShape(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
+}
+
+/**
+ * Truncate user-supplied input so configuration error messages stay readable
+ * even when the offending value is large.
+ */
+function truncate(input: string, max = 100): string {
+  if (input.length <= max) return input
+  return `${input.slice(0, max)}...`
+}

--- a/src/utils/base-dirs.ts
+++ b/src/utils/base-dirs.ts
@@ -303,6 +303,177 @@ function findParent(candidate: string, all: string[]): string | undefined {
 }
 
 // ============================================
+// Root resolver
+// ============================================
+
+/**
+ * Input to {@link resolveBaseDirs}. Each axis maps directly to one of the
+ * configuration sources defined in the multi-base-dirs plan:
+ *
+ *  - `cliRoots` — collected `--base-dir` flag occurrences (highest precedence)
+ *  - `envBaseDirs` — raw `BASE_DIRS` env value (JSON array)
+ *  - `envBaseDir` — raw `BASE_DIR` env value (single path string)
+ *  - `cwd` — `process.cwd()` snapshot (lowest precedence, always required)
+ *
+ * The resolver is pure with respect to its inputs (no `process.env` reads,
+ * no `process.cwd()` calls) so it can be exercised under deterministic tests
+ * and reused from both the CLI entry and the MCP server entry without
+ * implicitly depending on process state.
+ */
+export interface ResolveBaseDirsInput {
+  cliRoots?: string[] | undefined
+  envBaseDirs?: string | undefined
+  envBaseDir?: string | undefined
+  cwd: string
+}
+
+/**
+ * Result of {@link resolveBaseDirs}. Discriminated by `ok` so callers can
+ * branch on configuration validity without try/catch — invalid `BASE_DIRS`
+ * is a routine user-facing error path, not an exceptional condition.
+ *
+ * On success, `warnings` aggregates every warning surfaced during resolution
+ * in display order:
+ *  1. `base-dirs-overrides-base-dir` (when applicable) — shown first so the
+ *     precedence note is visible before per-root pruning notes.
+ *  2. `nested-root-pruned` — one warning per pruned child, in pruning order.
+ */
+export type ResolveBaseDirsResult =
+  | { ok: true; config: BaseDirsConfig; warnings: BaseDirsConfigWarning[] }
+  | { ok: false; error: BaseDirsConfigError }
+
+/**
+ * Resolve effective base directories from CLI / env / cwd inputs.
+ *
+ * Resolution order (per the multi-base-dirs plan):
+ *   1. `cliRoots` (one or more `--base-dir` flags) — when non-empty, replaces
+ *      env roots. CLI and env are never merged.
+ *   2. `envBaseDirs` (JSON array) — when CLI roots are absent.
+ *   3. `envBaseDir` (single path) — when CLI and `BASE_DIRS` are absent.
+ *   4. `cwd` — when none of the above are set.
+ *
+ * Warning rules:
+ *  - `BASE_DIRS > BASE_DIR` precedence warning fires only when CLI roots are
+ *    absent AND both `BASE_DIRS` and `BASE_DIR` are set. CLI-driven runs do
+ *    not produce this warning even if both env vars are also set.
+ *  - Nested-root pruning warnings always fire when applicable, regardless
+ *    of which source provided the roots.
+ *
+ * Error rules:
+ *  - Invalid `BASE_DIRS` (malformed JSON, non-array, empty array, empty
+ *    string element, ...) returns `{ ok: false, error }`. The resolver does
+ *    NOT fall back to `BASE_DIR` or `cwd` — callers surface the error per
+ *    their UI contract (CLI exit code, MCP tool error, `status` diagnostic).
+ *  - A path that fails realpath resolution (does not exist, not a directory,
+ *    permission denied) also returns `{ ok: false, error }`. Roots must
+ *    point at real directories the process is allowed to read.
+ *
+ * Post-resolution normalization:
+ *  - Every selected path is realpath-normalized and gets a trailing path
+ *    separator (see {@link normalizeRealpath}) so it can be used as a prefix
+ *    in security checks.
+ *  - Exact duplicates are silently deduplicated.
+ *  - Nested roots are pruned with a warning (see {@link dedupAndPruneRoots}).
+ */
+export async function resolveBaseDirs(input: ResolveBaseDirsInput): Promise<ResolveBaseDirsResult> {
+  const selection = selectRoots(input)
+  if (!selection.ok) {
+    return selection
+  }
+
+  const warnings: BaseDirsConfigWarning[] = []
+  if (selection.precedenceWarning) {
+    warnings.push(selection.precedenceWarning)
+  }
+
+  // Realpath-normalize each selected root. Failures (missing directory,
+  // permission denied, ...) are surfaced as a structured config error.
+  const normalized: string[] = []
+  for (const root of selection.roots) {
+    try {
+      normalized.push(await normalizeRealpath(root))
+    } catch (error) {
+      if (error instanceof BaseDirsConfigError) {
+        return { ok: false, error }
+      }
+      throw error
+    }
+  }
+
+  const { roots, warnings: pruningWarnings } = dedupAndPruneRoots(normalized)
+  warnings.push(...pruningWarnings)
+
+  return {
+    ok: true,
+    config: { baseDirs: roots },
+    warnings,
+  }
+}
+
+/**
+ * Output of {@link selectRoots}. Either picks a source's raw paths (still
+ * un-normalized) plus an optional precedence warning, or returns a structured
+ * error so the caller can short-circuit.
+ */
+type SelectRootsResult =
+  | {
+      ok: true
+      roots: string[]
+      precedenceWarning?: BaseDirsConfigWarning
+    }
+  | { ok: false; error: BaseDirsConfigError }
+
+/**
+ * Apply the source-precedence rules to pick which input set of roots to use.
+ *
+ * Kept as a small helper so the realpath normalization in
+ * {@link resolveBaseDirs} stays focused on I/O, not precedence logic. This
+ * function performs only string-level parsing and selection — no fs access.
+ */
+function selectRoots(input: ResolveBaseDirsInput): SelectRootsResult {
+  // 1. CLI roots — when non-empty, replace env entirely (no precedence
+  //    warning even if env vars are also set, because the user explicitly
+  //    overrode them via CLI).
+  if (input.cliRoots !== undefined && input.cliRoots.length > 0) {
+    return { ok: true, roots: input.cliRoots }
+  }
+
+  // 2. BASE_DIRS — when CLI absent. Whitespace-only is treated as an
+  //    invalid value (consistent with parseBaseDirsEnv), not as "unset",
+  //    so the user notices a malformed env var instead of silently falling
+  //    through to BASE_DIR.
+  if (input.envBaseDirs !== undefined && input.envBaseDirs.length > 0) {
+    const parsed = parseBaseDirsEnv(input.envBaseDirs)
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error }
+    }
+
+    const precedenceWarning =
+      input.envBaseDir !== undefined && input.envBaseDir.trim().length > 0
+        ? ({
+            kind: 'base-dirs-overrides-base-dir',
+            message:
+              'BASE_DIRS is set; BASE_DIR is ignored. Unset BASE_DIR or remove BASE_DIRS to silence this warning.',
+          } satisfies BaseDirsConfigWarning)
+        : undefined
+
+    return precedenceWarning
+      ? { ok: true, roots: parsed.value, precedenceWarning }
+      : { ok: true, roots: parsed.value }
+  }
+
+  // 3. BASE_DIR — when CLI and BASE_DIRS are absent. Whitespace-only is
+  //    treated as "unset" (a user clearing the value with spaces gets the
+  //    same behavior as not setting it at all).
+  if (input.envBaseDir !== undefined && input.envBaseDir.trim().length > 0) {
+    return { ok: true, roots: [input.envBaseDir] }
+  }
+
+  // 4. cwd — final fallback.
+  return { ok: true, roots: [input.cwd] }
+}
+
+// ============================================
 // Legacy single-root accessor
 // ============================================
 

--- a/src/utils/raw-data-utils.ts
+++ b/src/utils/raw-data-utils.ts
@@ -1,8 +1,8 @@
 // Raw Data Utilities for ingest_data tool
 // Handles: base64url encoding, source normalization, file saving, source extraction
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve, sep } from 'node:path'
 
 // ============================================
 // Base64URL Encoding/Decoding
@@ -159,15 +159,47 @@ export async function saveRawData(
 // ============================================
 
 /**
- * Check if file path is in raw-data directory
- *
- * @param filePath - File path to check
- * @returns True if path is in raw-data directory
+ * Display-only heuristic. NOT a security boundary — use
+ * {@link isPathInRawDataDir} when the result gates filesystem access.
  */
-export function isRawDataPath(filePath: string): boolean {
-  // Normalize Windows backslashes for cross-platform path detection
+export function looksLikeRawDataPath(filePath: string): boolean {
   const normalized = filePath.replace(/\\/g, '/')
   return normalized.includes('/raw-data/')
+}
+
+/**
+ * Case-normalize a path for prefix containment. Windows filesystems are
+ * case-insensitive by default, so the boundary check must mirror that.
+ */
+function caseNormalize(p: string): string {
+  return process.platform === 'win32' ? p.toLowerCase() : p
+}
+
+/**
+ * Lexical containment in `<dbPath>/raw-data/`. Safe for cleanup gates
+ * (`unlink` does not follow symlinks). Use {@link isPathInRawDataDir}
+ * when the result controls `readFile`.
+ */
+export function isPathInRawDataDirLexical(filePath: string, dbPath: string): boolean {
+  const target = caseNormalize(resolve(filePath))
+  const rawDir = caseNormalize(resolve(getRawDataDir(dbPath)))
+  return target === rawDir || target.startsWith(rawDir + sep)
+}
+
+/**
+ * Lexical containment plus `realpath` so a symlink under raw-data
+ * pointing outside cannot route a read through the raw-data fast-path.
+ * Fail-closed on `realpath` errors.
+ */
+export async function isPathInRawDataDir(filePath: string, dbPath: string): Promise<boolean> {
+  if (!isPathInRawDataDirLexical(filePath, dbPath)) return false
+  try {
+    const realTarget = caseNormalize(await realpath(resolve(filePath)))
+    const realRaw = caseNormalize(await realpath(resolve(getRawDataDir(dbPath))))
+    return realTarget === realRaw || realTarget.startsWith(realRaw + sep)
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/utils/sensitive-path.ts
+++ b/src/utils/sensitive-path.ts
@@ -1,0 +1,89 @@
+// Sensitive-path policy shared by the CLI and the MCP server entry point.
+//
+// Both entry points must refuse to use system or credential directories as
+// document roots: pre-multi-root code only enforced this at the CLI surface,
+// which left a gap where `BASE_DIRS=["/etc"]` in the MCP server's environment
+// would be silently accepted. This module owns the single source of truth
+// for the policy so the CLI (`cli/options.ts` and `cli/common.ts`) and the
+// server entry point (`server-main.ts`) cannot drift.
+//
+// The policy is intentionally simple — a small allow-list-by-exclusion of
+// system mount points and credential directories under `$HOME`. It is not a
+// general-purpose sandboxing mechanism; the parser layer (`DocumentParser`)
+// remains the authoritative path-traversal / symlink-escape boundary.
+
+import { realpathSync } from 'node:fs'
+
+const SENSITIVE_PATH_LITERALS = ['/etc', '/usr', '/sys', '/proc', '/var'] as const
+
+/**
+ * Returns the literal prefixes joined with their `realpath`-resolved forms.
+ * Without canonicalization macOS would let `/etc` (which realpaths to
+ * `/private/etc`) slip past once the resolver normalizes the path. The
+ * literal is always kept so a realpath failure cannot weaken the policy.
+ */
+export function buildSensitivePrefixes(
+  realpathSyncFn: (p: string) => string = realpathSync
+): string[] {
+  const set = new Set<string>()
+  for (const literal of SENSITIVE_PATH_LITERALS) {
+    set.add(literal)
+    try {
+      const canonical = realpathSyncFn(literal)
+      if (typeof canonical === 'string' && canonical.length > 0) {
+        set.add(canonical)
+      }
+    } catch {
+      // realpath unavailable on this platform; literal already retained.
+    }
+  }
+  return [...set]
+}
+
+const SENSITIVE_PATH_PREFIXES: ReadonlyArray<string> = buildSensitivePrefixes()
+
+/**
+ * Directories under `$HOME` that hold credentials and must never be opened
+ * as document roots even when the user expands the path themselves.
+ */
+const SENSITIVE_HOME_PREFIXES = ['.ssh', '.gnupg']
+
+/**
+ * Returns a user-facing error string when `value` resolves to a sensitive
+ * system or credential directory. Returns `undefined` when the path is
+ * acceptable.
+ *
+ * `flagName` is interpolated into the error message so the surfacing
+ * surface (CLI flag, env var, ...) is visible at the call site. The CLI uses
+ * `'--base-dir'`; the server entry point uses `'BASE_DIR'` or `'BASE_DIRS'`
+ * to attribute the rejection to the env var actually consulted.
+ *
+ * The trailing-separator check on system prefixes guards against sibling
+ * paths like `/etcetera`. Both the `~/.ssh` and the expanded form are
+ * rejected so the policy holds when `$HOME` is unset.
+ */
+export function checkSensitivePath(value: string, flagName: string): string | undefined {
+  const normalized = value.startsWith('~/')
+    ? `${process.env['HOME'] ?? ''}/${value.slice(2)}`
+    : value
+
+  for (const prefix of SENSITIVE_PATH_PREFIXES) {
+    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
+      return `Refusing to use sensitive system path for ${flagName}: ${value}`
+    }
+  }
+
+  for (const dir of SENSITIVE_HOME_PREFIXES) {
+    const homePath = `${process.env['HOME'] ?? ''}/${dir}`
+    if (normalized === homePath || normalized.startsWith(`${homePath}/`)) {
+      return `Refusing to use sensitive system path for ${flagName}: ${value}`
+    }
+    // Also reject the unexpanded form so `~/.ssh` cannot bypass the check
+    // when `$HOME` is unset.
+    if (value === `~/${dir}` || value.startsWith(`~/${dir}/`)) {
+      return `Refusing to use sensitive system path for ${flagName}: ${value}`
+    }
+  }
+
+  return undefined
+}

--- a/src/utils/sensitive-path.ts
+++ b/src/utils/sensitive-path.ts
@@ -13,6 +13,16 @@
 // remains the authoritative path-traversal / symlink-escape boundary.
 
 import { realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
+
+// Normalize a path for comparison: forward-slash separators throughout and
+// lower-case on Windows (case-insensitive filesystem). Used by the security
+// boundary checks below so `C:\Users\me\.ssh` and `c:/users/me/.ssh` resolve
+// to the same comparable form.
+function toComparable(p: string): string {
+  const slashed = p.replace(/\\/g, '/')
+  return process.platform === 'win32' ? slashed.toLowerCase() : slashed
+}
 
 const SENSITIVE_PATH_LITERALS = ['/etc', '/usr', '/sys', '/proc', '/var'] as const
 
@@ -63,23 +73,25 @@ const SENSITIVE_HOME_PREFIXES = ['.ssh', '.gnupg']
  * rejected so the policy holds when `$HOME` is unset.
  */
 export function checkSensitivePath(value: string, flagName: string): string | undefined {
-  const normalized = value.startsWith('~/')
-    ? `${process.env['HOME'] ?? ''}/${value.slice(2)}`
-    : value
+  const home = process.env['HOME'] || homedir()
+  const expanded = value.startsWith('~/') ? `${home}/${value.slice(2)}` : value
+  const valueCmp = toComparable(expanded)
 
   for (const prefix of SENSITIVE_PATH_PREFIXES) {
-    if (normalized === prefix || normalized.startsWith(`${prefix}/`)) {
+    const prefixCmp = toComparable(prefix)
+    if (valueCmp === prefixCmp || valueCmp.startsWith(`${prefixCmp}/`)) {
       return `Refusing to use sensitive system path for ${flagName}: ${value}`
     }
   }
 
   for (const dir of SENSITIVE_HOME_PREFIXES) {
-    const homePath = `${process.env['HOME'] ?? ''}/${dir}`
-    if (normalized === homePath || normalized.startsWith(`${homePath}/`)) {
-      return `Refusing to use sensitive system path for ${flagName}: ${value}`
+    if (home.length > 0) {
+      const homePathCmp = toComparable(`${home}/${dir}`)
+      if (valueCmp === homePathCmp || valueCmp.startsWith(`${homePathCmp}/`)) {
+        return `Refusing to use sensitive system path for ${flagName}: ${value}`
+      }
     }
-    // Also reject the unexpanded form so `~/.ssh` cannot bypass the check
-    // when `$HOME` is unset.
+    // Unexpanded `~/...` form — caught even when `home` is empty.
     if (value === `~/${dir}` || value.startsWith(`~/${dir}/`)) {
       return `Refusing to use sensitive system path for ${flagName}: ${value}`
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,8 @@
     "module": "node16",
     "lib": ["ES2023"],
     "types": ["node"],
-    "baseUrl": ".",  // Use project root as reference
     "paths": {
-      "src/*": ["src/*"]
+      "src/*": ["./src/*"]
     },
     
     // Output configuration


### PR DESCRIPTION
## Summary

Closes #139. Adds first-class support for multiple allowed document roots
without requiring users to pick an overly broad common parent or run
multiple MCP server instances with fragmented databases.

- **`BASE_DIRS`** — JSON-array env var (`'["/a","/b"]'`). Takes precedence over `BASE_DIR`.
- **`--base-dir`** — repeatable CLI flag on `ingest` and `list`. CLI roots replace env roots (no merge).
- **Resolution order**: CLI `--base-dir` > `BASE_DIRS` > `BASE_DIR` > `process.cwd()`.
- **Security boundary** stays single-source: `DocumentParser.validateFilePath` accepts any configured root, rejects sibling-prefix paths and symlink escapes, and uses realpath normalization.
- **Visible warnings** — `BASE_DIRS > BASE_DIR` precedence and nested-root pruning are surfaced through every MCP tool response (not just stderr), prefixed with an explicit instruction so client agents do not suppress them silently.
- **Degraded mode** — invalid `BASE_DIRS` (malformed JSON, empty array, sensitive path, non-existent directory) returns a structured error from root-dependent tools while `status` stays callable and exposes the diagnostic. No silent fallback to `BASE_DIR` or `cwd`.
- **List contract additive** — `list_files` (MCP) and CLI `list` both return `baseDirs: string[]`, keep legacy `baseDir` (first effective root), and annotate each file entry with its producing `baseDir`. Raw-data entries stay under `sources` without root annotation.
- **Sensitive-path policy** canonicalized via realpath (closes the macOS `/private/etc` bypass) and applied uniformly to CLI flags, CLI raw env values, and MCP server env values.
- **Raw-data boundary** in `handleIngestFile` switched from substring to lexical + realpath containment, closing the arbitrary-file-read vector via `/raw-data/../../etc/passwd` and symlink escape from inside `<dbPath>/raw-data/`.

Bumps `package.json` and `server.json` to 0.14.2.

## Test plan

- [x] `pnpm run check:all` — biome + knip + dpdm + tsc strict + vitest (54 files / 802 tests).
- [x] CLI smoke against built artifact — list output shape, repeatable `--base-dir`, CLI override, precedence warning on stderr, invalid env exits 1, sensitive-path rejection, nested pruning, ingest directory bounded to positional, help text.
- [x] MCP smoke (S1) against a real client — `ingest_file` with `BASE_DIRS` + `BASE_DIR` both set surfaces the precedence warning content block to the user.
- [ ] MCP smoke (S2 — degraded mode with invalid `BASE_DIRS`) optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)