### PR TITLE
chore: bump version to 0.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.15.1",
+  "version": "0.15.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bump the patch version from `0.15.1` to `0.15.2`.

- `package.json`: `0.15.1` → `0.15.2`
- `server.json`: top-level and packages entry `0.15.1` → `0.15.2`

## Test plan

- No code changes; version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)