### PR TITLE
feat: optional scope path-prefix filter for query_documents (#146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Search uses semantic similarity with keyword boost. This means `useEffect` finds
 
 Results include text content, source file, document title, and relevance score. The document title provides context for each chunk, helping identify which document a result belongs to. Adjust result count with `limit` (1-20, default 10).
 
+Narrow a search to part of your corpus with `scope` — one path prefix or a list of them. Results are restricted to chunks whose file path equals a prefix or sits under it (exact-or-descendant). For example, `"/docs/api"` matches `/docs/api` and `/docs/api/auth.md` but not `/docs/apiv2`; a file prefix like `"/docs/readme.md"` matches just that file. Pass prefixes in the server's OS path style.
+
 #### Expanding Context Around a Result
 
 When a search result needs more surrounding context, use `read_chunk_neighbors` to read the chunks before and after it:
@@ -218,6 +220,7 @@ All MCP tools are also available as CLI commands — no MCP server needed:
 ```bash
 npx mcp-local-rag ingest ./docs/               # Bulk ingest files
 npx mcp-local-rag query "authentication API"    # Search documents
+npx mcp-local-rag query "auth" --scope /docs/api --scope /docs/guide  # Restrict to path prefixes (repeatable)
 npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5  # Expand context
 npx mcp-local-rag list                          # Show ingestion status
 npx mcp-local-rag status                        # Database stats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.15.2",
+  "version": "0.15.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "transport": {
         "type": "stdio"
       },

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -57,7 +57,7 @@ Use `scope` when one database mixes multiple corpora and you want results from o
 | One corpus/folder | absolute prefix, e.g. `/Users/me/docs/api` |
 | Several corpora | list of absolute prefixes |
 
-Prefixes must be absolute, in the server's OS path style — relative prefixes match nothing.
+Prefixes must be absolute, in the server's OS path style — relative prefixes match nothing. If the user gives a relative path, derive an absolute prefix from a `filePath` in an earlier `query_documents`/`list_files` result, or omit `scope` when no absolute prefix is known.
 
 ### Query Formulation
 

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -11,7 +11,7 @@ description: Search, ingest, expand chunk context, or manage local documents via
 |----------|---------------|----------|
 | `ingest_file` | `npx mcp-local-rag ingest <path> [--visual]` | Local files (PDF, DOCX, TXT, MD). CLI for bulk/directory. PDF visual mode: see [Visual content (PDFs)](#visual-content-pdfs). |
 | `ingest_data` | — | Raw content (HTML, text) with source URL |
-| `query_documents` | `npx mcp-local-rag query <text>` | Semantic + keyword hybrid search |
+| `query_documents` | `npx mcp-local-rag query <text>` | Semantic + keyword hybrid search; optional `scope` to limit to a path prefix |
 | `delete_file` | `npx mcp-local-rag delete <path>` | Remove ingested content |
 | `list_files` | `npx mcp-local-rag list` | File ingestion status |
 | `status` | `npx mcp-local-rag status` | Database stats |
@@ -19,7 +19,7 @@ description: Search, ingest, expand chunk context, or manage local documents via
 
 ## Workflow
 
-1. For search requests, formulate a focused hybrid query, choose `limit` by intent, then filter results by score AND topical relevance.
+1. For search requests, formulate a focused hybrid query, choose `limit` by intent, optionally narrow to a corpus/path with `scope`, then filter results by score AND topical relevance.
 2. When a retrieved hit lacks enough surrounding context for a grounded answer, expand only that chunk via `read_chunk_neighbors`.
 3. For ingestion, choose `ingest_file` for local files and `ingest_data` for raw/web content.
 4. For PDFs, ask once about ingest mode unless the current request already specifies one (text-only, visual fast, or visual quality). See decision protocol in Ingestion.
@@ -46,6 +46,18 @@ Lower = better match. Use this to filter noise.
 | Specific answer (function, error) | 5 |
 | General understanding | 10 |
 | Comprehensive survey | 20 |
+
+### Scope (Optional)
+
+Use `scope` when one database mixes multiple corpora and you want results from only one. Pass an absolute path prefix, or a list (results are unioned); it matches a `filePath` equal to or under the prefix.
+
+| Intent | scope |
+|--------|-------|
+| Search everything | omit |
+| One corpus/folder | absolute prefix, e.g. `/Users/me/docs/api` |
+| Several corpora | list of absolute prefixes |
+
+Prefixes must be absolute, in the server's OS path style — relative prefixes match nothing.
 
 ### Query Formulation
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -60,12 +60,13 @@ The CLI accepts only `fast` or `quality` for `--visual-quality`. The MCP `ingest
 ### query
 
 ```bash
-npx mcp-local-rag [global-options] query [--limit <n>] <text>
+npx mcp-local-rag [global-options] query [--limit <n>] [--scope <prefix>]... <text>
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--limit <n>` | `10` | Max results (1–20) |
+| `--scope <prefix>` | — | Restrict to an absolute path prefix (matches a filePath equal to or under it). Repeat for multiple prefixes (unioned). Relative prefixes match nothing. |
 
 Output: JSON array to stdout.
 

--- a/skills/mcp-local-rag/references/result-refinement.md
+++ b/skills/mcp-local-rag/references/result-refinement.md
@@ -51,5 +51,6 @@ Single chunks may lack context ("as described above").
 
 1. Rephrase query (alternative terms)
 2. Broaden scope
-3. Check ingestion (`list_files`)
-4. Inform user: no matching content
+3. If `scope` was passed, confirm it is an absolute path prefix — a relative prefix silently matches nothing
+4. Check ingestion (`list_files`)
+5. Inform user: no matching content

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -277,7 +277,10 @@ describe('CLI query', () => {
 
     await captureOutput(() => runQuery(['--limit', '5', 'my search query']))
 
-    expect(mocks.search).toHaveBeenCalledWith(expect.any(Array), 'my search query', 5)
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ queryText: 'my search query', limit: 5 })
+    )
   })
 
   it('should use default limit of 10 when --limit is not specified', async () => {
@@ -285,7 +288,54 @@ describe('CLI query', () => {
 
     await captureOutput(() => runQuery(['my search query']))
 
-    expect(mocks.search).toHaveBeenCalledWith(expect.any(Array), 'my search query', 10)
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ queryText: 'my search query', limit: 10 })
+    )
+  })
+
+  // --------------------------------------------
+  // --scope threading into search options
+  // --------------------------------------------
+  it('should thread a single --scope value into search options', async () => {
+    mocks.search.mockResolvedValue([])
+
+    await captureOutput(() => runQuery(['--scope', 'docs/', 'my search query']))
+
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ queryText: 'my search query', limit: 10, scope: ['docs/'] })
+    )
+  })
+
+  it('should thread repeated --scope values into search options as an array', async () => {
+    mocks.search.mockResolvedValue([])
+
+    await captureOutput(() => runQuery(['--scope', 'docs/', '--scope', 'src/', 'my search query']))
+
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ scope: ['docs/', 'src/'] })
+    )
+  })
+
+  it('should not include scope in search options when --scope is absent', async () => {
+    mocks.search.mockResolvedValue([])
+
+    await captureOutput(() => runQuery(['my search query']))
+
+    const callOptions = mocks.search.mock.calls[0]?.[1]
+    expect(callOptions.scope).toBeUndefined()
+  })
+
+  it('should exit with code 1 when --scope value is empty', async () => {
+    const { stderr, error } = await captureOutput(() => runQuery(['--scope', '', 'search text']))
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('process.exit(1)')
+
+    const joined = stderr.join('\n')
+    expect(joined).toContain('--scope')
   })
 
   // --------------------------------------------
@@ -485,6 +535,42 @@ describe('CLI query', () => {
     it('should error when multiple positional arguments are given', () => {
       expect(() => parseArgs(['first query', 'second query'])).toThrow('process.exit(1)')
     })
+
+    it('should parse a single --scope into a one-element array', () => {
+      const result = parseArgs(['--scope', 'docs/', 'search text'])
+      expect(result.queryText).toBe('search text')
+      expect(result.options.scope).toEqual(['docs/'])
+    })
+
+    it('should accumulate repeated --scope into an array preserving order', () => {
+      const result = parseArgs(['--scope', 'docs/', '--scope', 'src/', 'search text'])
+      expect(result.options.scope).toEqual(['docs/', 'src/'])
+    })
+
+    it('should leave scope undefined when --scope is absent', () => {
+      const result = parseArgs(['search text'])
+      expect(result.options.scope).toBeUndefined()
+    })
+
+    it('should error when --scope value is empty', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--scope', '', 'search text'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('--scope value must not be empty')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
+    it('should error when --scope value is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--scope'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('Missing value for --scope')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
   })
 
   // --------------------------------------------
@@ -510,7 +596,10 @@ describe('CLI query', () => {
     const { error } = await captureOutput(() => runQuery(['--limit', '1', 'query']))
 
     expect(error).toBeUndefined()
-    expect(mocks.search).toHaveBeenCalledWith(expect.any(Array), 'query', 1)
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ queryText: 'query', limit: 1 })
+    )
   })
 
   it('should accept --limit 20 (maximum)', async () => {
@@ -519,6 +608,9 @@ describe('CLI query', () => {
     const { error } = await captureOutput(() => runQuery(['--limit', '20', 'query']))
 
     expect(error).toBeUndefined()
-    expect(mocks.search).toHaveBeenCalledWith(expect.any(Array), 'query', 20)
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ queryText: 'query', limit: 20 })
+    )
   })
 })

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -562,6 +562,16 @@ describe('CLI query', () => {
       }
     })
 
