### PR TITLE
ci: eliminate network flakiness in test and package-smoke jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,10 @@ jobs:
       run: pnpm run build
 
     - name: Smoke-test the published package in isolation
+      # The CPU native binary is bundled; skip onnxruntime-node's postinstall,
+      # which otherwise downloads CUDA EP binaries from NuGet (flaky on CI).
+      env:
+        ONNXRUNTIME_NODE_INSTALL: skip
       run: |
         pnpm pack --pack-destination "${RUNNER_TEMP}"
         SMOKE_DIR="$(mktemp -d)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       run: pnpm install --frozen-lockfile
 
     - name: Install Vulkan SDK and Software Rasterizer
-      uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
+      uses: jakoch/install-vulkan-sdk-action@b394a1abed9cb019d8e637eeadac93d73e0853da # v1.5.5
       with:
         install_runtime: true
         install_swiftshader: ${{ runner.os == 'Windows' }}

--- a/src/__tests__/e2e/rag-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/rag-workflow.e2e.test.ts
@@ -7,7 +7,7 @@ import { copyFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { RAGServer } from '../../server/index.js'
-import { withTestDevice } from '../test-device.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
 
 // ============================================
 // E2E Test: Complete RAG Workflow
@@ -32,7 +32,7 @@ describe('RAG MCP Server E2E Test', () => {
         withTestDevice({
           dbPath: testDbPath,
           modelName: 'Xenova/all-MiniLM-L6-v2',
-          cacheDir: './tmp/models',
+          cacheDir: testModelCacheDir(),
           baseDir: testDataDir,
           maxFileSize: 100 * 1024 * 1024,
         })
@@ -101,7 +101,7 @@ describe('RAG MCP Server E2E Test', () => {
         withTestDevice({
           dbPath: testDbPath,
           modelName: 'Xenova/all-MiniLM-L6-v2',
-          cacheDir: './tmp/models',
+          cacheDir: testModelCacheDir(),
           baseDir: testDataDir,
           maxFileSize: 100 * 1024 * 1024,
         })
@@ -153,7 +153,7 @@ describe('RAG MCP Server E2E Test', () => {
         withTestDevice({
           dbPath: testDbPath,
           modelName: 'Xenova/all-MiniLM-L6-v2',
-          cacheDir: './tmp/models',
+          cacheDir: testModelCacheDir(),
           baseDir: testDataDir,
           maxFileSize: 100 * 1024 * 1024,
         })

--- a/src/__tests__/embedder/embedder-dtype-failure.test.ts
+++ b/src/__tests__/embedder/embedder-dtype-failure.test.ts
@@ -18,6 +18,7 @@
 // imported dynamically afterwards.
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { testModelCacheDir } from '../test-device.js'
 
 const mocks = vi.hoisted(() => {
   return {
@@ -47,7 +48,7 @@ function makeEmbedder(dtype?: string) {
   return new Embedder({
     modelPath: MODEL_PATH,
     batchSize: 16,
-    cacheDir: './tmp/models',
+    cacheDir: testModelCacheDir(),
     ...(dtype !== undefined ? { dtype } : {}),
   })
 }

--- a/src/__tests__/embedder/embedder-dtype.test.ts
+++ b/src/__tests__/embedder/embedder-dtype.test.ts
@@ -14,6 +14,7 @@
 // imported dynamically afterwards.
 
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { testModelCacheDir } from '../test-device.js'
 
 const mocks = vi.hoisted(() => {
   return {
@@ -41,7 +42,7 @@ function makeEmbedder(dtype?: string) {
   return new Embedder({
     modelPath: MODEL_PATH,
     batchSize: 16,
-    cacheDir: './tmp/models',
+    cacheDir: testModelCacheDir(),
     ...(dtype !== undefined ? { dtype } : {}),
   })
 }

--- a/src/__tests__/embedder/embedder.test.ts
+++ b/src/__tests__/embedder/embedder.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { Embedder, EmbeddingError } from '../../embedder/index.js'
-import { getTestDevice } from '../test-device.js'
+import { getTestDevice, testModelCacheDir } from '../test-device.js'
 
 // embed()/embedBatch() resolve to numeric vectors; the `.catch` handlers below
 // capture the rejection, so the awaited value is typed `Error | <vector>`.
@@ -22,7 +22,7 @@ function makeEmbedder(device?: string): Embedder {
   return new Embedder({
     modelPath: 'Xenova/all-MiniLM-L6-v2',
     batchSize: 16,
-    cacheDir: './tmp/models',
+    cacheDir: testModelCacheDir(),
     device: device ?? getTestDevice(),
   })
 }

--- a/src/__tests__/security/security.test.ts
+++ b/src/__tests__/security/security.test.ts
@@ -9,7 +9,7 @@ import { resolve } from 'node:path'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DocumentParser, ValidationError } from '../../parser/index.js'
 import { RAGServer } from '../../server/index.js'
-import { withTestDevice } from '../test-device.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
 
 // ============================================
 // Test Configuration
@@ -18,7 +18,7 @@ import { withTestDevice } from '../test-device.js'
 const testConfig = {
   dbPath: './tmp/test-security-db',
   modelName: 'Xenova/all-MiniLM-L6-v2',
-  cacheDir: './tmp/models',
+  cacheDir: testModelCacheDir(),
   baseDir: resolve('./'), // Project root (accessible to both tests/fixtures and tmp)
   maxFileSize: 100 * 1024 * 1024, // 100MB
 }

--- a/src/__tests__/test-device.ts
+++ b/src/__tests__/test-device.ts
@@ -1,5 +1,27 @@
+import { existsSync, mkdirSync, symlinkSync } from 'node:fs'
+import { resolve } from 'node:path'
+
 export function getTestDevice(): string {
   return process.env['RAG_DEVICE'] || 'cpu'
+}
+
+// Pre-warmed by CI's prepare-models job and scripts/prewarm-embedder-cache.mjs.
+const SHARED_MODEL_CACHE = './tmp/models'
+const MODEL_NAMESPACE = 'Xenova'
+
+// A cacheDir holding the pre-warmed model so the embedder never hits the network.
+// With a path, the model is linked in via a junction (Windows-safe) that rmSync
+// removes without touching the shared cache.
+export function testModelCacheDir(isolatedPath?: string): string {
+  if (!isolatedPath) {
+    return SHARED_MODEL_CACHE
+  }
+  mkdirSync(isolatedPath, { recursive: true })
+  const link = resolve(isolatedPath, MODEL_NAMESPACE)
+  if (!existsSync(link)) {
+    symlinkSync(resolve(SHARED_MODEL_CACHE, MODEL_NAMESPACE), link, 'junction')
+  }
+  return isolatedPath
 }
 
 // Test runners own device selection. Passing through this helper deliberately

--- a/src/embedder/__tests__/lazy-initialization.test.ts
+++ b/src/embedder/__tests__/lazy-initialization.test.ts
@@ -2,7 +2,7 @@
 // TDD Red phase: These tests should fail initially
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getTestDevice } from '../../__tests__/test-device.js'
+import { getTestDevice, testModelCacheDir } from '../../__tests__/test-device.js'
 import type { EmbedderConfig } from '../index.js'
 import { Embedder, EmbeddingError } from '../index.js'
 
@@ -13,7 +13,7 @@ describe('Embedder - Lazy Initialization', () => {
     testConfig = {
       modelPath: 'Xenova/all-MiniLM-L6-v2',
       batchSize: 8,
-      cacheDir: './tmp/models',
+      cacheDir: testModelCacheDir(),
       device: getTestDevice(),
     }
   })

--- a/src/server/__tests__/ingest-rollback.test.ts
+++ b/src/server/__tests__/ingest-rollback.test.ts
@@ -5,7 +5,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import type { VectorChunk } from '../../vectordb/index.js'
 import { DatabaseError } from '../../vectordb/types.js'
 import { RAGServer } from '../index.js'
@@ -23,7 +23,7 @@ describe('Ingest Rollback', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/multi-root-integration.test.ts
+++ b/src/server/__tests__/multi-root-integration.test.ts
@@ -31,7 +31,7 @@
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { resolveServerConfig } from '../../server-main.js'
 import { BaseDirsConfigError, displayPath, resolveBaseDirs } from '../../utils/base-dirs.js'
 import { RAGServer } from '../index.js'
@@ -117,7 +117,7 @@ describe('AC-008/AC-011: multi-root ingest -> list -> query -> delete workflow',
   const rootA = resolve(testBase, 'rootA')
   const rootB = resolve(testBase, 'rootB')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   let server: RAGServer
   let fileA: string
@@ -232,7 +232,7 @@ describe('AC-009: ingest_data behavior unchanged in multi-root mode (warnings ad
   const rootA = resolve(testBase, 'rootA')
   const rootB = resolve(testBase, 'rootB')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   let server: RAGServer
 
@@ -342,7 +342,7 @@ describe('AC-003/AC-013: real resolveBaseDirs warnings surface in MCP responses'
   const nestedChild = resolve(rootA, 'nested-child')
   const legacyBase = resolve(testBase, 'legacy-base-dir')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   beforeAll(() => {
     mkdirSync(rootA, { recursive: true })
@@ -475,7 +475,7 @@ describe('post-launch finding #10: list_files per-root error tolerance', () => {
   const rootA = resolve(testBase, 'rootA')
   const rootB = resolve(testBase, 'rootB')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   beforeAll(() => {
     mkdirSync(rootA, { recursive: true })
@@ -551,7 +551,7 @@ describe('post-launch finding #10: list_files per-root error tolerance', () => {
 describe('post-launch findings #3 + #4: server-main wiring rejects sensitive roots and never falls back to cwd', () => {
   const testBase = resolve('./tmp/test-server-main-policy')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   beforeAll(() => {
     mkdirSync(dbPath, { recursive: true })
@@ -637,7 +637,7 @@ describe('post-launch findings #3 + #4: server-main wiring rejects sensitive roo
 describe('AC-010: invalid BASE_DIRS end-to-end (real resolveBaseDirs)', () => {
   const testBase = resolve('./tmp/test-multi-root-invalid')
   const dbPath = resolve(testBase, 'lancedb')
-  const cacheDir = resolve(testBase, 'cache')
+  const cacheDir = testModelCacheDir()
 
   beforeAll(() => {
     mkdirSync(dbPath, { recursive: true })

--- a/src/server/__tests__/rag-server.config.test.ts
+++ b/src/server/__tests__/rag-server.config.test.ts
@@ -11,6 +11,7 @@
 import { mkdirSync, rmSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { testModelCacheDir } from '../../__tests__/test-device.js'
 import { BaseDirsConfigError } from '../../utils/base-dirs.js'
 import { RAGServer } from '../index.js'
 
@@ -34,7 +35,7 @@ describe('RAGServerConfig degraded-mode construction guards (P3-T1)', () => {
         new RAGServer({
           dbPath: testDbPath,
           modelName: 'Xenova/all-MiniLM-L6-v2',
-          cacheDir: './tmp/models',
+          cacheDir: testModelCacheDir(),
           baseDirs: [],
           maxFileSize: 100 * 1024 * 1024,
         })
@@ -50,7 +51,7 @@ describe('RAGServerConfig degraded-mode construction guards (P3-T1)', () => {
     const server = new RAGServer({
       dbPath: testDbPath,
       modelName: 'Xenova/all-MiniLM-L6-v2',
-      cacheDir: './tmp/models',
+      cacheDir: testModelCacheDir(),
       baseDirs: [],
       maxFileSize: 100 * 1024 * 1024,
       configError,

--- a/src/server/__tests__/rag-server.delete.integration.test.ts
+++ b/src/server/__tests__/rag-server.delete.integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { RAGServer } from '../index.js'
 
 describe('AC-010: File Deletion', () => {
@@ -20,7 +20,7 @@ describe('AC-010: File Deletion', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.dispatcher-mapping.test.ts
+++ b/src/server/__tests__/rag-server.dispatcher-mapping.test.ts
@@ -15,7 +15,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import type { Embedder } from '../../embedder/index.js'
 import { EmbeddingError } from '../../embedder/index.js'
 import { BaseDirsConfigError } from '../../utils/base-dirs.js'
@@ -69,7 +69,7 @@ describe('Central dispatcher error mapping (AC-004/005/006/008)', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -289,7 +289,7 @@ describe('Handler identity preservation + local rollback (AC-004)', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -366,7 +366,7 @@ describe('Config-gate central mapping + status diagnostic block (AC-007)', () =>
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDirs: [],
         maxFileSize: 100 * 1024 * 1024,
         configError,

--- a/src/server/__tests__/rag-server.dtype-pdf-regression.test.ts
+++ b/src/server/__tests__/rag-server.dtype-pdf-regression.test.ts
@@ -35,7 +35,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 
 // ============================================
 // Mocks (hoisted so the doMock factories can reference them)
@@ -159,7 +159,7 @@ describe('AC-009: dtype×PDF protocol regression (mock-based, no real model/Hub/
       withTestDevice({
         dbPath: testDbPath,
         modelName: modelPath,
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
         // Explicit dtype gates the enrichment path (TD-5): only an explicitly-set

--- a/src/server/__tests__/rag-server.embedding.integration.test.ts
+++ b/src/server/__tests__/rag-server.embedding.integration.test.ts
@@ -4,7 +4,7 @@
 import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 
 describe('AC-003: Vector Embedding Generation', () => {
   // AC interpretation: [Technical requirement] Text chunks are converted to 384-dimensional vectors
@@ -15,7 +15,7 @@ describe('AC-003: Vector Embedding Generation', () => {
       withTestDevice({
         modelPath: 'Xenova/all-MiniLM-L6-v2',
         batchSize: 8,
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
       })
     )
 
@@ -60,7 +60,7 @@ describe('AC-003: Vector Embedding Generation', () => {
       withTestDevice({
         modelPath: 'Xenova/all-MiniLM-L6-v2',
         batchSize: 8,
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
       })
     )
 
@@ -91,7 +91,7 @@ describe('AC-003: Vector Embedding Generation', () => {
       withTestDevice({
         modelPath: 'Xenova/all-MiniLM-L6-v2',
         batchSize: 8,
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
       })
     )
 
@@ -110,7 +110,7 @@ describe('AC-003: Vector Embedding Generation', () => {
       withTestDevice({
         modelPath: 'Xenova/all-MiniLM-L6-v2',
         batchSize: 8,
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
       })
     )
 

--- a/src/server/__tests__/rag-server.files.integration.test.ts
+++ b/src/server/__tests__/rag-server.files.integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { RAGServer } from '../index.js'
 
 describe('AC-006: Additional Format Support (Phase 2)', () => {
@@ -22,7 +22,7 @@ describe('AC-006: Additional Format Support (Phase 2)', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: localCacheDir,
+        cacheDir: testModelCacheDir(localCacheDir),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -97,7 +97,7 @@ describe('AC-007: File Management', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: localCacheDir,
+        cacheDir: testModelCacheDir(localCacheDir),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -235,7 +235,7 @@ describe('AC-007: File Management', () => {
         withTestDevice({
           dbPath: excludeTestDb,
           modelName: 'Xenova/all-MiniLM-L6-v2',
-          cacheDir: excludeTestCache,
+          cacheDir: testModelCacheDir(excludeTestCache),
           baseDir: excludeTestBase,
           maxFileSize: 100 * 1024 * 1024,
         })
@@ -305,7 +305,7 @@ describe('AC-007: File Management', () => {
           withTestDevice({
             dbPath: siblingDb,
             modelName: 'Xenova/all-MiniLM-L6-v2',
-            cacheDir: siblingCache,
+            cacheDir: testModelCacheDir(siblingCache),
             baseDir: siblingData,
             maxFileSize: 100 * 1024 * 1024,
           })
@@ -365,7 +365,7 @@ describe('AC-008: list_files multi-root contract', () => {
       withTestDevice({
         dbPath: multiDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: multiCacheDir,
+        cacheDir: testModelCacheDir(multiCacheDir),
         baseDirs: [rootA, rootB],
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -511,7 +511,7 @@ describe('AC-008: list_files single-root regression (legacy shape preserved)', (
       withTestDevice({
         dbPath: singleDb,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: singleCache,
+        cacheDir: testModelCacheDir(singleCache),
         baseDir: singleData,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.ingest.integration.test.ts
+++ b/src/server/__tests__/rag-server.ingest.integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { RAGServer } from '../index.js'
 
 describe('AC-008: File Re-ingestion', () => {
@@ -20,7 +20,7 @@ describe('AC-008: File Re-ingestion', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -96,7 +96,7 @@ describe('AC-009: Error Handling (Complete)', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.metadata.integration.test.ts
+++ b/src/server/__tests__/rag-server.metadata.integration.test.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdirSync, rmSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { generateMetaJsonPath, generateRawDataPath } from '../../utils/raw-data-utils.js'
 import { RAGServer } from '../index.js'
 
@@ -22,7 +22,7 @@ describe('File Title Extraction Pipeline', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -96,7 +96,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.protocol.integration.test.ts
+++ b/src/server/__tests__/rag-server.protocol.integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { DatabaseError } from '../../vectordb/types.js'
 import { RAGServer } from '../index.js'
 
@@ -21,7 +21,7 @@ describe('AC-001: MCP Protocol Integration', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -79,7 +79,7 @@ describe('AC-005: Error Handling (Basic)', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -122,7 +122,7 @@ describe('AC-005: Error Handling (Basic)', () => {
       withTestDevice({
         dbPath: invalidDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -19,7 +19,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { looksLikeRawDataPath } from '../../utils/raw-data-utils.js'
 import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
 import { RAGServer } from '../index.js'
@@ -108,7 +108,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -203,7 +203,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -300,7 +300,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -391,7 +391,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -491,7 +491,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -579,7 +579,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -708,7 +708,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -817,7 +817,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -888,7 +888,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -957,7 +957,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -1032,7 +1032,7 @@ describe('read_chunk_neighbors integration', () => {
       ragServer = createTestRagServer({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.search.integration.test.ts
+++ b/src/server/__tests__/rag-server.search.integration.test.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { RAGServer } from '../index.js'
 
 describe('AC-004: Vector Search', () => {
@@ -21,7 +21,7 @@ describe('AC-004: Vector Search', () => {
       withTestDevice({
         dbPath: localTestDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })
@@ -116,7 +116,7 @@ describe('AC-004: Vector Search', () => {
       withTestDevice({
         dbPath: emptyDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: localTestDataDir,
         maxFileSize: 100 * 1024 * 1024,
       })

--- a/src/server/__tests__/rag-server.warning-visibility.test.ts
+++ b/src/server/__tests__/rag-server.warning-visibility.test.ts
@@ -15,7 +15,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { withTestDevice } from '../../__tests__/test-device.js'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
 import { BaseDirsConfigError } from '../../utils/base-dirs.js'
 import { RAGServer } from '../index.js'
 
@@ -70,7 +70,7 @@ describe('root-dependent tools fail fast on configError; non-root-dependent stay
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir, // degraded-mode fallback root
         maxFileSize: 100 * 1024 * 1024,
         configError,
@@ -143,7 +143,7 @@ describe('P3-T3: status callable with configError and exposes diagnostic', () =>
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
         configError,
@@ -266,7 +266,7 @@ describe('P3-T3: warnings appear in every tool response when warnings exist', ()
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
         configWarnings: [PRECEDENCE_WARNING, NESTED_PRUNED_WARNING],
@@ -377,7 +377,7 @@ describe('P3-T3: no spurious blocks when warnings absent', () => {
       withTestDevice({
         dbPath: testDbPath,
         modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: './tmp/models',
+        cacheDir: testModelCacheDir(),
         baseDir: testDataDir,
         maxFileSize: 100 * 1024 * 1024,
         // No configWarnings, no configError.


### PR DESCRIPTION
## Summary

Two independent network dependencies were causing recurring CI failures (timeouts). This removes both so CI runs deterministically against pre-warmed/bundled artifacts.

### 1. Tests downloaded the model at test time (`test` job)

The `prepare-models` job pre-warms the model into `./tmp/models`, and most integration tests already pointed their `cacheDir` there. But some (notably `multi-root-integration.test.ts`) constructed their own per-test `cacheDir`, so the embedder resolved the model from an empty directory and fell back to downloading it from HuggingFace — flaky, slow, and the direct cause of the recurring multi-root timeouts.

- Add `testModelCacheDir()` in `src/__tests__/test-device.ts` as the single source of truth for the pre-warmed cache path. Hand-written `'./tmp/models'` literals (18 files) now go through it, so future tests can't silently diverge.
- The model is still resolved through the tool's normal `cacheDir` config — **no external env injection** (no `env.localModelPath`, no `process.env`).
- Passing a path links the pre-warmed model into it via a junction (Windows-safe; a symlink elsewhere) that `rmSync` removes without touching the shared cache. This keeps tests that need a `cacheDir` at a specific location — e.g. the `dbPath/cacheDir`-exclusion checks nested inside a scanned root — offline while preserving their assertions.

### 2. `package-smoke` downloaded CUDA binaries

The smoke job's `npm install` of the packed tarball triggers `onnxruntime-node`'s postinstall, which on `linux/x64` downloads CUDA EP binaries from NuGet (`api.nuget.org`) — a network call that intermittently times out. The CPU native binary is bundled in the package and is all the smoke test needs, so set `ONNXRUNTIME_NODE_INSTALL=skip`.

## Verification

- `pnpm run check:all` green: 61 files / **898 tests pass**, lint/format/type-check/build/knip/dpdm clean.
- Tests load the model from the pre-warmed cache with **zero network access** locally.
- package-smoke fix is verified against `onnxruntime-node@1.24.3`'s `install-metadata.js`: only `linux/x64` requires the `cuda12` EP download; the base CPU runtime ships in `bin/napi-v6/{linux,darwin,win32}`. CI (linux) exercises the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)