### PR TITLE
Fail delete_file on raw-data unlink errors

### DIFF
--- a/src/__tests__/cli/delete.test.ts
+++ b/src/__tests__/cli/delete.test.ts
@@ -201,6 +201,42 @@ describe('CLI delete', () => {
     expect(parsed.timestamp).toBeDefined()
   })
 
+  it('should report removed chunks and existed=true when vector rows were deleted', async () => {
+    mocks.deleteChunks.mockResolvedValue(3)
+
+    const { error } = await captureStderr(() => runDelete(['/path/to/file.md']))
+
+    expect(error).toBeUndefined()
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1)
+    const writtenData = stdoutSpy.mock.calls[0]![0] as string
+    const parsed = JSON.parse(writtenData)
+    expect(parsed.filePath).toBe(resolve('/path/to/file.md'))
+    expect(parsed.deleted).toBe(true)
+    expect(parsed.removedChunks).toBe(3)
+    expect(parsed.existed).toBe(true)
+  })
+
+  it('should report existed=true when only raw-data meta exists', async () => {
+    const { generateMetaJsonPath, generateRawDataPath } = await import(
+      '../../utils/raw-data-utils.js'
+    )
+    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/meta-only', 'markdown')
+    await mkdir(resolve(cleanupDbPath, 'raw-data'), { recursive: true })
+    await writeFile(generateMetaJsonPath(mdPath), '{}')
+
+    const { error } = await captureStderr(() =>
+      runDelete(['--source', 'https://example.com/meta-only'], { dbPath: cleanupDbPath })
+    )
+
+    expect(error).toBeUndefined()
+
+    const writtenData = stdoutSpy.mock.calls[0]![0] as string
+    const parsed = JSON.parse(writtenData)
+    expect(parsed.removedChunks).toBe(0)
+    expect(parsed.existed).toBe(true)
+  })
+
   // --------------------------------------------
   // Delete by --source
   // --------------------------------------------
