### PR TITLE
fix(vectordb): recover from FTS optimize GenericFailure (lance-index Rust panic)

### DIFF
--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -312,7 +312,34 @@ export class VectorStore {
     }
 
     const cleanupThreshold = new Date(Date.now() - FTS_CLEANUP_THRESHOLD_MS)
-    await this.table.optimize({ cleanupOlderThan: cleanupThreshold })
+    try {
+      await this.table.optimize({ cleanupOlderThan: cleanupThreshold })
+    } catch (error) {
+      // lance-index Rust panics (e.g. inverted index out-of-bounds in
+      // lance-index-7.0.0) surface as GenericFailure. Recover by dropping
+      // the corrupted FTS index and rebuilding from scratch.
+      if ((error as { code?: string }).code === 'GenericFailure') {
+        console.error(
+          'VectorStore: FTS optimize panicked (lance-index bug) — dropping and rebuilding FTS index'
+        )
+        this.ftsEnabled = false
+        try {
+          const indices = await this.table.listIndices()
+          for (const idx of indices.filter((i: { indexType: string }) => i.indexType === 'FTS')) {
+            await this.table.dropIndex(idx.name)
+            console.error(`VectorStore: Dropped corrupted FTS index "${idx.name}"`)
+          }
+          await this.ensureFtsIndex()
+        } catch (rebuildError) {
+          console.error(
+            'VectorStore: FTS index rebuild failed — falling back to vector-only search',
+            rebuildError
+          )
+        }
+      } else {
+        throw new DatabaseError('Failed to optimize', error as Error)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When `lance-index` ≥7.0.0 encounters an out-of-bounds condition in its
inverted index during `table.optimize()`, the underlying Rust panic is
propagated through napi-rs as an error with `code: 'GenericFailure'`.

The bare `await this.table.optimize(...)` call in `VectorStore.optimize()`
has no handler for this, so the MCP server crashes and leaves the FTS
index in a permanently corrupted state. Subsequent ingest/query calls
also fail until the index is manually deleted.

## Fix

Wrap `table.optimize()` in a try-catch scoped to `GenericFailure`:

1. Disable FTS on this instance (`this.ftsEnabled = false`)
2. Drop all corrupted FTS indices via `table.dropIndex()`
3. Call `ensureFtsIndex()` to rebuild from scratch
4. If rebuild also fails: log the error and continue with vector-only search
5. Any non-`GenericFailure` error: re-throw as `DatabaseError` (existing behaviour)

This makes the server self-healing: one corrupted optimize cycle auto-recovers
without operator intervention or a server restart.

## Tested against

- `@lancedb/lancedb` 0.18.2 + `lance-index` 7.0.0 on Ubuntu 24.04 / Node 24
- Reproduced by ingesting a large document set that triggers the inverted-index
  out-of-bounds panic, then verifying the server recovers and resumes hybrid search

🤖 Generated with [Claude Code](https://claude.com/claude-code)