+    it('should error when --scope value is whitespace-only', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        expect(() => parseArgs(['--scope', '   ', 'search text'])).toThrow('process.exit(1)')
+        expect(errorSpy).toHaveBeenCalledWith('--scope value must not be empty')
+      } finally {
+        errorSpy.mockRestore()
+      }
+    })
+
     it('should error when --scope value is missing', () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       try {

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -547,6 +547,11 @@ describe('CLI query', () => {
       expect(result.options.scope).toEqual(['docs/', 'src/'])
     })
 
+    it('should trim surrounding whitespace from a --scope value', () => {
+      const result = parseArgs(['--scope', '  docs/  ', 'search text'])
+      expect(result.options.scope).toEqual(['docs/'])
+    })
+
     it('should leave scope undefined when --scope is absent', () => {
       const result = parseArgs(['search text'])
       expect(result.options.scope).toBeUndefined()

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -90,7 +90,7 @@ export function parseArgs(args: string[]): ParsedArgs {
       }
       case '--scope': {
         const value = requireFlagValue(args, i, '--scope')
-        if (value.length === 0) {
+        if (value.trim().length === 0) {
           console.error('--scope value must not be empty')
           process.exit(1)
         }

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -11,6 +11,7 @@ import { requireFlagValue, resolveGlobalConfig } from './options.js'
 
 interface QueryCliOptions {
   limit?: number | undefined
+  scope?: string[] | undefined
 }
 
 interface ParsedArgs {
@@ -46,6 +47,7 @@ Search ingested documents using hybrid vector + keyword matching.
 
 Options:
   --limit <n>            Max results (default: ${QUERY_DEFAULTS.limit}, range: 1-20)
+  --scope <prefix>       Restrict results to a path prefix (repeatable for multiple prefixes)
   -h, --help             Show this help
 
 Global options (must appear before "query"):
@@ -59,7 +61,7 @@ Global options (must appear before "query"):
 
 /**
  * Parse query-specific CLI arguments into options and a positional query text.
- * Flags: --limit, -h/--help
+ * Flags: --limit, --scope (repeatable), -h/--help
  * Unknown flags (including global flags passed after subcommand) cause an error.
  */
 export function parseArgs(args: string[]): ParsedArgs {
@@ -83,6 +85,18 @@ export function parseArgs(args: string[]): ParsedArgs {
           process.exit(1)
         }
         options.limit = Number.parseInt(value, 10)
+        i += 2
+        break
+      }
+      case '--scope': {
+        const value = requireFlagValue(args, i, '--scope')
+        if (value.length === 0) {
+          console.error('--scope value must not be empty')
+          process.exit(1)
+        }
+        const scope = options.scope ?? []
+        scope.push(value)
+        options.scope = scope
         i += 2
         break
       }
@@ -169,8 +183,13 @@ export async function runQuery(args: string[], globalOptions: GlobalOptions = {}
       throw new Error('Failed to generate query embedding')
     }
 
-    // Hybrid search (vector + BM25)
-    const searchResults = await vectorStore.search(queryVector, queryText, limit)
+    // Hybrid search (vector + BM25). Thread scope only when present so the
+    // scope-absent call shape stays identical to the pre-flag behavior.
+    const searchResults = await vectorStore.search(queryVector, {
+      queryText,
+      limit,
+      ...(options.scope ? { scope: options.scope } : {}),
+    })
 
     // Format results with source restoration for raw-data files
     const results: QueryResultOutput[] = searchResults.map((result) => {

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -89,8 +89,8 @@ export function parseArgs(args: string[]): ParsedArgs {
         break
       }
       case '--scope': {
-        const value = requireFlagValue(args, i, '--scope')
-        if (value.trim().length === 0) {
+        const value = requireFlagValue(args, i, '--scope').trim()
+        if (value.length === 0) {
           console.error('--scope value must not be empty')
           process.exit(1)
         }

--- a/src/server/__tests__/rag-server.search.integration.test.ts
+++ b/src/server/__tests__/rag-server.search.integration.test.ts
@@ -3,8 +3,11 @@
 
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
+import type { Embedder } from '../../embedder/index.js'
+import type { SearchResult, VectorStore } from '../../vectordb/index.js'
+import type { SearchOptions } from '../../vectordb/types.js'
 import { RAGServer } from '../index.js'
 
 describe('AC-004: Vector Search', () => {
@@ -158,5 +161,84 @@ describe('AC-004: Vector Search', () => {
     const results20 = JSON.parse(result20.content[0].text)
     expect(Array.isArray(results20)).toBe(true)
     expect(results20.length).toBeLessThanOrEqual(20)
+  })
+})
+
+// Boundary test (spy-based unit): asserts handleQueryDocuments threads its
+// arguments into VectorStore.search()'s options object. The data-layer behavior
+// (scope prefilter) is proven in the vectordb integration suite (Task 01/02);
+// here we only verify the handler → search() call boundary, so search and the
+// embedder are spied. Roundtrip check: the normalized `string[]` the parser
+// emits is the `string[]` search() receives, unchanged.
+describe('handleQueryDocuments → VectorStore.search() options boundary', () => {
+  let server: RAGServer
+  const dbPath = resolve('./tmp/test-lancedb-search-options')
+  const dataDir = resolve('./tmp/test-data-search-options')
+
+  function internals(s: RAGServer): { embedder: Embedder; vectorStore: VectorStore } {
+    return s as unknown as { embedder: Embedder; vectorStore: VectorStore }
+  }
+
+  const queryVector = [0.1, 0.2, 0.3]
+  const emptyResults: SearchResult[] = []
+
+  beforeAll(async () => {
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(dataDir, { recursive: true })
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(),
+        baseDir: dataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterAll(async () => {
+    await server.close()
+    rmSync(dbPath, { recursive: true, force: true })
+    rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  it('passes scope through unchanged as the scope option when present', async () => {
+    vi.spyOn(internals(server).embedder, 'embed').mockResolvedValue(queryVector)
+    const searchSpy = vi
+      .spyOn(internals(server).vectorStore, 'search')
+      .mockResolvedValue(emptyResults)
+
+    await server.handleQueryDocuments({
+      query: 'typescript',
+      limit: 7,
+      scope: ['/docs', '/src'],
+    })
+
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+    const [vector, options] = searchSpy.mock.calls[0] as [number[], SearchOptions]
+    expect(vector).toEqual(queryVector)
+    expect(options).toEqual({ queryText: 'typescript', limit: 7, scope: ['/docs', '/src'] })
+  })
+
+  it('passes scope: undefined when scope is absent', async () => {
+    vi.spyOn(internals(server).embedder, 'embed').mockResolvedValue(queryVector)
+    const searchSpy = vi
+      .spyOn(internals(server).vectorStore, 'search')
+      .mockResolvedValue(emptyResults)
+
+    await server.handleQueryDocuments({ query: 'typescript' })
+
+    const [, options] = searchSpy.mock.calls[0] as [number[], SearchOptions]
+    // scope key omitted when absent → search() takes its scope-absent path
+    expect(options.scope).toBeUndefined()
+    // limit defaulting preserved (?? 10) and query threaded as queryText
+    expect(options.queryText).toBe('typescript')
+    expect(options.limit).toBe(10)
+    expect(Object.hasOwn(options, 'scope')).toBe(false)
   })
 })

--- a/src/server/__tests__/tool-input.test.ts
+++ b/src/server/__tests__/tool-input.test.ts
@@ -55,6 +55,52 @@ describe('parseQueryDocumentsInput', () => {
       expect((error as McpError).code).toBe(ErrorCode.InvalidParams)
     }
   })
+
+  it('normalizes a string scope to a single-element array', () => {
+    expect(parseQueryDocumentsInput({ query: 'q', scope: '/a/b' })).toEqual({
+      query: 'q',
+      scope: ['/a/b'],
+    })
+  })
+
+  it('passes a string array scope through', () => {
+    expect(parseQueryDocumentsInput({ query: 'q', scope: ['/a/b', '/c/d'] })).toEqual({
+      query: 'q',
+      scope: ['/a/b', '/c/d'],
+    })
+  })
+
+  it('keeps input unchanged when scope is absent (with limit)', () => {
+    expect(parseQueryDocumentsInput({ query: 'q', limit: 5 })).toEqual({ query: 'q', limit: 5 })
+  })
+
+  it('keeps input unchanged when scope is absent (no limit)', () => {
+    expect(parseQueryDocumentsInput({ query: 'q' })).toEqual({ query: 'q' })
+  })
+
+  it('accepts scope alongside limit', () => {
+    expect(parseQueryDocumentsInput({ query: 'q', limit: 5, scope: '/a/b' })).toEqual({
+      query: 'q',
+      limit: 5,
+      scope: ['/a/b'],
+    })
+  })
+
+  it.each([
+    ['empty array scope', { query: 'q', scope: [] }],
+    ['empty string scope', { query: 'q', scope: '' }],
+    ['whitespace string scope', { query: 'q', scope: '   ' }],
+    ['array with empty-string element', { query: 'q', scope: ['/a/b', ''] }],
+    ['array with whitespace element', { query: 'q', scope: ['/a/b', '   '] }],
+    ['array with non-string element', { query: 'q', scope: ['/a/b', 5] }],
+    ['number scope', { query: 'q', scope: 42 }],
+    ['object scope', { query: 'q', scope: { path: '/a/b' } }],
+    ['null scope', { query: 'q', scope: null }],
+  ])('rejects %s', (_label, raw) => {
+    expect(() => parseQueryDocumentsInput(raw)).toThrow(
+      /scope must be a non-empty string or a non-empty array of non-empty strings/
+    )
+  })
 })
 
 describe('parseIngestDataInput', () => {

--- a/src/server/__tests__/tool-input.test.ts
+++ b/src/server/__tests__/tool-input.test.ts
@@ -70,6 +70,17 @@ describe('parseQueryDocumentsInput', () => {
     })
   })
 
+  it('trims surrounding whitespace from scope values (string and array)', () => {
+    expect(parseQueryDocumentsInput({ query: 'q', scope: '  /a/b  ' })).toEqual({
+      query: 'q',
+      scope: ['/a/b'],
+    })
+    expect(parseQueryDocumentsInput({ query: 'q', scope: ['  /a/b', '/c/d\t'] })).toEqual({
+      query: 'q',
+      scope: ['/a/b', '/c/d'],
+    })
+  })
+
   it('keeps input unchanged when scope is absent (with limit)', () => {
     expect(parseQueryDocumentsInput({ query: 'q', limit: 5 })).toEqual({ query: 'q', limit: 5 })
   })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -300,8 +300,19 @@ export class RAGServer {
     // Generate query embedding
     const queryVector = await this.embedder.embed(args.query)
 
-    // Hybrid search (vector + BM25 keyword matching)
-    const searchResults = await this.vectorStore.search(queryVector, args.query, args.limit || 10)
+    // Hybrid search (vector + BM25 keyword matching). `args.scope` is already
+    // normalized to `string[] | undefined` by `parseQueryDocumentsInput`; the
+    // array-wrap reconciles the wider `string | string[]` boundary type without
+    // re-validating (that stays the parser's responsibility). The key is omitted
+    // when scope is absent (exactOptionalPropertyTypes), preserving search()'s
+    // scope-absent path.
+    const searchResults = await this.vectorStore.search(queryVector, {
+      queryText: args.query,
+      limit: args.limit ?? 10,
+      ...(args.scope !== undefined
+        ? { scope: Array.isArray(args.scope) ? args.scope : [args.scope] }
+        : {}),
+    })
 
     // Format results with source restoration for raw-data files
     const results: QueryResult[] = searchResults.map((result) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -300,12 +300,8 @@ export class RAGServer {
     // Generate query embedding
     const queryVector = await this.embedder.embed(args.query)
 
-    // Hybrid search (vector + BM25 keyword matching). `args.scope` is already
-    // normalized to `string[] | undefined` by `parseQueryDocumentsInput`; the
-    // array-wrap reconciles the wider `string | string[]` boundary type without
-    // re-validating (that stays the parser's responsibility). The key is omitted
-    // when scope is absent (exactOptionalPropertyTypes), preserving search()'s
-    // scope-absent path.
+    // `args.scope` is parser-validated; array-wrap without re-validating, and
+    // omit the key when absent (exactOptionalPropertyTypes) to keep the scope-absent path.
     const searchResults = await this.vectorStore.search(queryVector, {
       queryText: args.query,
       limit: args.limit ?? 10,

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -26,6 +26,11 @@ export const toolDefinitions: Tool[] = [
           description:
             'Maximum number of results to return (default: 10, range: 1-20). Recommended: 5 for precision, 10 for balance, 20 for broad exploration.',
         },
+        scope: {
+          oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+          description:
+            'Optional path-prefix filter: one prefix or a list of prefixes (results from multiple prefixes are unioned). Restricts results to chunks whose filePath equals a prefix or is a descendant of it (exact-or-descendant). Example: "/docs/api" matches "/docs/api" and "/docs/api/auth.md" but not "/docs/apiv2"; a file prefix "/docs/readme.md" matches that file. Pass prefixes in the server OS path style.',
+        },
       },
       required: ['query'],
     },

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -17,7 +17,8 @@ export const toolDefinitions: Tool[] = [
       properties: {
         query: {
           type: 'string',
-          description: 'Search query.',
+          description:
+            'Search query. Preserve specific user terms (for keyword match); add context when the query is vague (for semantic match).',
         },
         limit: {
           type: 'number',
@@ -29,7 +30,7 @@ export const toolDefinitions: Tool[] = [
         scope: {
           oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
           description:
-            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting results to a filePath equal to or under a prefix. "/docs/api" matches "/docs/api/auth.md" but not "/docs/apiv2". Use the server OS path style; relative prefixes match nothing.',
+            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting results to a filePath equal to or under a prefix. "/docs/api" matches "/docs/api/auth.md" but not "/docs/apiv2". Must be absolute (server OS style); a relative prefix matches nothing — derive one from a filePath returned by an earlier query, or omit scope.',
         },
       },
       required: ['query'],
@@ -84,7 +85,8 @@ export const toolDefinitions: Tool[] = [
             format: {
               type: 'string',
               enum: ['text', 'html', 'markdown'],
-              description: 'Content format: "text", "html", or "markdown"',
+              description:
+                'Content format: text (plain/copied text), html (fetched web pages), or markdown.',
             },
           },
           required: ['source', 'format'],

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -11,25 +11,25 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'query_documents',
     description:
-      'Search ingested documents. Your query words are matched exactly (keyword search). Your query meaning is matched semantically (vector search). Preserve specific terms from the user. Add context if the query is ambiguous. Results include score (0 = most relevant, higher = less relevant).',
+      'Search ingested documents with hybrid keyword + semantic matching. Returns results sorted by relevance, each with filePath, chunkIndex, text, fileTitle, score (0 = best, higher = worse), and source (for ingest_data items).',
     inputSchema: {
       type: 'object',
       properties: {
         query: {
           type: 'string',
-          description: 'Search query. Include specific terms and add context if needed.',
+          description: 'Search query.',
         },
         limit: {
           type: 'number',
           minimum: 1,
           maximum: 20,
           description:
-            'Maximum number of results to return (default: 10, range: 1-20). Recommended: 5 for precision, 10 for balance, 20 for broad exploration.',
+            'Max results (default 10, range 1-20). Lower favors precision, higher recall.',
         },
         scope: {
           oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
           description:
-            'Optional path-prefix filter: one prefix or a list of prefixes (results from multiple prefixes are unioned). Restricts results to chunks whose filePath equals a prefix or is a descendant of it (exact-or-descendant). Example: "/docs/api" matches "/docs/api" and "/docs/api/auth.md" but not "/docs/apiv2"; a file prefix "/docs/readme.md" matches that file. Pass prefixes in the server OS path style.',
+            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting results to a filePath equal to or under a prefix. "/docs/api" matches "/docs/api/auth.md" but not "/docs/apiv2". Use the server OS path style; relative prefixes match nothing.',
         },
       },
       required: ['query'],
@@ -38,7 +38,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'ingest_file',
     description:
-      'Ingest a document file (PDF, DOCX, TXT, MD) into the vector database for semantic search. File path must be an absolute path. Supports re-ingestion to update existing documents.',
+      'Ingest a document file (PDF, DOCX, TXT, MD) into the vector database. Path must be absolute; re-ingesting the same path replaces its existing data. Returns { filePath, chunkCount, timestamp, fileTitle }.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -49,15 +49,14 @@ export const toolDefinitions: Tool[] = [
         },
         visual: {
           type: 'boolean',
-          description:
-            'If true and the file is a PDF, run VLM captioning on figure pages. No effect on non-PDF files.',
+          description: 'Run VLM captioning on figure pages (PDF only; default false).',
         },
         visualQuality: {
           type: 'string',
           enum: ['fast', 'quality'],
           default: 'fast',
           description:
-            'VLM profile to use when visual is true. "fast" (default) is the lightweight SmolVLM-256M; "quality" is Qwen2.5-VL-3B-Instruct-ONNX with higher fidelity on figures with in-image text (~10x model-cache footprint, ~2x per-page inference). The server also accepts an empty string as a synonym for omitted (normalized to "fast"). Silently ignored when visual is false.',
+            'VLM profile when visual is true (default "fast"). "quality" is more accurate on figures with in-image text but much heavier and slower. Ignored when visual is false.',
         },
       },
       required: ['filePath'],
@@ -66,7 +65,7 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'ingest_data',
     description:
-      'Ingest content as a string, not from a file. Use for: fetched web pages (format: html), copied text (format: text), or markdown strings (format: markdown). The source identifier enables re-ingestion to update existing content. For files on disk, use ingest_file instead.',
+      'Ingest in-memory content as a string (use ingest_file for files on disk). The source identifier enables re-ingestion to update existing content. Returns { filePath, chunkCount, timestamp, fileTitle }.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -117,31 +116,31 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'list_files',
     description:
-      'List all files in BASE_DIR (PDF, DOCX, TXT, MD) and show which are ingested into the vector database. Also lists any other ingested items (web pages, clipboard content, etc.) that are outside BASE_DIR.',
+      'List supported files (PDF, DOCX, TXT, MD) under the configured base directories and whether each is ingested. Returns { baseDirs, files, sources }; sources holds ingested items outside the base dirs (web pages, clipboard, etc.).',
     inputSchema: { type: 'object', properties: {} },
   },
   {
     name: 'status',
     description:
-      'Get system status including total documents, total chunks, database size, and configuration information.',
+      'Get index status: { documentCount, chunkCount, memoryUsage (MB), uptime (s), ftsIndexEnabled, searchMode }.',
     inputSchema: { type: 'object', properties: {} },
   },
   {
     name: 'read_chunk_neighbors',
     description:
-      "Expand a query_documents result by reading the chunks immediately before and after it in the same document. Use when the hit needs more surrounding context — for example, a definition without its example, or a conclusion without its reasoning. Pass chunkIndex from the query_documents result, along with the document's filePath (from ingest_file) or source (from ingest_data). Returns the target chunk (isTarget: true) plus neighbors, sorted ascending by chunkIndex. The before/after window is clamped to the document's existing chunks; a chunkIndex beyond the document returns an empty result. Defaults: before=2, after=2 (max 50 each). Provide exactly one of filePath or source.",
+      'Read the chunks immediately before and after a query_documents result, in the same document, for more surrounding context. Pass chunkIndex from the result plus exactly one of filePath (ingest_file) or source (ingest_data). Returns the target chunk (isTarget: true) and its neighbors, ascending by chunkIndex; an out-of-range chunkIndex returns []. Defaults: before=2, after=2 (max 50 each).',
     inputSchema: {
       type: 'object',
       properties: {
         filePath: {
           type: 'string',
           description:
-            'Absolute path to the file (for documents ingested via ingest_file). Example: "/Users/user/documents/manual.pdf". Provide either filePath or source, not both.',
+            'Absolute path to the file (for ingest_file documents). Provide exactly one of filePath or source. Example: "/Users/user/documents/manual.pdf".',
         },
         source: {
           type: 'string',
           description:
-            'Source identifier used in ingest_data (for data ingested via ingest_data). Examples: "https://example.com/page", "clipboard://2024-12-30". Provide either filePath or source, not both.',
+            'Source identifier (for ingest_data documents). Provide exactly one of filePath or source. Examples: "https://example.com/page", "clipboard://2024-12-30".',
         },
         chunkIndex: {
           type: 'number',

--- a/src/server/tool-input.ts
+++ b/src/server/tool-input.ts
@@ -14,6 +14,30 @@ import type { IngestDataInput, QueryDocumentsInput } from './types.js'
 
 const CONTENT_FORMATS: readonly ContentFormat[] = ['text', 'html', 'markdown']
 
+const SCOPE_ERROR = 'scope must be a non-empty string or a non-empty array of non-empty strings'
+
+/**
+ * Normalize the optional `scope` argument to `string[]`. Accepts a non-empty
+ * string or a non-empty array of non-empty strings; rejects empty array,
+ * empty/whitespace string, non-string array element, and any non-string
+ * non-array value with `McpError(InvalidParams)`. Mirrors the `limit`
+ * defense-in-depth check at the entry boundary.
+ */
+function normalizeScope(scope: unknown): string[] {
+  const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === 'string' && value.trim().length > 0
+
+  if (isNonEmptyString(scope)) {
+    return [scope]
+  }
+
+  if (Array.isArray(scope) && scope.length > 0 && scope.every(isNonEmptyString)) {
+    return scope
+  }
+
+  throw new McpError(ErrorCode.InvalidParams, SCOPE_ERROR)
+}
+
 function asRecord(raw: unknown, label: string): Record<string, unknown> {
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
     throw new McpError(ErrorCode.InvalidParams, `${label} arguments must be an object`)
@@ -28,11 +52,13 @@ function asRecord(raw: unknown, label: string): Record<string, unknown> {
  */
 export function parseQueryDocumentsInput(raw: unknown): QueryDocumentsInput {
   const obj = asRecord(raw, 'query_documents')
-  const { query, limit } = obj
+  const { query, limit, scope } = obj
 
   if (typeof query !== 'string' || query.trim().length === 0) {
     throw new McpError(ErrorCode.InvalidParams, 'query must be a non-empty string')
   }
+
+  const input: QueryDocumentsInput = { query }
 
   if (limit !== undefined) {
     // Bound to 1-20 at the entry boundary — the same range VectorStore.search
@@ -42,10 +68,14 @@ export function parseQueryDocumentsInput(raw: unknown): QueryDocumentsInput {
     if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1 || limit > 20) {
       throw new McpError(ErrorCode.InvalidParams, 'limit must be an integer between 1 and 20')
     }
-    return { query, limit }
+    input.limit = limit
   }
 
-  return { query }
+  if (scope !== undefined) {
+    input.scope = normalizeScope(scope)
+  }
+
+  return input
 }
 
 /**

--- a/src/server/tool-input.ts
+++ b/src/server/tool-input.ts
@@ -27,12 +27,13 @@ function normalizeScope(scope: unknown): string[] {
   const isNonEmptyString = (value: unknown): value is string =>
     typeof value === 'string' && value.trim().length > 0
 
+  // Trim so whitespace-padded prefixes don't silently match nothing.
   if (isNonEmptyString(scope)) {
-    return [scope]
+    return [scope.trim()]
   }
 
   if (Array.isArray(scope) && scope.length > 0 && scope.every(isNonEmptyString)) {
-    return scope
+    return scope.map((value) => value.trim())
   }
 
   throw new McpError(ErrorCode.InvalidParams, SCOPE_ERROR)

--- a/src/server/tool-input.ts
+++ b/src/server/tool-input.ts
@@ -17,11 +17,8 @@ const CONTENT_FORMATS: readonly ContentFormat[] = ['text', 'html', 'markdown']
 const SCOPE_ERROR = 'scope must be a non-empty string or a non-empty array of non-empty strings'
 
 /**
- * Normalize the optional `scope` argument to `string[]`. Accepts a non-empty
- * string or a non-empty array of non-empty strings; rejects empty array,
- * empty/whitespace string, non-string array element, and any non-string
- * non-array value with `McpError(InvalidParams)`. Mirrors the `limit`
- * defense-in-depth check at the entry boundary.
+ * Normalize the optional `scope` to a trimmed `string[]`, rejecting any other
+ * shape with `McpError(InvalidParams)`. Mirrors the `limit` boundary check.
  */
 function normalizeScope(scope: unknown): string[] {
   const isNonEmptyString = (value: unknown): value is string =>

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -82,11 +82,7 @@ export interface QueryDocumentsInput {
   query: string
   /** Number of results to retrieve (default 10) */
   limit?: number
-  /**
-   * Path prefix scope: one prefix or a list of prefixes. Accepted as
-   * `string | string[]` at the MCP boundary; `parseQueryDocumentsInput`
-   * normalizes it to `string[]`, which is the shape the handler reads.
-   */
+  /** Path prefix scope (one or a list); the parser normalizes to `string[]`. */
   scope?: string | string[]
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -82,6 +82,12 @@ export interface QueryDocumentsInput {
   query: string
   /** Number of results to retrieve (default 10) */
   limit?: number
+  /**
+   * Path prefix scope: one prefix or a list of prefixes. Accepted as
+   * `string | string[]` at the MCP boundary; `parseQueryDocumentsInput`
+   * normalizes it to `string[]`, which is the shape the handler reads.
+   */
+  scope?: string | string[]
 }
 
 /**

--- a/src/vectordb/__tests__/vectordb.test.ts
+++ b/src/vectordb/__tests__/vectordb.test.ts
@@ -1682,4 +1682,170 @@ describe('VectorStore', () => {
       })
     })
   })
+
+  /**
+   * search({ scope, queryText }) — the FTS / keyword-boost branch (Step 3 of
+   * search()). Distinct from the vector-only `search scope prefilter` block:
+   * every search here passes a non-empty queryText so the FTS branch is active
+   * (ftsEnabled is true after insertChunks creates the index). Real-LanceDB
+   * integration (mocks cannot verify the FTS `filePath IN (...)` / scope
+   * interaction). Discharges AC4 (FTS stays in-scope; skip on zero hits) and
+   * AC7 (scope-absent hybrid unchanged).
+   */
+  describe('search scope prefilter (FTS/hybrid branch)', () => {
+    /** Distinct filePaths from a scoped hybrid (queryText present) search. */
+    async function scopedHybridFilePaths(
+      store: VectorStore,
+      scope: string[],
+      queryText: string
+    ): Promise<string[]> {
+      const results = await store.search(createNormalizedVector(1), { scope, queryText, limit: 20 })
+      return [...new Set(results.map((r) => r.filePath))].sort()
+    }
+
+    it('restricts hybrid (queryText present) results to in-scope files only', async () => {
+      await withTempDb('fts-scope-boundary', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha keyword inside', '/a/b/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha keyword nested', '/a/b/sub/y.md', 0, createNormalizedVector(2)),
+          createTestChunk('alpha keyword boundary', '/a/bc.md', 0, createNormalizedVector(3)),
+          createTestChunk('alpha keyword other', '/foo/bar.md', 0, createNormalizedVector(4)),
+        ])
+
+        // queryText 'alpha' matches every doc's text via FTS; only scope must
+        // restrict the set. /a/bc.md (boundary) and /foo/bar.md (other) excluded.
+        const paths = await scopedHybridFilePaths(store, ['/a/b'], 'alpha')
+
+        expect(paths).toEqual(['/a/b/sub/y.md', '/a/b/x.md'])
+      })
+    })
+
+    it('skips the FTS branch entirely when scope matches no stored path (no IN ())', async () => {
+      await withTempDb('fts-scope-empty', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha keyword one', '/a/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha keyword two', '/b/y.md', 0, createNormalizedVector(2)),
+        ])
+
+        // Scope matches nothing → scoped vector step returns zero hits. The FTS
+        // branch must be skipped before building a predicate, so table.search
+        // (the FTS query) is never invoked — otherwise it builds a malformed
+        // `filePath IN ()` that LanceDB rejects. Asserting the call count turns
+        // this red under the defect (where the catch swallows the parse error
+        // and the result is empty either way).
+        const table = (store as unknown as { table: { search: (...args: unknown[]) => unknown } })
+          .table
+        const ftsSpy = vi.spyOn(table, 'search')
+
+        const results = await store.search(createNormalizedVector(1), {
+          scope: ['/nonexistent'],
+          queryText: 'alpha',
+          limit: 20,
+        })
+
+        expect(results).toEqual([])
+        expect(ftsSpy).not.toHaveBeenCalled()
+        ftsSpy.mockRestore()
+      })
+    })
+
+    it('keeps scope-absent hybrid results unchanged (backward compatible)', async () => {
+      await withTempDb('fts-scope-absent', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha keyword a', '/a/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha keyword b', '/b/y.md', 0, createNormalizedVector(2)),
+        ])
+
+        const results = await store.search(createNormalizedVector(1), {
+          queryText: 'alpha',
+          limit: 20,
+        })
+        const paths = [...new Set(results.map((r) => r.filePath))].sort()
+
+        // No scope → FTS branch runs over all vector hits → every corpus surfaces.
+        expect(paths).toEqual(['/a/x.md', '/b/y.md'])
+      })
+    })
+
+    it('inherits scope on the FTS branch for backslash-style stored paths', async () => {
+      await withTempDb('fts-scope-backslash', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha win inside', 'C:\\docs\\a.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha win boundary', 'C:\\docsX\\b.md', 0, createNormalizedVector(2)),
+        ])
+
+        const paths = await scopedHybridFilePaths(store, ['C:\\docs'], 'alpha')
+
+        expect(paths).toEqual(['C:\\docs\\a.md'])
+      })
+    })
+
+    it('matches an exact file scope on the FTS branch (exact-or-descendant)', async () => {
+      await withTempDb('fts-scope-exact-file', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha the file', '/foo/bar.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha sibling', '/foo/bar.md.bak', 0, createNormalizedVector(2)),
+        ])
+
+        const paths = await scopedHybridFilePaths(store, ['/foo/bar.md'], 'alpha')
+
+        // Exact file scope matches the file itself; the .bak sibling is excluded.
+        expect(paths).toEqual(['/foo/bar.md'])
+      })
+    })
+
+    it('matches everything under a root scope on the FTS branch without doubling', async () => {
+      await withTempDb('fts-scope-root', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha top', '/a.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha nested', '/deep/nested.md', 0, createNormalizedVector(2)),
+        ])
+
+        const paths = await scopedHybridFilePaths(store, ['/'], 'alpha')
+
+        expect(paths).toEqual(['/a.md', '/deep/nested.md'])
+      })
+    })
+
+    it('unions multiple prefixes on the FTS branch', async () => {
+      await withTempDb('fts-scope-multi', async (store) => {
+        await store.insertChunks([
+          createTestChunk('alpha corpus a', '/a/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('alpha corpus b', '/b/y.md', 0, createNormalizedVector(2)),
+          createTestChunk('alpha corpus c', '/c/z.md', 0, createNormalizedVector(3)),
+        ])
+
+        const paths = await scopedHybridFilePaths(store, ['/a', '/b'], 'alpha')
+
+        expect(paths).toEqual(['/a/x.md', '/b/y.md'])
+      })
+    })
+
+    it('neutralizes an injection prefix on the FTS branch (quote/%/_)', async () => {
+      await withTempDb('fts-scope-injection', async (store) => {
+        const trickyDir = "/danger/o'_%dir"
+        await store.insertChunks([
+          createTestChunk(
+            'alpha inside tricky',
+            `${trickyDir}/child.md`,
+            0,
+            createNormalizedVector(1)
+          ),
+          createTestChunk(
+            'alpha wildcard decoy',
+            '/danger/oXY_ZZZdir/child.md',
+            0,
+            createNormalizedVector(2)
+          ),
+          createTestChunk('alpha unrelated', '/safe/file.md', 0, createNormalizedVector(3)),
+        ])
+
+        const paths = await scopedHybridFilePaths(store, [trickyDir], 'alpha')
+
+        // Only the literal descendant; %/_ must not act as wildcards and the
+        // quote must not break the predicate even through the FTS branch.
+        expect(paths).toEqual([`${trickyDir}/child.md`])
+      })
+    })
+  })
 })

--- a/src/vectordb/__tests__/vectordb.test.ts
+++ b/src/vectordb/__tests__/vectordb.test.ts
@@ -154,7 +154,10 @@ describe('VectorStore', () => {
       })
 
       // The query still resolves with vector-only results (no throw).
-      const results = await store.search(createNormalizedVector(1), 'typescript', 5)
+      const results = await store.search(createNormalizedVector(1), {
+        queryText: 'typescript',
+        limit: 5,
+      })
       expect(results.length).toBeGreaterThan(0)
 
       // FTS is NOT permanently disabled by a single failed query.
@@ -162,7 +165,10 @@ describe('VectorStore', () => {
 
       // And the next query retries hybrid search successfully.
       ftsSpy.mockRestore()
-      const retry = await store.search(createNormalizedVector(1), 'typescript', 5)
+      const retry = await store.search(createNormalizedVector(1), {
+        queryText: 'typescript',
+        limit: 5,
+      })
       expect(retry.length).toBeGreaterThan(0)
     })
   })
@@ -246,7 +252,10 @@ describe('VectorStore', () => {
         await store.insertChunks([chunk])
 
         // Search should still work (vector-only) and return the inserted document
-        const results = await store.search(createNormalizedVector(1), 'test query', 10)
+        const results = await store.search(createNormalizedVector(1), {
+          queryText: 'test query',
+          limit: 10,
+        })
         expect(results).toHaveLength(1)
         expect(results[0]?.filePath).toBe('/test/fallback.txt')
         expect(results[0]?.text).toBe('Fallback test document')
@@ -292,7 +301,10 @@ describe('VectorStore', () => {
 
         // Search with exact keyword match
         const queryVector = createNormalizedVector(1)
-        const results = await store.search(queryVector, 'ProjectLifetimeScope', 10)
+        const results = await store.search(queryVector, {
+          queryText: 'ProjectLifetimeScope',
+          limit: 10,
+        })
 
         // All 3 documents should be returned
         expect(results).toHaveLength(3)
@@ -321,7 +333,7 @@ describe('VectorStore', () => {
         await store.insertChunks([chunk])
 
         // Search with empty query text (should use vector-only)
-        const results = await store.search(createNormalizedVector(1), '', 10)
+        const results = await store.search(createNormalizedVector(1), { queryText: '', limit: 10 })
 
         // Should return the inserted document via vector-only search
         expect(results).toHaveLength(1)
@@ -346,7 +358,7 @@ describe('VectorStore', () => {
         await store.insertChunks([chunk])
 
         // Original search signature should still work (queryText = undefined)
-        const results = await store.search(createNormalizedVector(1), undefined, 10)
+        const results = await store.search(createNormalizedVector(1), { limit: 10 })
 
         // Should return the inserted document
         expect(results).toHaveLength(1)
@@ -385,7 +397,7 @@ describe('VectorStore', () => {
 
         // Search with Japanese keyword
         const queryVector = createNormalizedVector(1)
-        const results = await store.search(queryVector, '依存性注入', 10)
+        const results = await store.search(queryVector, { queryText: '依存性注入', limit: 10 })
 
         // Verify Japanese document is found (ngram tokenizer works)
         const foundJapanese = results.some((r) => r.filePath === '/test/japanese.md')
@@ -445,7 +457,7 @@ describe('VectorStore', () => {
         await store.insertChunks([doc2])
 
         // Search with keyword that matches doc1, but query vector close to doc2
-        const results = await store.search(queryVector, 'UniqueKeyword', 10)
+        const results = await store.search(queryVector, { queryText: 'UniqueKeyword', limit: 10 })
 
         expect(results).toHaveLength(2)
 
@@ -495,7 +507,7 @@ describe('VectorStore', () => {
         await store.insertChunks([doc1])
         await store.insertChunks([doc2])
 
-        const results = await store.search(queryVector, 'UniqueKeyword', 10)
+        const results = await store.search(queryVector, { queryText: 'UniqueKeyword', limit: 10 })
 
         expect(results).toHaveLength(2)
 
@@ -544,7 +556,7 @@ describe('VectorStore', () => {
         await store.insertChunks([doc1])
         await store.insertChunks([doc2])
 
-        const results = await store.search(queryVector, 'UniqueKeyword', 10)
+        const results = await store.search(queryVector, { queryText: 'UniqueKeyword', limit: 10 })
 
         expect(results).toHaveLength(2)
 
@@ -591,7 +603,7 @@ describe('VectorStore', () => {
           createTestChunk('seed50', '/test/s50.txt', 0, createNormalizedVector(50)),
         ])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // Verify: seed 1 < seed 2 < seed 50 in distance
         const score1 = results.find((r) => r.filePath === '/test/s1.txt')?.score ?? 999
@@ -649,7 +661,7 @@ describe('VectorStore', () => {
         await store.insertChunks([fileAChunk0, fileAChunk1])
         await store.insertChunks([fileBChunk0, fileBChunk1])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // Only File A chunks should remain (2 chunks inserted)
         expect(results).toHaveLength(2)
@@ -697,7 +709,7 @@ describe('VectorStore', () => {
           createTestChunk('File C chunk', '/test/fileC.txt', 0, createNormalizedVector(3)),
         ])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // File A and File B should remain, File C excluded
         expect(results.length).toBe(2)
@@ -738,7 +750,7 @@ describe('VectorStore', () => {
           createTestChunk('File C chunk', '/test/fileC.txt', 0, createNormalizedVector(50)),
         ])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // All 3 files should be returned
         expect(results).toHaveLength(3)
@@ -776,7 +788,7 @@ describe('VectorStore', () => {
           createTestChunk('File B chunk', '/test/fileB.txt', 0, createNormalizedVector(10)),
         ])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // All files returned since maxFiles > unique files
         expect(results).toHaveLength(2)
@@ -817,7 +829,7 @@ describe('VectorStore', () => {
           createTestChunk('File C in group 2', '/test/fileC.txt', 0, createNormalizedVector(200)),
         ])
 
-        const results = await store.search(queryVector, '', 10)
+        const results = await store.search(queryVector, { queryText: '', limit: 10 })
 
         // Grouping should remove File C (group 2), then maxFiles=1 keeps only 1 file from group 1
         expect(results).toHaveLength(1)
@@ -873,7 +885,10 @@ describe('VectorStore', () => {
           )
           await store.insertChunks([chunk])
 
-          const results = await store.search(createNormalizedVector(1), '', 10)
+          const results = await store.search(createNormalizedVector(1), {
+            queryText: '',
+            limit: 10,
+          })
 
           // Contract: Single result returned as-is
           expect(results).toHaveLength(1)
@@ -907,7 +922,7 @@ describe('VectorStore', () => {
             await store.insertChunks([chunk])
           }
 
-          const results = await store.search(baseVector, '', 10)
+          const results = await store.search(baseVector, { queryText: '', limit: 10 })
 
           // Contract: No significant gaps → return all results
           expect(results).toHaveLength(4)
@@ -949,7 +964,7 @@ describe('VectorStore', () => {
             await store.insertChunks([chunk])
           }
 
-          const results = await store.search(baseVector, '', 10)
+          const results = await store.search(baseVector, { queryText: '', limit: 10 })
 
           // Contract: 'similar' mode cuts at first boundary
           // Only Group 1 should be returned
@@ -994,7 +1009,7 @@ describe('VectorStore', () => {
             await store.insertChunks([chunk])
           }
 
-          const results = await store.search(baseVector, '', 10)
+          const results = await store.search(baseVector, { queryText: '', limit: 10 })
 
           // Contract: 'related' mode with only 1 boundary → return all results
           expect(results).toHaveLength(5)
@@ -1045,7 +1060,7 @@ describe('VectorStore', () => {
           for (const chunk of testChunks) {
             await similarStore.insertChunks([chunk])
           }
-          const similarResults = await similarStore.search(baseVector, '', 10)
+          const similarResults = await similarStore.search(baseVector, { queryText: '', limit: 10 })
 
           // Test with related mode
           const relatedStore = new VectorStore({
@@ -1057,7 +1072,7 @@ describe('VectorStore', () => {
           for (const chunk of testChunks) {
             await relatedStore.insertChunks([chunk])
           }
-          const relatedResults = await relatedStore.search(baseVector, '', 10)
+          const relatedResults = await relatedStore.search(baseVector, { queryText: '', limit: 10 })
 
           // Contract: 'similar' cuts at first boundary, 'related' at second (or returns all if only 1)
           // Therefore: relatedResults.length >= similarResults.length
@@ -1196,7 +1211,10 @@ describe('VectorStore', () => {
           await newStore.insertChunks([newChunk])
 
           // Step 4: Verify search returns results with fileTitle field
-          const results = await newStore.search(createNormalizedVector(2), '', 10)
+          const results = await newStore.search(createNormalizedVector(2), {
+            queryText: '',
+            limit: 10,
+          })
           expect(results.length).toBeGreaterThanOrEqual(1)
 
           // The new document should have fileTitle
@@ -1252,7 +1270,10 @@ describe('VectorStore', () => {
           await store3.initialize()
 
           // Search should still work
-          const results = await store3.search(createNormalizedVector(1), '', 10)
+          const results = await store3.search(createNormalizedVector(1), {
+            queryText: '',
+            limit: 10,
+          })
           expect(results).toHaveLength(1)
           expect(results[0]?.filePath).toBe('/test/doc.txt')
         } finally {
@@ -1480,6 +1501,184 @@ describe('VectorStore', () => {
         const status = await store.getStatus()
         expect(status.documentCount).toBe(2)
         expect(status.chunkCount).toBe(3)
+      })
+    })
+  })
+
+  /**
+   * search({ scope }) — scope prefix prefilter applied as a .where() on
+   * vectorSearch. Real-LanceDB integration (mocks cannot verify query/filter
+   * correctness). Discharges proof obligations AC3/AC5 (boundary-safe
+   * exact-or-descendant), AC6 (escaping), AC9 (separator from prefix).
+   *
+   * Helper: seed a corpus, search with scope, collect the distinct in-scope
+   * filePaths. A fixed all-ones vector against fixed normalized seeds returns
+   * every chunk as a candidate (limit*2), so the scope .where() prefilter is
+   * the only thing that restricts the result set.
+   */
+  describe('search scope prefilter', () => {
+    /** Collect the distinct filePaths returned by a scoped search. */
+    async function scopedFilePaths(store: VectorStore, scope: string[]): Promise<string[]> {
+      const results = await store.search(createNormalizedVector(1), { scope, limit: 20 })
+      return [...new Set(results.map((r) => r.filePath))].sort()
+    }
+
+    it('restricts results to descendants of a directory prefix and excludes the boundary sibling', async () => {
+      await withTempDb('scope-boundary', async (store) => {
+        await store.insertChunks([
+          createTestChunk('inside one', '/a/b/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('inside two', '/a/b/sub/y.md', 0, createNormalizedVector(2)),
+          createTestChunk('boundary sibling', '/a/bc.md', 0, createNormalizedVector(3)),
+          createTestChunk('other corpus', '/foo/bar.md', 0, createNormalizedVector(4)),
+        ])
+
+        const paths = await scopedFilePaths(store, ['/a/b'])
+
+        // /a/b matches descendants but NOT /a/bc.md (boundary) or /foo/bar.md.
+        expect(paths).toEqual(['/a/b/sub/y.md', '/a/b/x.md'])
+      })
+    })
+
+    it('matches an exact file scope to that file only (exact-or-descendant)', async () => {
+      await withTempDb('scope-exact-file', async (store) => {
+        await store.insertChunks([
+          createTestChunk('the file', '/foo/bar.md', 0, createNormalizedVector(1)),
+          createTestChunk(
+            'descendant-looking sibling',
+            '/foo/bar.md.bak',
+            0,
+            createNormalizedVector(2)
+          ),
+          createTestChunk('other', '/foo/baz.md', 0, createNormalizedVector(3)),
+        ])
+
+        const paths = await scopedFilePaths(store, ['/foo/bar.md'])
+
+        // Exact file scope matches the file itself; /foo/bar.md.bak is NOT a
+        // descendant (no separator boundary) and must be excluded.
+        expect(paths).toEqual(['/foo/bar.md'])
+      })
+    })
+
+    it('treats /a/b, /a/b/ and /a/b// as equivalent (trailing-separator normalization)', async () => {
+      await withTempDb('scope-normalize', async (store) => {
+        await store.insertChunks([
+          createTestChunk('inside', '/a/b/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('exact dir', '/a/b', 0, createNormalizedVector(2)),
+          createTestChunk('boundary', '/a/bc.md', 0, createNormalizedVector(3)),
+        ])
+
+        const plain = await scopedFilePaths(store, ['/a/b'])
+        const oneSlash = await scopedFilePaths(store, ['/a/b/'])
+        const twoSlash = await scopedFilePaths(store, ['/a/b//'])
+
+        expect(plain).toEqual(['/a/b', '/a/b/x.md'])
+        expect(oneSlash).toEqual(plain)
+        expect(twoSlash).toEqual(plain)
+      })
+    })
+
+    it('matches everything under a root scope without doubling the separator', async () => {
+      await withTempDb('scope-root', async (store) => {
+        await store.insertChunks([
+          createTestChunk('top-level', '/a.md', 0, createNormalizedVector(1)),
+          createTestChunk('nested', '/deep/nested.md', 0, createNormalizedVector(2)),
+        ])
+
+        // Root scope '/' must become LIKE '/%' (not '//%'), matching every
+        // posix path; the root itself is not normalized away to empty.
+        const paths = await scopedFilePaths(store, ['/'])
+
+        expect(paths).toEqual(['/a.md', '/deep/nested.md'])
+      })
+    })
+
+    it('unions results across multiple prefixes', async () => {
+      await withTempDb('scope-multi', async (store) => {
+        await store.insertChunks([
+          createTestChunk('corpus a', '/a/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('corpus b', '/b/y.md', 0, createNormalizedVector(2)),
+          createTestChunk('corpus c', '/c/z.md', 0, createNormalizedVector(3)),
+        ])
+
+        const paths = await scopedFilePaths(store, ['/a', '/b'])
+
+        // Union across prefixes: /a and /b in, /c out.
+        expect(paths).toEqual(['/a/x.md', '/b/y.md'])
+      })
+    })
+
+    it('derives the boundary separator from a backslash-style prefix', async () => {
+      await withTempDb('scope-backslash', async (store) => {
+        await store.insertChunks([
+          createTestChunk('win inside', 'C:\\docs\\a.md', 0, createNormalizedVector(1)),
+          createTestChunk('win boundary', 'C:\\docsX\\b.md', 0, createNormalizedVector(2)),
+        ])
+
+        // Prefix contains '\' so the boundary separator is '\', not path.sep.
+        // 'C:\\docs' matches 'C:\\docs\\a.md' but not 'C:\\docsX\\b.md'.
+        const paths = await scopedFilePaths(store, ['C:\\docs'])
+
+        expect(paths).toEqual(['C:\\docs\\a.md'])
+      })
+    })
+
+    it('matches everything under a backslash root scope (C:\\) without doubling', async () => {
+      await withTempDb('scope-backslash-root', async (store) => {
+        await store.insertChunks([
+          createTestChunk('win doc', 'C:\\docs\\a.md', 0, createNormalizedVector(1)),
+          createTestChunk('win other', 'C:\\other\\b.md', 0, createNormalizedVector(2)),
+        ])
+
+        // 'C:\\' is a root: LIKE 'C:\\%' (escaped backslash), matching all.
+        const paths = await scopedFilePaths(store, ['C:\\'])
+
+        expect(paths).toEqual(['C:\\docs\\a.md', 'C:\\other\\b.md'])
+      })
+    })
+
+    it('neutralizes an injection prefix containing quote/%/_ (LIKE metacharacters)', async () => {
+      await withTempDb('scope-injection', async (store) => {
+        // A posix directory whose name contains a single quote and the LIKE
+        // wildcards % and _. The descendant child must match literally; %/_
+        // must NOT behave as wildcards and the quote must not break the
+        // predicate. (Backslash escaping is covered by the backslash-prefix
+        // tests; mixing separator styles in one prefix is outside the caller
+        // contract, which is single-separator-style per host OS.)
+        const trickyDir = "/danger/o'_%dir"
+        await store.insertChunks([
+          createTestChunk('inside tricky', `${trickyDir}/child.md`, 0, createNormalizedVector(1)),
+          // Decoy: if % and _ matched as wildcards, 'oX_Ydir' / 'oA_BCdir' would
+          // be caught by the unescaped pattern. They must be excluded.
+          createTestChunk(
+            'wildcard decoy',
+            '/danger/oXY_ZZZdir/child.md',
+            0,
+            createNormalizedVector(2)
+          ),
+          createTestChunk('unrelated', '/safe/file.md', 0, createNormalizedVector(3)),
+        ])
+
+        const paths = await scopedFilePaths(store, [trickyDir])
+
+        // Only the literal descendant; the decoy (where % / _ would have matched
+        // as wildcards) must be excluded, proving the chars are escaped.
+        expect(paths).toEqual([`${trickyDir}/child.md`])
+      })
+    })
+
+    it('leaves results unchanged when scope is absent (backward compatible)', async () => {
+      await withTempDb('scope-absent', async (store) => {
+        await store.insertChunks([
+          createTestChunk('a', '/a/x.md', 0, createNormalizedVector(1)),
+          createTestChunk('b', '/b/y.md', 0, createNormalizedVector(2)),
+        ])
+
+        const results = await store.search(createNormalizedVector(1), { limit: 20 })
+        const paths = [...new Set(results.map((r) => r.filePath))].sort()
+
+        // No scope → no .where() prefilter → every corpus surfaces.
+        expect(paths).toEqual(['/a/x.md', '/b/y.md'])
       })
     })
   })

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -1,5 +1,6 @@
 // VectorStore implementation with LanceDB integration
 
+import { sep as PATH_SEP } from 'node:path'
 import { type Connection, connect, Index, type Table } from '@lancedb/lancedb'
 import { applyFileFilter, applyGrouping, applyKeywordBoost } from './search-filters.js'
 import {
@@ -9,6 +10,7 @@ import {
   FTS_CLEANUP_THRESHOLD_MS,
   FTS_INDEX_NAME,
   HYBRID_SEARCH_CANDIDATE_MULTIPLIER,
+  type SearchOptions,
   type SearchResult,
   toChunkRow,
   toSearchResult,
@@ -322,11 +324,12 @@ export class VectorStore {
    * - Keyword matching acts as a boost, not a replacement for semantic similarity
    *
    * @param queryVector - Query vector (dimension depends on model)
-   * @param queryText - Optional query text for keyword boost (BM25)
-   * @param limit - Number of results to retrieve (default 10)
+   * @param options - Optional search options (queryText for keyword boost,
+   *   limit, and scope path-prefix prefilter)
    * @returns Array of search results (sorted by distance ascending, filtered by quality settings)
    */
-  async search(queryVector: number[], queryText?: string, limit = 10): Promise<SearchResult[]> {
+  async search(queryVector: number[], options: SearchOptions = {}): Promise<SearchResult[]> {
+    const { queryText, limit = 10, scope } = options
     if (!this.table) {
       console.error('VectorStore: Returning empty results as table does not exist')
       return []
@@ -340,6 +343,13 @@ export class VectorStore {
       // Step 1: Semantic (vector) search - always the primary search
       const candidateLimit = limit * HYBRID_SEARCH_CANDIDATE_MULTIPLIER
       let query = this.table.vectorSearch(queryVector).distanceType('dot').limit(candidateLimit)
+
+      // Scope prefilter: restrict to chunks under the given path prefixes
+      // (exact-or-descendant) before ranking. Applied only when scope is
+      // present so scope-absent behavior is byte-for-byte unchanged.
+      if (scope && scope.length > 0) {
+        query = query.where(this.buildScopePredicate(scope))
+      }
 
       // Apply distance threshold at query level
       if (this.config.maxDistance !== undefined) {
@@ -398,6 +408,78 @@ export class VectorStore {
     } catch (error) {
       throw new DatabaseError('Failed to search vectors', error as Error)
     }
+  }
+
+  /**
+   * Build a LanceDB `.where()` predicate restricting `filePath` to the
+   * exact-or-descendant set of the given path prefixes (union across prefixes).
+   *
+   * Single source of truth for the scope predicate — both the vector branch
+   * and (in a later task) the FTS branch consume this. Per prefix P:
+   * 1. Normalize: strip all trailing separators (`/a/b`, `/a/b/`, `/a/b//` all
+   *    collapse to `/a/b`); a posix root `/` is preserved as `/` so it expands
+   *    to `/%` rather than emptying.
+   * 2. Derive the boundary separator from P (the separator present in P),
+   *    defaulting to `node:path.sep` when P contains none.
+   * 3. Emit `` `filePath` = '<P>' OR `filePath` LIKE '<D>%' ESCAPE '\' ``
+   *    where D = P.endsWith(sep) ? P : P + sep. The `endsWith` form keeps a
+   *    posix root (`/` → `/%`) from doubling the separator; a Windows drive
+   *    root `C:\` normalizes to `C:` whose descendant `C:\%` matches the drive.
+   *
+   * Matching is a byte-prefix over the stored `filePath`. Escaping mirrors the
+   * existing convention (`'` → `''`) and additionally escapes the LIKE
+   * metacharacters `%`, `_`, and `\` (backslash matters for Windows paths) via
+   * the explicit `ESCAPE '\'` clause.
+   */
+  private buildScopePredicate(prefixes: string[]): string {
+    return prefixes.map((prefix) => this.buildPrefixPredicate(prefix)).join(' OR ')
+  }
+
+  /** Build the exact-or-descendant predicate for a single prefix. */
+  private buildPrefixPredicate(prefix: string): string {
+    const sep = prefix.includes('\\') ? '\\' : prefix.includes('/') ? '/' : PATH_SEP
+    const normalized = this.stripTrailingSeparators(prefix, sep)
+    const descendant = normalized.endsWith(sep) ? normalized : normalized + sep
+    const exactTerm = `\`filePath\` = '${this.escapeQuotes(normalized)}'`
+    const descendantTerm = `\`filePath\` LIKE '${this.escapeLike(descendant)}%' ESCAPE '\\'`
+    return `(${exactTerm} OR ${descendantTerm})`
+  }
+
+  /**
+   * Strip all trailing `sep` characters. If stripping empties the string (a
+   * posix root such as `/`, which is only separators), keep one separator so
+   * the descendant term becomes `<root>%` (e.g. `/` → `/%`) rather than a bare
+   * `%` paired with an empty exact term. A Windows drive root like `C:\`
+   * strips to `C:`, whose descendant term `C:\%` already matches everything
+   * under the drive, so no special case is needed there.
+   */
+  private stripTrailingSeparators(prefix: string, sep: string): string {
+    let end = prefix.length
+    while (end > 0 && prefix[end - 1] === sep) {
+      end--
+    }
+    if (end === 0) {
+      return sep
+    }
+    return prefix.slice(0, end)
+  }
+
+  /** Escape single quotes for a SQL string literal (mirrors deleteChunks). */
+  private escapeQuotes(value: string): string {
+    return value.replace(/'/g, "''")
+  }
+
+  /**
+   * Escape a value for use inside a LIKE term with `ESCAPE '\'`: backslash
+   * first (so it does not double-escape the others), then the LIKE wildcards
+   * `%` and `_`, then single quotes for the surrounding string literal.
+   */
+  private escapeLike(value: string): string {
+    return value
+      .replace(/\\/g, '\\\\')
+      .replace(/%/g, '\\%')
+      .replace(/_/g, '\\_')
+      .replace(/'/g, "''")
   }
 
   /**

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -424,25 +424,10 @@ export class VectorStore {
 
   /**
    * Build a LanceDB `.where()` predicate restricting `filePath` to the
-   * exact-or-descendant set of the given path prefixes (union across prefixes).
-   *
-   * Single source of truth for the scope predicate (consumed by the vector
-   * branch's `.where()`; the FTS branch inherits scope via its own
-   * `filePath IN (...)` over the scoped hits). Per prefix P:
-   * 1. Normalize: strip all trailing separators (`/a/b`, `/a/b/`, `/a/b//` all
-   *    collapse to `/a/b`); a posix root `/` is preserved as `/` so it expands
-   *    to `/%` rather than emptying.
-   * 2. Derive the boundary separator from P (the separator present in P),
-   *    defaulting to `node:path.sep` when P contains none.
-   * 3. Emit `` `filePath` = '<P>' OR `filePath` LIKE '<D>%' ESCAPE '\' ``
-   *    where D = P.endsWith(sep) ? P : P + sep. The `endsWith` form keeps a
-   *    posix root (`/` → `/%`) from doubling the separator; a Windows drive
-   *    root `C:\` normalizes to `C:` whose descendant `C:\%` matches the drive.
-   *
-   * Matching is a byte-prefix over the stored `filePath`. Escaping mirrors the
-   * existing convention (`'` → `''`) and additionally escapes the LIKE
-   * metacharacters `%`, `_`, and `\` (backslash matters for Windows paths) via
-   * the explicit `ESCAPE '\'` clause.
+   * exact-or-descendant set of the given prefixes (OR'd): `filePath = P OR
+   * filePath LIKE 'D%'`, where the separator boundary in D stops `/a/b` from
+   * matching `/a/bc`. Consumed by the vector branch only — the FTS branch
+   * inherits scope via its own `filePath IN (...)` over the scoped hits.
    */
   private buildScopePredicate(prefixes: string[]): string {
     return prefixes.map((prefix) => this.buildPrefixPredicate(prefix)).join(' OR ')
@@ -460,12 +445,8 @@ export class VectorStore {
   }
 
   /**
-   * Strip all trailing `sep` characters. If stripping empties the string (a
-   * posix root such as `/`, which is only separators), keep one separator so
-   * the descendant term becomes `<root>%` (e.g. `/` → `/%`) rather than a bare
-   * `%` paired with an empty exact term. A Windows drive root like `C:\`
-   * strips to `C:`, whose descendant term `C:\%` already matches everything
-   * under the drive, so no special case is needed there.
+   * Strip trailing separators. A posix root `/` (only separators) is kept as a
+   * single `/` so its descendant term becomes `/%` instead of an empty prefix.
    */
   private stripTrailingSeparators(prefix: string, sep: string): string {
     let end = prefix.length
@@ -483,11 +464,7 @@ export class VectorStore {
     return value.replace(/'/g, "''")
   }
 
-  /**
-   * Escape a value for use inside a LIKE term with `ESCAPE '\'`: backslash
-   * first (so it does not double-escape the others), then the LIKE wildcards
-   * `%` and `_`, then single quotes for the surrounding string literal.
-   */
+  /** Escape for a LIKE term with `ESCAPE '\'`: backslash first (else it double-escapes), then `%`, `_`, then quotes. */
   private escapeLike(value: string): string {
     return value
       .replace(/\\/g, '\\\\')

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -426,8 +426,9 @@ export class VectorStore {
    * Build a LanceDB `.where()` predicate restricting `filePath` to the
    * exact-or-descendant set of the given path prefixes (union across prefixes).
    *
-   * Single source of truth for the scope predicate — both the vector branch
-   * and (in a later task) the FTS branch consume this. Per prefix P:
+   * Single source of truth for the scope predicate (consumed by the vector
+   * branch's `.where()`; the FTS branch inherits scope via its own
+   * `filePath IN (...)` over the scoped hits). Per prefix P:
    * 1. Normalize: strip all trailing separators (`/a/b`, `/a/b/`, `/a/b//` all
    *    collapse to `/a/b`); a posix root `/` is preserved as `/` so it expands
    *    to `/%` rather than emptying.
@@ -449,6 +450,7 @@ export class VectorStore {
 
   /** Build the exact-or-descendant predicate for a single prefix. */
   private buildPrefixPredicate(prefix: string): string {
+    // Caveat: on posix `\` is a legal filename char, so a `/`-path containing `\` mis-derives the separator.
     const sep = prefix.includes('\\') ? '\\' : prefix.includes('/') ? '/' : PATH_SEP
     const normalized = this.stripTrailingSeparators(prefix, sep)
     const descendant = normalized.endsWith(sep) ? normalized : normalized + sep

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -367,9 +367,21 @@ export class VectorStore {
         results = applyGrouping(results, this.config.grouping)
       }
 
-      // Step 3: Apply keyword boost if enabled
+      // Step 3: Apply keyword boost if enabled.
+      // results.length > 0 guards the FTS branch: when the (scoped) vector step
+      // returned zero hits, uniqueFilePaths would be empty and the IN clause
+      // would degrade to a malformed `filePath IN ()` that LanceDB rejects.
+      // Skipping is also correct — there is nothing to rerank. The FTS branch
+      // inherits scope through uniqueFilePaths (derived from the scoped hits),
+      // so no separate scope predicate is needed here.
       const hybridWeight = this.config.hybridWeight ?? DEFAULT_HYBRID_WEIGHT
-      if (this.ftsEnabled && queryText && queryText.trim().length > 0 && hybridWeight > 0) {
+      if (
+        this.ftsEnabled &&
+        queryText &&
+        queryText.trim().length > 0 &&
+        hybridWeight > 0 &&
+        results.length > 0
+      ) {
         try {
           // Get unique filePaths from vector results to filter FTS search
           const uniqueFilePaths = [...new Set(results.map((r) => r.filePath))]

--- a/src/vectordb/types.ts
+++ b/src/vectordb/types.ts
@@ -48,6 +48,26 @@ export interface VectorStoreConfig {
 }
 
 /**
+ * Per-call options for {@link VectorStore.search}.
+ * Grouped into an object (instead of positional params) so the caller can pass
+ * any subset and so adding options (like `scope`) is not a breaking signature
+ * change.
+ */
+export interface SearchOptions {
+  /** Optional query text for keyword boost (BM25) */
+  queryText?: string
+  /** Number of results to retrieve (default 10, valid range 1-20) */
+  limit?: number
+  /**
+   * Optional path-prefix scope. Results are restricted to chunks whose
+   * `filePath` equals one of the prefixes or is a descendant of it
+   * (exact-or-descendant). Multiple prefixes are unioned. When omitted, no
+   * scope prefilter is applied (fully backward compatible).
+   */
+  scope?: string[]
+}
+
+/**
  * Document metadata
  */
 export interface DocumentMetadata {

--- a/src/vectordb/types.ts
+++ b/src/vectordb/types.ts
@@ -59,10 +59,8 @@ export interface SearchOptions {
   /** Number of results to retrieve (default 10, valid range 1-20) */
   limit?: number
   /**
-   * Optional path-prefix scope. Results are restricted to chunks whose
-   * `filePath` equals one of the prefixes or is a descendant of it
-   * (exact-or-descendant). Multiple prefixes are unioned. When omitted, no
-   * scope prefilter is applied (fully backward compatible).
+   * Optional path-prefix scope (exact-or-descendant, prefixes unioned). Omitted
+   * = no prefilter (backward compatible).
    */
   scope?: string[]
 }


### PR DESCRIPTION
## Summary

Adds an optional `scope` parameter to `query_documents` (MCP) and the `query` CLI subcommand that limits a search to documents under one or more absolute path prefixes. This lets a single shared database hold multiple corpora while letting a query focus on one when precision matters. Closes #146.

- `scope` accepts one prefix or a list (results are unioned).
- Matching is **exact-or-descendant**: a prefix matches a `filePath` equal to it or under it (`/docs/api` matches `/docs/api/auth.md` but not `/docs/apiv2`).
- Applied as a `.where()` prefilter on the vector candidate prefetch; the FTS/keyword-boost branch inherits scope via its existing `filePath IN (...)`.
- Optional and backward compatible: omitting `scope` is byte-for-byte unchanged.

## Design notes

- **Boundary-safe**: each prefix is normalized (trailing separators stripped, posix/Windows roots handled), then built as `filePath = P OR filePath LIKE 'D%'` where `D` carries a separator boundary. Reuses the existing single-quote escaping and additionally escapes `%`, `_`, `\` with `ESCAPE '\'`.
- **Absolute prefixes**: stored `filePath`s are absolute, so a relative prefix matches nothing by design. The MCP tool description and shipped skill document how to obtain an absolute prefix (or omit `scope`).
- **Signature**: `VectorStore.search` now takes an options object `search(queryVector, { queryText?, limit?, scope? })`.
- **FTS skip-on-empty**: the keyword-boost branch is skipped when the scoped vector step returns zero hits (avoids a malformed `filePath IN ()`).
- Input validated and trimmed at both the MCP (`McpError`) and CLI (`process.exit`) boundaries.

## Surface

- MCP: `query_documents` gains `scope` (string | string[]).
- CLI: `query` gains a repeatable `--scope <prefix>` flag.
- `list_files` / `read_chunk_neighbors` are intentionally out of scope for this PR.

## Docs

- Corrected and tightened all MCP tool descriptions to stand alone (return shapes documented; `status` description fixed to actual fields).
- Documented `scope` in the shipped `skills/mcp-local-rag` (SKILL.md, CLI reference, result-refinement).

## Testing

- `pnpm run check:all` green (947 tests).
- Real-LanceDB integration tests cover boundary exclusion, exact-file scope, trailing-separator normalization, root scopes, `/`- and `\`-style paths, multi-prefix union, injection escaping, FTS skip-on-empty, and scope-absent regression. Plus MCP/CLI validation and handler-threading tests.
- Manually verified end-to-end via the CLI against a multi-corpus database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)