@@ -251,6 +287,11 @@ describe('CLI delete', () => {
     const unlinkCalls = mocks.unlink.mock.calls.map((c: unknown[]) => c[0] as string)
     expect(unlinkCalls.some((p: string) => p.endsWith('.md'))).toBe(true)
     expect(unlinkCalls.some((p: string) => p.endsWith('.meta.json'))).toBe(true)
+
+    const writtenData = stdoutSpy.mock.calls[0]![0] as string
+    const parsed = JSON.parse(writtenData)
+    expect(parsed.removedChunks).toBe(0)
+    expect(parsed.existed).toBe(true)
   })
 
   it('should not clean up files when path is not a raw-data path', async () => {
@@ -287,7 +328,7 @@ describe('CLI delete', () => {
     expect(parsed.existed).toBe(false)
   })
 
-  it('attempts .meta.json cleanup even when the .md file is already missing', async () => {
+  it('should attempt .meta.json cleanup even when the .md file is already missing', async () => {
     mocks.deleteChunks.mockResolvedValue(0)
     const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     mocks.unlink.mockRejectedValue(enoentError)

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -358,6 +358,26 @@ This is markdown content with **bold** and _italic_ text.
       await expect(server.handleDeleteFile({ filePath })).resolves.toBeDefined()
     })
 
+    it('delete_file throws when raw-data unlink fails for a non-ENOENT reason', async () => {
+      const source = 'https://example.com/delete-unlink-failure-test'
+      const content =
+        'Content for testing raw-data unlink failure handling. ' +
+        'This needs to be long enough to create chunks for the test to work properly.'
+
+      const ingestResult = await server.handleIngestData({
+        content,
+        metadata: { source, format: 'text' },
+      })
+      const parsed = JSON.parse(ingestResult.content[0].text)
+      const filePath = parsed.filePath
+
+      const { unlink } = await import('node:fs/promises')
+      await unlink(filePath)
+      await mkdir(filePath)
+
+      await expect(server.handleDeleteFile({ filePath })).rejects.toThrow()
+    })
+
     it('delete_file accepts source parameter to delete raw-data', async () => {
       const source = 'https://example.com/delete-by-source-test'
       const content =

--- a/src/cli/delete.ts
+++ b/src/cli/delete.ts
@@ -6,6 +6,7 @@ import {
   checkRawDataArtifacts,
   generateMetaJsonPath,
   generateRawDataPath,
+  isEnoent,
   isPathInRawDataDirLexical,
 } from '../utils/raw-data-utils.js'
 import { createVectorStore, formatCliError } from './common.js'
@@ -168,11 +169,7 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
         await unlink(targetPath)
       } catch (error: unknown) {
         // Ignore ENOENT (file already deleted / never existed)
-        if (
-          !(error instanceof Error) ||
-          !('code' in error) ||
-          (error as NodeJS.ErrnoException).code !== 'ENOENT'
-        ) {
+        if (!isEnoent(error)) {
           throw error
         }
       }
@@ -181,11 +178,7 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
         await unlink(generateMetaJsonPath(targetPath))
       } catch (error: unknown) {
         // Ignore ENOENT
-        if (
-          !(error instanceof Error) ||
-          !('code' in error) ||
-          (error as NodeJS.ErrnoException).code !== 'ENOENT'
-        ) {
+        if (!isEnoent(error)) {
           throw error
         }
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,6 +24,7 @@ import {
   extractSourceFromPath,
   generateMetaJsonPath,
   generateRawDataPath,
+  isEnoent,
   isPathInRawDataDir,
   isPathInRawDataDirLexical,
   loadMetaJson,
@@ -795,14 +796,19 @@ export class RAGServer {
       try {
         await unlink(targetPath)
         console.error(`Deleted raw-data file: ${targetPath}`)
-      } catch {
+      } catch (error: unknown) {
+        if (!isEnoent(error)) {
+          throw error
+        }
         console.warn(`Could not delete raw-data file (may not exist): ${targetPath}`)
       }
       try {
         await unlink(generateMetaJsonPath(targetPath))
         console.error(`Deleted meta.json: ${generateMetaJsonPath(targetPath)}`)
-      } catch {
-        // .meta.json may not exist for old data, silently ignore
+      } catch (error: unknown) {
+        if (!isEnoent(error)) {
+          throw error
+        }
       }
     }
 

--- a/src/utils/raw-data-utils.ts
+++ b/src/utils/raw-data-utils.ts
@@ -278,15 +278,20 @@ export async function loadMetaJson(mdPath: string): Promise<RawDataMeta | null> 
     const content = await readFile(metaPath, 'utf-8')
     return JSON.parse(content) as RawDataMeta
   } catch (error: unknown) {
-    if (
-      error instanceof Error &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'ENOENT'
-    ) {
+    if (isEnoent(error)) {
       return null
     }
     throw error
   }
+}
+
+/**
+ * True when a filesystem error means the target path does not exist.
+ */
+export function isEnoent(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+  )
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- make MCP `delete_file` fail on non-ENOENT raw-data unlink errors, matching the CLI behavior
- add a shared `isEnoent()` helper for filesystem ENOENT checks
- expand delete response tests for `removedChunks`, raw-data artifacts, and meta-only existence

## Rationale

A raw-data unlink failure other than ENOENT means the delete did not fully remove the requested artifacts. Previously the MCP server warned or ignored those failures while still returning `deleted: true`. This keeps idempotent handling for missing files, but surfaces real filesystem cleanup failures to the caller.

## Test plan

- `pnpm test -- src/__tests__/cli/delete.test.ts src/__tests__/server/ingest-data.test.ts src/server/__tests__/rag-server.delete.integration.test.ts src/__tests__/server/raw-data-utils.test.ts src/server/__tests__/raw-data-meta.test.ts`
- `pnpm run check`
- `pnpm exec tsc --noEmit`