### PR TITLE
feat: add optional scope path-prefix filter to list_files and list CLI (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Pass the `filePath` and `chunkIndex` from the search result. The response includ
 "Show RAG server status"           # Check system health
 ```
 
+Narrow the listing with `scope` on `list_files` — one path prefix or a list of them. Results are restricted to files reachable at a path equal to or under a prefix (exact-or-descendant); for example, `"/docs/api"` matches `/docs/api` and `/docs/api/auth.md` but not `/docs/apiv2`. Raw-data sources (from `ingest_data`) stay listed regardless of scope. On large volumes, scope also speeds up the listing by skipping out-of-scope directories during the scan.
+
 ### Using as CLI
 
 All MCP tools are also available as CLI commands — no MCP server needed:
@@ -223,6 +225,7 @@ npx mcp-local-rag query "authentication API"    # Search documents
 npx mcp-local-rag query "auth" --scope /docs/api --scope /docs/guide  # Restrict to path prefixes (repeatable)
 npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5  # Expand context
 npx mcp-local-rag list                          # Show ingestion status
+npx mcp-local-rag list --scope /docs/api --scope /docs/guide  # Restrict listing to path prefixes (repeatable)
 npx mcp-local-rag status                        # Database stats
 npx mcp-local-rag delete ./docs/old.pdf         # Remove content
 npx mcp-local-rag delete --source "https://..."  # Remove by source URL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.15.4",
+  "version": "0.16.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.15.4",
+      "version": "0.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -59,8 +59,6 @@ Use `scope` when one database mixes multiple corpora and you want results from o
 
 Prefixes must be absolute, in the server's OS path style — relative prefixes match nothing. If the user gives a relative path, derive an absolute prefix from a `filePath` in an earlier `query_documents`/`list_files` result, or omit `scope` when no absolute prefix is known.
 
-`list_files` (CLI `list --scope`) takes the same `scope` (one absolute prefix or a list, same exact-or-descendant boundary), matched on each file's reachable scan path under the base directories. Raw-data sources (from `ingest_data`) stay listed regardless of scope.
-
 ### Query Formulation
 
 | Situation | Why Transform | Action |

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -13,7 +13,7 @@ description: Search, ingest, expand chunk context, or manage local documents via
 | `ingest_data` | — | Raw content (HTML, text) with source URL |
 | `query_documents` | `npx mcp-local-rag query <text>` | Semantic + keyword hybrid search; optional `scope` to limit to a path prefix |
 | `delete_file` | `npx mcp-local-rag delete <path>` | Remove ingested content |
-| `list_files` | `npx mcp-local-rag list` | File ingestion status |
+| `list_files` | `npx mcp-local-rag list [--scope <prefix>]` | File ingestion status; optional `scope` to limit to a path prefix (reachable scan path) |
 | `status` | `npx mcp-local-rag status` | Database stats |
 | `read_chunk_neighbors` | `npx mcp-local-rag read-neighbors` | Read N chunks adjacent to a known chunkIndex (context expansion; call after `query_documents` or grep) |
 
@@ -58,6 +58,8 @@ Use `scope` when one database mixes multiple corpora and you want results from o
 | Several corpora | list of absolute prefixes |
 
 Prefixes must be absolute, in the server's OS path style — relative prefixes match nothing. If the user gives a relative path, derive an absolute prefix from a `filePath` in an earlier `query_documents`/`list_files` result, or omit `scope` when no absolute prefix is known.
+
+`list_files` (CLI `list --scope`) takes the same `scope` (one absolute prefix or a list, same exact-or-descendant boundary), matched on each file's reachable scan path under the base directories. Raw-data sources (from `ingest_data`) stay listed regardless of scope.
 
 ### Query Formulation
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -73,12 +73,13 @@ Output: JSON array to stdout.
 ### list
 
 ```bash
-npx mcp-local-rag [global-options] list [--base-dir <path>]...
+npx mcp-local-rag [global-options] list [--base-dir <path>]... [--scope <prefix>]...
 ```
 
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
 | `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Base directory to scan. Repeatable; CLI roots replace env roots. |
+| `--scope <prefix>` | — | — | Restrict the listing to files reachable at a path equal to or under an absolute prefix within the base directories (scan-path basis). Repeat for multiple prefixes (unioned). Boundary-safe: `/docs/api` matches `/docs/api/x.md`, not `/docs/apiv2`. Raw-data `sources` (from `ingest_data`) stay listed regardless of scope. |
 
 Output: JSON to stdout. The result includes `baseDirs: string[]` (all effective roots) plus a legacy `baseDir: string` (first effective root after normalization and nested-root pruning). Each file entry is annotated with the `baseDir` that produced it. Raw-data/orphaned entries remain under `sources` without a root annotation.
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -79,7 +79,7 @@ npx mcp-local-rag [global-options] list [--base-dir <path>]... [--scope <prefix>
 | Option | Env Var | Default | Description |
 |--------|---------|---------|-------------|
 | `--base-dir <path>` | `BASE_DIR` / `BASE_DIRS` | cwd | Base directory to scan. Repeatable; CLI roots replace env roots. |
-| `--scope <prefix>` | — | — | Restrict the listing to files reachable at a path equal to or under an absolute prefix within the base directories (scan-path basis). Repeat for multiple prefixes (unioned). Boundary-safe: `/docs/api` matches `/docs/api/x.md`, not `/docs/apiv2`. Raw-data `sources` (from `ingest_data`) stay listed regardless of scope. |
+| `--scope <prefix>` | — | — | Restrict the listing to files whose scan path is equal to or under an absolute prefix. Repeat for multiple prefixes (unioned). Relative prefixes match nothing. `ingest_data` `sources` are always listed regardless of scope. |
 
 Output: JSON to stdout. The result includes `baseDirs: string[]` (all effective roots) plus a legacy `baseDir: string` (first effective root after normalization and nested-root pruning). Each file entry is annotated with the `baseDir` that produced it. Raw-data/orphaned entries remain under `sources` without a root annotation.
 

--- a/src/__tests__/cli/list-scope-absolute-warning.int.test.ts
+++ b/src/__tests__/cli/list-scope-absolute-warning.int.test.ts
@@ -1,0 +1,126 @@
+// `runList(--scope)` non-absolute-prefix warning (code-review finding #2).
+//
+// AC: The `list` help documents that `--scope` must be absolute and a relative
+//     prefix matches nothing. This test pins the CLI UX signal: a non-absolute
+//     `--scope` prints a non-fatal stderr warning while STILL exiting 0 with a
+//     (correctly empty for that prefix) result — relative is unhelpful, not an
+//     error. Absolute `--scope` prints no such warning and returns its results.
+// Behavior: `runList(['--scope', <relative>])` over a real LanceDB + real-FS
+//     fixture (uningested scan, no embedder) → non-absolute prefix filtered by
+//     `nonAbsolutePrefixes` and printed as a `Warning [scope]:` stderr line,
+//     process exits 0, stdout result stays empty for that prefix; absolute
+//     `--scope` emits no such warning and returns its scanned files[].
+// ROI: 80
+// @category: integration
+// @lane: integration
+// @dependency: CLI runList + real LanceDB + real-FS fixture (no embedder)
+// @complexity: low (no mocks; real dbPath/cacheDir + uningested scan fixture)
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { runList } from '../../cli/list.js'
+
+const NON_ABSOLUTE_WARNING = /Warning \[scope\]: "([^"]+)" is not an absolute path/
+
+function warnedPrefixes(stderr: string[]): string[] {
+  const prefixes: string[] = []
+  for (const line of stderr) {
+    const match = NON_ABSOLUTE_WARNING.exec(line)
+    if (match?.[1] !== undefined) prefixes.push(match[1])
+  }
+  return prefixes
+}
+
+/**
+ * Run `runList` capturing stdout writes and stderr, with `process.exit` mocked
+ * to throw so a non-zero exit surfaces as a caught error rather than killing the
+ * test runner.
+ */
+function captureRunList(args: string[], globalOptions: Record<string, unknown>) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      stdout.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk))
+      return true
+    })
+  const stderrSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    stderr.push(a.map(String).join(' '))
+  })
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`)
+  })
+  return (runList as (a: string[], g?: unknown) => Promise<void>)(args, globalOptions)
+    .then(() => ({ stdout, stderr, error: undefined as unknown }))
+    .catch((error: unknown) => ({ stdout, stderr, error }))
+    .finally(() => {
+      stdoutSpy.mockRestore()
+      stderrSpy.mockRestore()
+      exitSpy.mockRestore()
+    })
+}
+
+describe('runList(--scope) — non-absolute prefix warning (finding #2)', () => {
+  const base = resolve('./tmp/test-cli-list-nonabs-warning')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+  const inScopeFile = join(dataDir, 'keep.txt')
+  const globalOptions = { dbPath, cacheDir, modelName: 'Xenova/all-MiniLM-L6-v2' }
+
+  beforeAll(() => {
+    mkdirSync(dataDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(inScopeFile, 'A scannable file. '.repeat(20))
+  })
+
+  afterAll(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('warns on stderr for a relative --scope but still exits 0 with an empty result', async () => {
+    const { stdout, stderr, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', 'relative'],
+      globalOptions
+    )
+
+    // No exit thrown → exit 0 (relative is unhelpful, not an error).
+    expect(error).toBeUndefined()
+    expect(warnedPrefixes(stderr)).toContain('relative')
+
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    expect(filePaths).not.toContain(inScopeFile)
+  })
+
+  it('emits no non-absolute warning for an absolute --scope and returns its results', async () => {
+    const { stdout, stderr, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', dataDir],
+      globalOptions
+    )
+
+    expect(error).toBeUndefined()
+    expect(warnedPrefixes(stderr)).toEqual([])
+
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    expect(filePaths).toContain(inScopeFile)
+  })
+
+  it('warns only for the relative prefix in a mixed --scope and keeps absolute results', async () => {
+    const { stdout, stderr, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', dataDir, '--scope', 'relative'],
+      globalOptions
+    )
+
+    expect(error).toBeUndefined()
+    expect(warnedPrefixes(stderr)).toEqual(['relative'])
+
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    expect(filePaths).toContain(inScopeFile)
+  })
+})

--- a/src/__tests__/cli/list-scope.int.test.ts
+++ b/src/__tests__/cli/list-scope.int.test.ts
@@ -1,0 +1,436 @@
+// INT-3: `runList(--scope)` CLI integration (Phase 3 Task 2).
+//
+// AC: AC2 (repeatable `--scope` parsed + documented in HELP_TEXT) / AC3 (files
+//     restricted exact-or-descendant on the scan path + symlink-alias contract) /
+//     AC6 (raw-data sources always kept; real-file entries scope-filtered from
+//     both files[] and sources[]) / AC9 (empty/whitespace/malformed `--scope`
+//     rejected with a non-zero exit and a clear stderr message).
+// Behavior: `runList(['--base-dir', dataDir, '--scope', inScopeDir], global)` over
+//     a real LanceDB + real-FS fixture → BFS pushdown prunes scope-outside
+//     subtrees → scoped stdout files[], raw-data sources retained, out-of-scope
+//     real-file ingested entry excluded from files[] AND sources[], no
+//     scope-outside SCANNED path reaches realpathForMatch, symlink-alias entry
+//     included with its stored filePath spelling; empty/whitespace/missing
+//     `--scope` exits non-zero with a stderr message and config resolution still
+//     fires even when scope is present.
+// @category: integration
+// @lane: integration
+// @dependency: CLI runList + real LanceDB + real-FS fixture (mkdir/symlink) + RAGServer (fixture ingest) + realpathForMatch spy
+// @complexity: high (real embed/DB ingest, scan-path pushdown spy, symlink-alias fixture)
+// ROI: 72
+//
+// Mocking strategy (shared-registry safe per project-context: isolate:false,
+// pool forks, maxWorkers 1): `../../utils/scan.js` is partial-mocked via
+// vi.doMock so `realpathForMatch` RECORDS its argument then DELEGATES to the
+// real implementation; `runList` (and the fixture-ingesting RAGServer) are
+// dynamically imported AFTER doMock and the mock is removed via doUnmock +
+// resetModules in afterAll. Only the CLI SCANNED call site (list.ts:268) is
+// asserted: the probe path is an UNINGESTED out-of-scope file, so it can reach
+// realpathForMatch solely through the scanned loop — the unchanged ingested-side
+// loop (list.ts:253) never sees it, so it cannot confound the proof. DB and FS
+// are otherwise real; runList itself needs no embedder (VectorStore only).
+
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
+
+// Records every path passed to the (spied) realpathForMatch, in call order.
+const realpathCalls: string[] = []
+
+// Directory symlinks require admin/developer mode on windows-latest (in the CI
+// matrix); probe support once so the alias contract describe is skipped there
+// rather than failing the job on an environment limitation.
+function directorySymlinkSupported(): boolean {
+  const probeBase = mkdtempSync(join(tmpdir(), 'cli-list-scope-symlink-probe-'))
+  try {
+    const target = join(probeBase, 'target')
+    mkdirSync(target)
+    symlinkSync(target, join(probeBase, 'link'), 'dir')
+    return true
+  } catch {
+    return false
+  } finally {
+    rmSync(probeBase, { recursive: true, force: true })
+  }
+}
+
+let runList: typeof import('../../cli/list.js').runList
+let RAGServer: typeof import('../../server/index.js').RAGServer
+
+async function installScanSpyAndImportModules(): Promise<void> {
+  vi.doMock('../../utils/scan.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/scan.js')>()
+    return {
+      ...actual,
+      realpathForMatch: vi.fn(async (filePath: string) => {
+        realpathCalls.push(filePath)
+        return actual.realpathForMatch(filePath)
+      }),
+    }
+  })
+  vi.resetModules()
+  ;({ runList } = await import('../../cli/list.js'))
+  ;({ RAGServer } = await import('../../server/index.js'))
+}
+
+/**
+ * Run `runList` capturing stdout writes and stderr, with `process.exit` mocked
+ * to throw so a non-zero exit surfaces as a caught error rather than killing the
+ * test runner.
+ */
+function captureRunList(args: string[], globalOptions: Record<string, unknown>) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      stdout.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk))
+      return true
+    })
+  const stderrSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+    stderr.push(a.map(String).join(' '))
+  })
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`)
+  })
+  return (runList as (a: string[], g?: unknown) => Promise<void>)(args, globalOptions)
+    .then(() => ({ stdout, stderr, error: undefined as unknown }))
+    .catch((error: unknown) => ({ stdout, stderr, error }))
+    .finally(() => {
+      stdoutSpy.mockRestore()
+      stderrSpy.mockRestore()
+      exitSpy.mockRestore()
+    })
+}
+
+describe('INT-3: runList(--scope) — scoped files, sources split, pushdown proof', () => {
+  const base = resolve('./tmp/test-cli-list-scope-int')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+
+  const inScopeDir = join(dataDir, 'in-scope')
+  const inScopeFile = join(inScopeDir, 'keep.txt')
+  // In-scope but NOT ingested: reachable only via the scanned-file loop, so it
+  // is the airtight non-vacuousness probe for the realpathForMatch spy (an
+  // ingested file would also be realpath'd by the ingested-side loop).
+  const inScopeUningested = join(inScopeDir, 'scanned-only.txt')
+  const deepDir = join(inScopeDir, 'deep')
+  const deepFile = join(deepDir, 'deep-keep.txt')
+
+  const outScopeDir = join(dataDir, 'out-scope')
+  const outScopeUningested = join(outScopeDir, 'uningested.txt')
+  const outScopeIngested = join(outScopeDir, 'ingested-out.txt')
+
+  const secondScopeDir = join(dataDir, 'second-scope')
+  const secondScopeFile = join(secondScopeDir, 'second-keep.txt')
+
+  const rawSource = 'https://example.com/int3-raw-source'
+
+  const globalOptions = { dbPath, cacheDir, modelName: 'Xenova/all-MiniLM-L6-v2' }
+
+  let server: InstanceType<typeof import('../../server/index.js').RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(inScopeDir, { recursive: true })
+    mkdirSync(deepDir, { recursive: true })
+    mkdirSync(outScopeDir, { recursive: true })
+    mkdirSync(secondScopeDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+
+    writeFileSync(inScopeFile, 'In-scope file content. '.repeat(20))
+    writeFileSync(inScopeUningested, 'In-scope UNINGESTED file. '.repeat(20))
+    writeFileSync(deepFile, 'Deep in-scope file content. '.repeat(20))
+    writeFileSync(outScopeUningested, 'Out-of-scope UNINGESTED file. '.repeat(20))
+    writeFileSync(outScopeIngested, 'Out-of-scope ingested file. '.repeat(20))
+    writeFileSync(secondScopeFile, 'Second-scope file content. '.repeat(20))
+
+    await installScanSpyAndImportModules()
+
+    // Ingest the fixture via a real RAGServer (real embed + LanceDB). runList
+    // then reads the same dbPath; listing needs no embedder.
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        baseDir: dataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+
+    await server.handleIngestFile({ filePath: inScopeFile })
+    await server.handleIngestFile({ filePath: deepFile })
+    await server.handleIngestFile({ filePath: secondScopeFile })
+    await server.handleIngestFile({ filePath: outScopeIngested })
+    await server.handleIngestData({
+      content:
+        'Raw-data content ingested via ingest_data for the INT-3 CLI scope test. ' +
+        'Long enough to produce at least one chunk in the vector store.',
+      metadata: { source: rawSource, format: 'text' },
+    })
+  }, 120000)
+
+  afterAll(async () => {
+    if (server) await server.close()
+    vi.doUnmock('../../utils/scan.js')
+    vi.resetModules()
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('restricts stdout files[] to the in-scope subtree (out-of-scope files excluded)', async () => {
+    const { stdout, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', inScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    expect(filePaths).toContain(inScopeFile)
+    expect(filePaths).toContain(deepFile)
+    expect(filePaths).toContain(inScopeUningested)
+    expect(filePaths).not.toContain(outScopeUningested)
+    expect(filePaths).not.toContain(outScopeIngested)
+    expect(filePaths).not.toContain(secondScopeFile)
+
+    // Config resolution still fires with scope present (missing-config proof).
+    // rawBaseDirs carry a trailing separator (base-dirs normal-path form), so
+    // assert the resolved root without coupling to that exact spelling.
+    expect(parsed.baseDirs).toHaveLength(1)
+    expect(parsed.baseDir).toBe(parsed.baseDirs[0])
+    expect(parsed.baseDir.startsWith(dataDir)).toBe(true)
+  })
+
+  it('unions results across repeated --scope flags', async () => {
+    const { stdout, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', inScopeDir, '--scope', secondScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    expect(filePaths).toContain(inScopeFile)
+    expect(filePaths).toContain(secondScopeFile)
+    expect(filePaths).not.toContain(outScopeUningested)
+    expect(filePaths).not.toContain(outScopeIngested)
+  })
+
+  it('keeps raw-data sources regardless of scope', async () => {
+    const { stdout, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', inScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+
+    const sourceEntry = parsed.sources.find((s: { source?: string }) => s.source === rawSource)
+    expect(sourceEntry).toBeDefined()
+  })
+
+  it('excludes an out-of-scope real-file ingested entry from BOTH files[] and sources[] (AC6 negative)', async () => {
+    const { stdout, error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', inScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    const sourcePaths: string[] = parsed.sources.map((s: { filePath?: string }) => s.filePath)
+
+    expect(filePaths).not.toContain(outScopeIngested)
+    expect(sourcePaths).not.toContain(outScopeIngested)
+  })
+
+  it('lists every file when no --scope is given (scope-absent no-op)', async () => {
+    const { stdout, error } = await captureRunList(['--base-dir', dataDir], globalOptions)
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    expect(filePaths).toContain(inScopeFile)
+    expect(filePaths).toContain(deepFile)
+    expect(filePaths).toContain(outScopeUningested)
+    expect(filePaths).toContain(outScopeIngested)
+
+    const sourceEntry = parsed.sources.find((s: { source?: string }) => s.source === rawSource)
+    expect(sourceEntry).toBeDefined()
+  })
+
+  it('never routes a scope-outside SCANNED path through realpathForMatch (CLI-side pushdown proof, AC4)', async () => {
+    realpathCalls.length = 0
+    const { error } = await captureRunList(
+      ['--base-dir', dataDir, '--scope', inScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+
+    // The uningested out-of-scope file can only reach realpathForMatch via the
+    // scanned loop (list.ts:268). Under correct pushdown the walker prunes
+    // out-scope, so its path is never a call argument.
+    expect(realpathCalls).not.toContain(outScopeUningested)
+
+    // Non-vacuousness: the scanned loop DID run realpathForMatch over an
+    // in-scope file that is reachable ONLY via the scan (uningested, so the
+    // ingested-side loop never touches it) — proving the assertion above is not
+    // vacuously satisfied by a walker that produced nothing.
+    expect(realpathCalls).toContain(inScopeUningested)
+  })
+
+  it('documents --scope in the help text', async () => {
+    const { stderr, error } = await captureRunList(['--help'], globalOptions)
+    expect((error as Error).message).toBe('process.exit(0)')
+    const joined = stderr.join('\n')
+    expect(joined).toContain('--scope')
+  })
+})
+
+// AC9: empty / whitespace / missing --scope rejected, plus config resolution
+// still fires when scope is present. These cases exit before any DB access, so
+// they need no fixture — a valid dbPath/cacheDir keeps resolveGlobalConfig happy.
+describe('INT-3: runList(--scope) — validation and config-resolution ordering (AC9)', () => {
+  const base = resolve('./tmp/test-cli-list-scope-validate')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+  const globalOptions = { dbPath, cacheDir, modelName: 'Xenova/all-MiniLM-L6-v2' }
+
+  let localRunList: typeof import('../../cli/list.js').runList
+  let stderr: string[]
+
+  beforeAll(async () => {
+    mkdirSync(dataDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    vi.resetModules()
+    ;({ runList: localRunList } = await import('../../cli/list.js'))
+  })
+
+  afterAll(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  beforeEach(() => {
+    stderr = []
+    vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+      stderr.push(a.map(String).join(' '))
+    })
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('rejects an empty --scope value with a non-zero exit and a clear stderr message', async () => {
+    await expect(
+      localRunList(['--base-dir', dataDir, '--scope', ''], globalOptions)
+    ).rejects.toThrow('process.exit(1)')
+    expect(stderr.join('\n')).toContain('--scope')
+  })
+
+  it('rejects a whitespace-only --scope value with a non-zero exit', async () => {
+    await expect(
+      localRunList(['--base-dir', dataDir, '--scope', '   '], globalOptions)
+    ).rejects.toThrow('process.exit(1)')
+    expect(stderr.join('\n')).toContain('--scope')
+  })
+
+  it('rejects a --scope flag with a missing value (next token is a flag)', async () => {
+    await expect(
+      localRunList(['--base-dir', dataDir, '--scope', '--help'], globalOptions)
+    ).rejects.toThrow('process.exit(1)')
+    expect(stderr.join('\n')).toContain('Missing value for --scope')
+  })
+
+  it('still resolves base dirs (config) even when --scope is present — nonexistent root exits non-zero', async () => {
+    const missingRoot = join(base, 'does-not-exist')
+    await expect(
+      localRunList(['--base-dir', missingRoot, '--scope', join(missingRoot, 'sub')], globalOptions)
+    ).rejects.toThrow('process.exit(1)')
+    // The error came from config resolution, proving scope parsing did not
+    // bypass resolveCliBaseDirsOrExit.
+    expect(stderr.length).toBeGreaterThan(0)
+  })
+})
+
+// AC3 path-basis / symlink-alias contract: under an aliased (dir-symlinked)
+// baseDir, an ingested file whose SCAN path is under scope but whose stored
+// filePath uses a different (real) spelling is included, and the returned
+// filePath keeps its stored spelling.
+const describeAlias = directorySymlinkSupported() ? describe : describe.skip
+
+describeAlias('INT-3: runList(--scope) — symlink-alias contract (AC3)', () => {
+  const base = resolve('./tmp/test-cli-list-scope-alias')
+  const realRoot = join(base, 'real')
+  const aliasRoot = join(base, 'alias')
+  const realSubDir = join(realRoot, 'sub')
+  const realFile = join(realSubDir, 'aliased.txt')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+  const globalOptions = { dbPath, cacheDir, modelName: 'Xenova/all-MiniLM-L6-v2' }
+
+  let server: InstanceType<typeof import('../../server/index.js').RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(realSubDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(realFile, 'Aliased file content. '.repeat(20))
+
+    // Symlink support was confirmed by `directorySymlinkSupported` before this
+    // describe was selected, so the dir symlink creation here is expected to
+    // succeed.
+    symlinkSync(realRoot, aliasRoot, 'dir')
+
+    await installScanSpyAndImportModules()
+
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        baseDir: aliasRoot,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+
+    // Ingest via the REAL spelling so the stored filePath differs from the scan
+    // path; realpath containment permits it.
+    await server.handleIngestFile({ filePath: realFile })
+  }, 120000)
+
+  afterAll(async () => {
+    if (server) await server.close()
+    vi.doUnmock('../../utils/scan.js')
+    vi.resetModules()
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('includes an aliased ingested file (scan path under scope) with its stored filePath spelling', async () => {
+    const aliasScopeDir = join(aliasRoot, 'sub')
+    const { stdout, error } = await captureRunList(
+      ['--base-dir', aliasRoot, '--scope', aliasScopeDir],
+      globalOptions
+    )
+    expect(error).toBeUndefined()
+    const parsed = JSON.parse(stdout.join(''))
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    // Stored (real) spelling is returned, not the alias scan spelling.
+    expect(filePaths).toContain(realFile)
+    expect(filePaths).not.toContain(join(aliasScopeDir, 'aliased.txt'))
+
+    const entry = parsed.files.find((f: { filePath: string }) => f.filePath === realFile)
+    expect(entry.ingested).toBe(true)
+  })
+})

--- a/src/__tests__/e2e/list-scope.service.e2e.test.ts
+++ b/src/__tests__/e2e/list-scope.service.e2e.test.ts
@@ -1,0 +1,214 @@
+// E2E-1: `list --scope` service-integration E2E (Final Phase).
+//
+// AC: AC2 (CLI `list` accepts repeatable `--scope`) / AC3 (files[] restricted
+//     exact-or-descendant on the scan path) / AC6 (raw-data sources always
+//     emitted; a real-file ingested entry outside scope appears in neither
+//     files[] nor sources[]).
+// Behavior: spawn the ACTUAL CLI (`mcp-local-rag list --scope <dir>`) as a real
+//     child OS process against a real-FS + real-LanceDB fixture → the full
+//     traversal-pushdown stack runs in a fresh process → stdout JSON files[]
+//     lists only under-scope files and sources[] retains the raw-data source
+//     while excluding the out-of-scope ingested real file.
+// @category: service-integration-e2e
+// @lane: service-integration-e2e
+// @dependency: full CLI process (src/index.ts via tsx) + real LanceDB + real-FS
+//     fixture + RAGServer (fixture ingest, real embed) + shared pre-warmed model cache
+// @complexity: high (real child process spawn, real embed/DB ingest, full stack)
+// ROI: 84
+//
+// This E2E asserts BEHAVIORAL CORRECTNESS only: the spawn timeout is a perf
+// property (issue #165) and is NOT asserted here. The layered pushdown PROOFS
+// (readdir EACCES mock/spy + realpathForMatch spy) live in the integration lane
+// (INT-1/INT-2/INT-3); this E2E confirms the assembled CLI produces the scoped
+// result through a real process.
+//
+// Spawn convention: `process.execPath --import tsx src/index.ts ...`, mirroring
+// `src/__tests__/cli/entry-routing.test.ts` (the repo's spawned-CLI-in-default-
+// suite pattern). No `dist` build step is required, so the test is deterministic
+// under a plain `pnpm test`. The fixture is ingested in-process via RAGServer
+// (real embedder + LanceDB), then the server is closed before spawning so the
+// child `list` opens the persisted DB cleanly; `list` needs no embedder.
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RAGServer } from '../../server/index.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const PROJECT_ROOT = resolve(__dirname, '../../..')
+const ENTRY = resolve(PROJECT_ROOT, 'src/index.ts')
+
+// Cold tsx start + native LanceDB load in a fresh process: keep the ceiling
+// generous. The listing itself (VectorStore only, no embed) is fast.
+const SPAWN_TIMEOUT_MS = 60_000
+
+interface CliRun {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+function runListCli(globalAndListArgs: string[]): CliRun {
+  const result = spawnSync(process.execPath, ['--import', 'tsx', ENTRY, ...globalAndListArgs], {
+    encoding: 'utf-8',
+    cwd: PROJECT_ROOT,
+    timeout: SPAWN_TIMEOUT_MS,
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+interface ParsedListResult {
+  files: Array<{ filePath: string }>
+  sources: Array<{ source?: string; filePath?: string }>
+}
+
+/**
+ * Assert the spawned CLI exited 0 and parse its stdout JSON. On a non-zero exit
+ * or non-JSON stdout, surface the captured stderr (and stdout) so a CI failure
+ * is debuggable instead of an opaque JSON.parse error.
+ */
+function parseSuccessfulListOutput(run: CliRun): ParsedListResult {
+  expect(run.status, `CLI exited with ${run.status}; stderr:\n${run.stderr}`).toBe(0)
+  try {
+    return JSON.parse(run.stdout) as ParsedListResult
+  } catch (error) {
+    throw new Error(
+      `CLI stdout was not valid JSON (${(error as Error).message}).\n` +
+        `--- stdout ---\n${run.stdout}\n--- stderr ---\n${run.stderr}`
+    )
+  }
+}
+
+describe('E2E-1: spawned CLI `list --scope` — scoped files[], raw-data sources retained', () => {
+  const base = resolve('./tmp/e2e-list-scope')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+
+  const inScopeDir = join(dataDir, 'in-scope')
+  const inScopeFile = join(inScopeDir, 'keep.txt')
+  const deepDir = join(inScopeDir, 'deep')
+  const deepFile = join(deepDir, 'deep-keep.txt')
+
+  const outScopeDir = join(dataDir, 'out-scope')
+  const outScopeIngested = join(outScopeDir, 'ingested-out.txt')
+
+  const secondScopeDir = join(dataDir, 'second-scope')
+  const secondScopeFile = join(secondScopeDir, 'second-keep.txt')
+
+  const rawSource = 'https://example.com/list-scope-e2e-raw'
+
+  let server: InstanceType<typeof RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(deepDir, { recursive: true })
+    mkdirSync(outScopeDir, { recursive: true })
+    mkdirSync(secondScopeDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+
+    writeFileSync(inScopeFile, 'In-scope file content for the list-scope E2E. '.repeat(20))
+    writeFileSync(deepFile, 'Deep in-scope file content for the list-scope E2E. '.repeat(20))
+    writeFileSync(outScopeIngested, 'Out-of-scope ingested file content. '.repeat(20))
+    writeFileSync(secondScopeFile, 'Second-scope file content for the union case. '.repeat(20))
+
+    // Ingest the fixture in-process (real embedder + real LanceDB). The spawned
+    // `list` later reads this same persisted dbPath; listing needs no embedder.
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        baseDir: dataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+
+    await server.handleIngestFile({ filePath: inScopeFile })
+    await server.handleIngestFile({ filePath: deepFile })
+    await server.handleIngestFile({ filePath: outScopeIngested })
+    await server.handleIngestData({
+      content:
+        'Raw-data content ingested via ingest_data for the list-scope E2E. ' +
+        'Long enough to produce at least one chunk in the vector store.',
+      metadata: { source: rawSource, format: 'text' },
+    })
+
+    // Release DB handles before spawning so the child process opens cleanly.
+    await server.close()
+  }, 120_000)
+
+  afterAll(() => {
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it(
+    'restricts stdout files[] to the in-scope subtree and retains raw-data sources',
+    () => {
+      const run = runListCli([
+        '--db-path',
+        dbPath,
+        '--cache-dir',
+        cacheDir,
+        'list',
+        '--base-dir',
+        dataDir,
+        '--scope',
+        inScopeDir,
+      ])
+
+      const parsed = parseSuccessfulListOutput(run)
+      const filePaths = parsed.files.map((f) => f.filePath)
+      const sourcePaths = parsed.sources.map((s) => s.filePath)
+
+      // AC3: only under-scope files are listed (exact-or-descendant on scan path).
+      expect(filePaths).toContain(inScopeFile)
+      expect(filePaths).toContain(deepFile)
+      expect(filePaths).not.toContain(outScopeIngested)
+      expect(filePaths).not.toContain(secondScopeFile)
+
+      // AC6: raw-data source retained regardless of scope; the out-of-scope
+      // ingested real file appears in NEITHER files[] NOR sources[].
+      const rawEntry = parsed.sources.find((s: { source?: string }) => s.source === rawSource)
+      expect(rawEntry).toBeDefined()
+      expect(sourcePaths).not.toContain(outScopeIngested)
+    },
+    SPAWN_TIMEOUT_MS
+  )
+
+  it(
+    'unions results across repeated --scope flags',
+    () => {
+      const run = runListCli([
+        '--db-path',
+        dbPath,
+        '--cache-dir',
+        cacheDir,
+        'list',
+        '--base-dir',
+        dataDir,
+        '--scope',
+        inScopeDir,
+        '--scope',
+        secondScopeDir,
+      ])
+
+      const parsed = parseSuccessfulListOutput(run)
+      const filePaths = parsed.files.map((f) => f.filePath)
+
+      expect(filePaths).toContain(inScopeFile)
+      expect(filePaths).toContain(secondScopeFile)
+      expect(filePaths).not.toContain(outScopeIngested)
+    },
+    SPAWN_TIMEOUT_MS
+  )
+})

--- a/src/__tests__/server/list-files-scope-absolute-warning.int.test.ts
+++ b/src/__tests__/server/list-files-scope-absolute-warning.int.test.ts
@@ -1,0 +1,102 @@
+// handleListFiles(scope) non-absolute-prefix warning (code-review finding #2).
+//
+// AC: The tool schema documents that a scope prefix must be absolute and a
+//     relative prefix matches nothing. This test pins the UX signal: a
+//     non-absolute prefix yields a non-fatal warning content block while the
+//     result semantics stay exactly "matches nothing" (behavior-additive, no
+//     rejection); absolute prefixes produce no such block and still return
+//     their scoped files[].
+// Behavior: `handleListFiles({ scope })` over a real LanceDB + real-FS fixture
+//     (uningested files only — no embedding needed) → warning block naming each
+//     non-absolute prefix; absolute prefixes produce no such block and still
+//     return their scoped files[].
+// ROI: 80
+// @category: integration
+// @lane: integration
+// @dependency: RAGServer handler + real LanceDB + real-FS fixture (no embedder)
+// @complexity: low (no mocks; construct RAGServer, scan uningested fixture)
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { RagContentBlock } from '../../server/error-utils.js'
+import { RAGServer } from '../../server/index.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
+
+const NON_ABSOLUTE_WARNING = /Warning: scope prefix "([^"]+)" is not absolute/
+
+function warningPrefixes(content: RagContentBlock[]): string[] {
+  const prefixes: string[] = []
+  for (const block of content) {
+    if (block.type === 'text') {
+      const match = NON_ABSOLUTE_WARNING.exec(block.text)
+      if (match?.[1] !== undefined) prefixes.push(match[1])
+    }
+  }
+  return prefixes
+}
+
+function parsedFiles(content: RagContentBlock[]): string[] {
+  const first = content[0]
+  if (first === undefined || first.type !== 'text') {
+    throw new Error('expected a leading JSON text block')
+  }
+  const parsed = JSON.parse(first.text) as { files: { filePath: string }[] }
+  return parsed.files.map((f) => f.filePath)
+}
+
+describe('handleListFiles(scope) — non-absolute prefix warning (finding #2)', () => {
+  const base = resolve('./tmp/test-list-files-nonabs-warning')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+  const inScopeFile = join(dataDir, 'keep.txt')
+
+  let server: InstanceType<typeof RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(dataDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(inScopeFile, 'A scannable file. '.repeat(20))
+
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        baseDir: dataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+  }, 120000)
+
+  afterAll(async () => {
+    if (server) await server.close()
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('appends a warning block naming a non-absolute scope prefix (result stays empty)', async () => {
+    const { content } = await server.handleListFiles({ scope: ['relative'] })
+
+    expect(warningPrefixes(content)).toContain('relative')
+    // Semantics unchanged: a non-absolute prefix still matches nothing.
+    expect(parsedFiles(content)).toEqual([])
+  })
+
+  it('emits no non-absolute warning for an absolute scope prefix', async () => {
+    const { content } = await server.handleListFiles({ scope: [dataDir] })
+
+    expect(warningPrefixes(content)).toEqual([])
+    // The absolute scope still returns its scanned file.
+    expect(parsedFiles(content)).toContain(inScopeFile)
+  })
+
+  it('warns only for the relative prefix in a mixed scope and keeps absolute results', async () => {
+    const { content } = await server.handleListFiles({ scope: [dataDir, 'relative'] })
+
+    expect(warningPrefixes(content)).toEqual(['relative'])
+    expect(parsedFiles(content)).toContain(inScopeFile)
+  })
+})

--- a/src/__tests__/server/list-files-scope.int.test.ts
+++ b/src/__tests__/server/list-files-scope.int.test.ts
@@ -1,0 +1,272 @@
+// INT-1: `handleListFiles(scope)` MCP-handler integration (Phase 2 Task 2).
+//
+// AC: AC3 (scan-path basis + alias contract) / AC4 (handler-side pushdown:
+//     scanned-file realpathForMatch runs only over the pruned in-scope result) /
+//     AC6 (raw-data sources always kept; real-file entries scope-filtered from
+//     both files[] and sources[]) / AC12 (no-arg accepted as no-scope).
+// Behavior: `handleListFiles({ scope })` over a real LanceDB + real-FS fixture
+//     → BFS pushdown prunes scope-outside subtrees → scoped files[], raw-data
+//     sources retained, out-of-scope real-file orphan excluded, no scope-outside
+//     SCANNED path reaches realpathForMatch, symlink-alias entry included with
+//     its stored filePath spelling.
+// @category: integration
+// @lane: integration
+// @dependency: RAGServer handler + real LanceDB + real-FS fixture (mkdir/symlink) + realpathForMatch spy
+// @complexity: high (real embed/DB init, scan-path pushdown spy, symlink-alias fixture)
+// ROI: 96
+//
+// Mocking strategy (shared-registry safe per project-context: isolate:false,
+// pool forks, maxWorkers 1): `../../utils/scan.js` is partial-mocked via
+// vi.doMock so `realpathForMatch` RECORDS its argument then DELEGATES to the
+// real implementation; RAGServer is dynamically imported AFTER doMock and the
+// mock is removed via doUnmock + resetModules in afterAll. Only the SCANNED
+// call site (index.ts:668) is asserted: the probe path is an UNINGESTED
+// out-of-scope file, so it can reach realpathForMatch solely through the
+// scanned loop — the unchanged ingested-side loop (index.ts:647) never sees it,
+// so it cannot confound the proof. DB and FS are otherwise real.
+
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
+
+// Records every path passed to the (spied) realpathForMatch, in call order.
+const realpathCalls: string[] = []
+
+// Directory symlinks require admin/developer mode on windows-latest (in the CI
+// matrix); probe support once so the alias contract describe is skipped there
+// rather than failing the job on an environment limitation.
+function directorySymlinkSupported(): boolean {
+  const probeBase = mkdtempSync(join(tmpdir(), 'list-scope-symlink-probe-'))
+  try {
+    const target = join(probeBase, 'target')
+    mkdirSync(target)
+    symlinkSync(target, join(probeBase, 'link'), 'dir')
+    return true
+  } catch {
+    return false
+  } finally {
+    rmSync(probeBase, { recursive: true, force: true })
+  }
+}
+
+let RAGServer: typeof import('../../server/index.js').RAGServer
+
+async function installScanSpyAndImportServer(): Promise<void> {
+  vi.doMock('../../utils/scan.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/scan.js')>()
+    return {
+      ...actual,
+      realpathForMatch: vi.fn(async (filePath: string) => {
+        realpathCalls.push(filePath)
+        return actual.realpathForMatch(filePath)
+      }),
+    }
+  })
+  vi.resetModules()
+  ;({ RAGServer } = await import('../../server/index.js'))
+}
+
+describe('INT-1: handleListFiles(scope) — scoped files, sources split, pushdown proof', () => {
+  const base = resolve('./tmp/test-list-files-scope-int')
+  const dataDir = join(base, 'data')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+
+  const inScopeDir = join(dataDir, 'in-scope')
+  const inScopeFile = join(inScopeDir, 'keep.txt')
+  // In-scope but NOT ingested: reachable only via the scanned-file loop, so it
+  // is the airtight non-vacuousness probe for the realpathForMatch spy (an
+  // ingested file would also be realpath'd by the ingested-side loop).
+  const inScopeUningested = join(inScopeDir, 'scanned-only.txt')
+  const deepDir = join(inScopeDir, 'deep')
+  const deepFile = join(deepDir, 'deep-keep.txt')
+
+  const outScopeDir = join(dataDir, 'out-scope')
+  const outScopeUningested = join(outScopeDir, 'uningested.txt')
+  const outScopeIngested = join(outScopeDir, 'ingested-out.txt')
+
+  const rawSource = 'https://example.com/int1-raw-source'
+
+  let server: InstanceType<typeof import('../../server/index.js').RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(inScopeDir, { recursive: true })
+    mkdirSync(deepDir, { recursive: true })
+    mkdirSync(outScopeDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+
+    writeFileSync(inScopeFile, 'In-scope file content. '.repeat(20))
+    writeFileSync(inScopeUningested, 'In-scope UNINGESTED file. '.repeat(20))
+    writeFileSync(deepFile, 'Deep in-scope file content. '.repeat(20))
+    writeFileSync(outScopeUningested, 'Out-of-scope UNINGESTED file. '.repeat(20))
+    writeFileSync(outScopeIngested, 'Out-of-scope ingested file. '.repeat(20))
+
+    await installScanSpyAndImportServer()
+
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        baseDir: dataDir,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+
+    // Ingest the two in-scope files and the out-of-scope real file, plus one
+    // raw-data source. `uningested.txt` is deliberately NOT ingested — it is the
+    // scanned-loop pushdown probe.
+    await server.handleIngestFile({ filePath: inScopeFile })
+    await server.handleIngestFile({ filePath: deepFile })
+    await server.handleIngestFile({ filePath: outScopeIngested })
+    await server.handleIngestData({
+      content:
+        'Raw-data content ingested via ingest_data for the INT-1 scope test. ' +
+        'Long enough to produce at least one chunk in the vector store.',
+      metadata: { source: rawSource, format: 'text' },
+    })
+  }, 120000)
+
+  afterAll(async () => {
+    await server.close()
+    vi.doUnmock('../../utils/scan.js')
+    vi.resetModules()
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('restricts files[] to the in-scope subtree (out-of-scope files excluded)', async () => {
+    const result = await server.handleListFiles({ scope: inScopeDir })
+    const parsed = JSON.parse(result.content[0].text)
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    expect(filePaths).toContain(inScopeFile)
+    expect(filePaths).toContain(deepFile)
+    expect(filePaths).not.toContain(outScopeUningested)
+    expect(filePaths).not.toContain(outScopeIngested)
+  })
+
+  it('keeps raw-data sources regardless of scope', async () => {
+    const result = await server.handleListFiles({ scope: inScopeDir })
+    const parsed = JSON.parse(result.content[0].text)
+
+    const sourceEntry = parsed.sources.find((s: { source?: string }) => s.source === rawSource)
+    expect(sourceEntry).toBeDefined()
+  })
+
+  it('excludes an out-of-scope real-file ingested entry from BOTH files[] and sources[] (AC6 negative)', async () => {
+    const result = await server.handleListFiles({ scope: inScopeDir })
+    const parsed = JSON.parse(result.content[0].text)
+
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    const sourcePaths: string[] = parsed.sources.map((s: { filePath?: string }) => s.filePath)
+
+    expect(filePaths).not.toContain(outScopeIngested)
+    expect(sourcePaths).not.toContain(outScopeIngested)
+  })
+
+  it('accepts a no-arg call as "no scope" and returns every file (AC12)', async () => {
+    const result = await server.handleListFiles()
+    const parsed = JSON.parse(result.content[0].text)
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+
+    expect(filePaths).toContain(inScopeFile)
+    expect(filePaths).toContain(deepFile)
+    expect(filePaths).toContain(outScopeUningested)
+    expect(filePaths).toContain(outScopeIngested)
+
+    // Raw-data source still present with no scope.
+    const sourceEntry = parsed.sources.find((s: { source?: string }) => s.source === rawSource)
+    expect(sourceEntry).toBeDefined()
+  })
+
+  it('never routes a scope-outside SCANNED path through realpathForMatch (handler-side pushdown proof, AC4)', async () => {
+    realpathCalls.length = 0
+    await server.handleListFiles({ scope: inScopeDir })
+
+    // The uningested out-of-scope file can only reach realpathForMatch via the
+    // scanned loop (index.ts:668). Under correct pushdown the walker prunes
+    // out-scope, so its path is never a call argument.
+    expect(realpathCalls).not.toContain(outScopeUningested)
+
+    // Non-vacuousness: the scanned loop DID run realpathForMatch over an
+    // in-scope file that is reachable ONLY via the scan (uningested, so the
+    // ingested-side loop never touches it) — proving the assertion above is not
+    // vacuously satisfied by a walker that simply produced nothing.
+    expect(realpathCalls).toContain(inScopeUningested)
+  })
+})
+
+// AC3 path-basis / symlink-alias contract: under an aliased (dir-symlinked)
+// baseDir, an ingested file whose SCAN path is under scope but whose stored
+// filePath uses a different (real) spelling is included, and the returned
+// filePath keeps its stored spelling (scope is guaranteed over the reachable
+// scan path, not the stored spelling).
+const describeAlias = directorySymlinkSupported() ? describe : describe.skip
+
+describeAlias('INT-1: handleListFiles(scope) — symlink-alias contract (AC3)', () => {
+  const base = resolve('./tmp/test-list-files-scope-alias')
+  const realRoot = join(base, 'real')
+  const aliasRoot = join(base, 'alias')
+  const realSubDir = join(realRoot, 'sub')
+  const realFile = join(realSubDir, 'aliased.txt')
+  const dbPath = join(base, 'lancedb')
+  const cacheDir = join(base, 'cache')
+
+  let server: InstanceType<typeof import('../../server/index.js').RAGServer>
+
+  beforeAll(async () => {
+    mkdirSync(realSubDir, { recursive: true })
+    mkdirSync(dbPath, { recursive: true })
+    mkdirSync(cacheDir, { recursive: true })
+    writeFileSync(realFile, 'Aliased file content. '.repeat(20))
+
+    // Symlink support was confirmed by `directorySymlinkSupported` before this
+    // describe was selected, so the dir symlink creation here is expected to
+    // succeed.
+    symlinkSync(realRoot, aliasRoot, 'dir')
+
+    await installScanSpyAndImportServer()
+
+    server = new RAGServer(
+      withTestDevice({
+        dbPath,
+        modelName: 'Xenova/all-MiniLM-L6-v2',
+        cacheDir: testModelCacheDir(cacheDir),
+        // Scan through the aliased (symlinked) root; the walker follows the root
+        // symlink so scanned paths use the alias spelling.
+        baseDir: aliasRoot,
+        maxFileSize: 100 * 1024 * 1024,
+      })
+    )
+    await server.initialize()
+
+    // Ingest via the REAL spelling so the stored filePath differs from the scan
+    // path; realpath containment (real path under realpath(aliasRoot)) permits it.
+    await server.handleIngestFile({ filePath: realFile })
+  }, 120000)
+
+  afterAll(async () => {
+    if (server) await server.close()
+    vi.doUnmock('../../utils/scan.js')
+    vi.resetModules()
+    rmSync(base, { recursive: true, force: true })
+  })
+
+  it('includes an aliased ingested file (scan path under scope) with its stored filePath spelling', async () => {
+    const aliasScopeDir = join(aliasRoot, 'sub')
+    const result = await server.handleListFiles({ scope: aliasScopeDir })
+    const parsed = JSON.parse(result.content[0].text)
+
+    const filePaths: string[] = parsed.files.map((f: { filePath: string }) => f.filePath)
+    // Stored (real) spelling is returned, not the alias scan spelling.
+    expect(filePaths).toContain(realFile)
+    expect(filePaths).not.toContain(join(aliasScopeDir, 'aliased.txt'))
+
+    const entry = parsed.files.find((f: { filePath: string }) => f.filePath === realFile)
+    expect(entry.ingested).toBe(true)
+  })
+})

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -6,6 +6,7 @@ import { displayPath } from '../utils/base-dirs.js'
 import { MAX_SCAN_DEPTH } from '../utils/limits.js'
 import { classifyIngestedSources } from '../utils/list-sources.js'
 import { bfsCollectSupportedFiles, realpathForMatch } from '../utils/scan.js'
+import { nonAbsolutePrefixes } from '../utils/scope-match.js'
 import { createVectorStore, formatCliError, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions } from './options.js'
 import {
@@ -137,7 +138,7 @@ List files and their ingestion status.
 
 Options:
   --base-dir <path>      Base directory to scan for files (repeatable: pass once per root; default: BASE_DIRS/BASE_DIR env or cwd)
-  --scope <prefix>       Restrict results to a path prefix (repeatable for multiple prefixes)
+  --scope <prefix>       Restrict results to a path prefix (must be absolute; a relative prefix matches nothing; repeatable for multiple prefixes)
   -h, --help             Show this help
 
 Global options (must appear before "list"):
@@ -255,6 +256,16 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     await resolveCliBaseDirsOrExit(cliBaseDirs)
   for (const warning of baseDirsWarnings) {
     console.error(warning.message)
+  }
+
+  // A non-absolute `--scope` prefix matches nothing (scan matching is
+  // absolute-path based) but silently yields an empty result for that prefix.
+  // Surface it as a non-fatal stderr warning without changing result semantics
+  // or the exit code — relative is unhelpful, not an error.
+  if (options.scope) {
+    for (const prefix of nonAbsolutePrefixes(options.scope)) {
+      console.error(`Warning [scope]: "${prefix}" is not an absolute path; it matches nothing.`)
+    }
   }
 
   // Scan/display the normal-path roots (`rawBaseDirs`) so scanned paths match

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -4,11 +4,16 @@ import { resolve, sep } from 'node:path'
 
 import { displayPath } from '../utils/base-dirs.js'
 import { MAX_SCAN_DEPTH } from '../utils/limits.js'
-import { extractSourceFromPath, looksLikeRawDataPath } from '../utils/raw-data-utils.js'
+import { classifyIngestedSources } from '../utils/list-sources.js'
 import { bfsCollectSupportedFiles, realpathForMatch } from '../utils/scan.js'
 import { createVectorStore, formatCliError, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions } from './options.js'
-import { consumeBaseDirArg, resolveGlobalConfig, validatePath } from './options.js'
+import {
+  consumeBaseDirArg,
+  requireFlagValue,
+  resolveGlobalConfig,
+  validatePath,
+} from './options.js'
 
 // ============================================
 // Helpers
@@ -31,8 +36,19 @@ interface ScanRootResult {
  * `list`-specific warnings: per-directory read failures and the depth-limit
  * warning, both annotated with `displayPath`.
  */
-async function scanRoot(root: string, excludePaths: string[]): Promise<ScanRootResult> {
-  const { files, unreadableDirs, depthLimited } = await bfsCollectSupportedFiles(root, excludePaths)
+async function scanRoot(
+  root: string,
+  excludePaths: string[],
+  scope?: string[]
+): Promise<ScanRootResult> {
+  // `scope` threads into the walker as the 4th positional arg (after `maxDepth`);
+  // pass `undefined` for `maxDepth` to keep the default bound.
+  const { files, unreadableDirs, depthLimited } = await bfsCollectSupportedFiles(
+    root,
+    excludePaths,
+    undefined,
+    scope
+  )
 
   const warnings: string[] = []
   for (const { dirPath, code } of unreadableDirs) {
@@ -58,6 +74,13 @@ interface ListCliOptions {
    * provided.
    */
   baseDirs?: string[] | undefined
+  /**
+   * Collected `--scope` path prefixes in CLI order. Repeatable: multiple flags
+   * union. Each value is trimmed and validated non-empty at parse time.
+   * `undefined` means no scope (list every file); trailing-separator
+   * equivalence is applied downstream by `scope-match.ts`.
+   */
+  scope?: string[] | undefined
 }
 
 interface ParsedArgs {
@@ -114,6 +137,7 @@ List files and their ingestion status.
 
 Options:
   --base-dir <path>      Base directory to scan for files (repeatable: pass once per root; default: BASE_DIRS/BASE_DIR env or cwd)
+  --scope <prefix>       Restrict results to a path prefix (repeatable for multiple prefixes)
   -h, --help             Show this help
 
 Global options (must appear before "list"):
@@ -154,6 +178,22 @@ export function parseArgs(args: string[]): ParsedArgs {
         }
         const valueIndex = consumeBaseDirArg(args, i, options.baseDirs)
         i = valueIndex + 1
+        break
+      }
+      case '--scope': {
+        // Repeatable prefix filter (mirrors `query --scope`). Trim and reject
+        // empty/whitespace locally — the same non-empty check `normalizeScope`
+        // applies at the MCP boundary, kept module-private there. Trailing-
+        // separator equivalence is handled downstream in `scope-match.ts`.
+        const value = requireFlagValue(args, i, '--scope').trim()
+        if (value.length === 0) {
+          console.error('--scope value must not be empty')
+          process.exit(1)
+        }
+        const scope = options.scope ?? []
+        scope.push(value)
+        options.scope = scope
+        i += 2
         break
       }
       default:
@@ -260,7 +300,11 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     const keyToRoot = new Map<string, string>()
     const keyToScanned = new Map<string, string>()
     for (const root of rawBaseDirs) {
-      const { files: perRoot, warnings: rootWarnings } = await scanRoot(root, excludePaths)
+      const { files: perRoot, warnings: rootWarnings } = await scanRoot(
+        root,
+        excludePaths,
+        options.scope
+      )
       for (const warning of rootWarnings) {
         console.error(`Warning [${root}]: ${warning}`)
       }
@@ -293,16 +337,15 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
     files.sort((a, b) => (a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0))
 
     // Content ingested via ingest_data plus orphaned DB entries: ingested
-    // entries whose identity key matched no scanned file.
-    const sources: SourceEntry[] = ingestedKeyed
-      .filter(({ key }) => !matchedKeys.has(key))
-      .map(({ entry: f }) => {
-        if (looksLikeRawDataPath(f.filePath)) {
-          const source = extractSourceFromPath(f.filePath)
-          if (source) return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
-        }
-        return { filePath: f.filePath, chunkCount: f.chunkCount, timestamp: f.timestamp }
-      })
+    // entries whose identity key matched no scanned file. With `scope` present,
+    // raw-data sources are always kept while real-file entries are scope-filtered
+    // (see `classifyIngestedSources`); scope-absent behavior is unchanged. The
+    // same helper backs the MCP `list_files` surface, so both stay identical.
+    const sources: SourceEntry[] = classifyIngestedSources(
+      ingestedKeyed,
+      matchedKeys,
+      options.scope
+    )
 
     const result: ListResult = {
       baseDirs: [...rawBaseDirs],

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -1,0 +1,40 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+import { describe, expect, it } from 'vitest'
+import { toolDefinitions } from '../tool-definitions.js'
+
+const findTool = (name: string): Tool => {
+  const tool = toolDefinitions.find((t) => t.name === name)
+  if (!tool) throw new Error(`tool ${name} not found`)
+  return tool
+}
+
+describe('list_files tool definition scope', () => {
+  const listFiles = findTool('list_files')
+  const scope = (listFiles.inputSchema.properties as Record<string, unknown>)?.scope as
+    | Record<string, unknown>
+    | undefined
+
+  it('advertises an optional scope property', () => {
+    expect(scope).toBeDefined()
+    // scope is optional: list_files declares no required arguments (backward compatible)
+    expect(listFiles.inputSchema.required).toBeUndefined()
+  })
+
+  it('uses the string | array<string> oneOf shape', () => {
+    expect(scope?.oneOf).toEqual([{ type: 'string' }, { type: 'array', items: { type: 'string' } }])
+  })
+
+  it('describes scope on a reachable/scan-path basis, not the query stored-filePath phrasing', () => {
+    const description = scope?.description as string
+    expect(description).toMatch(/reachable/i)
+    // MUST NOT copy the query_documents wording, which contradicts the scan-path basis
+    expect(description).not.toMatch(/filePath equal to or under/)
+  })
+
+  it('keeps boundary-safe and absolute-path guidance', () => {
+    const description = scope?.description as string
+    expect(description).toContain('/docs/api')
+    expect(description).toContain('/docs/apiv2')
+    expect(description).toMatch(/absolute/i)
+  })
+})

--- a/src/server/__tests__/tool-input.test.ts
+++ b/src/server/__tests__/tool-input.test.ts
@@ -1,6 +1,10 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { describe, expect, it } from 'vitest'
-import { parseIngestDataInput, parseQueryDocumentsInput } from '../tool-input.js'
+import {
+  parseIngestDataInput,
+  parseListFilesInput,
+  parseQueryDocumentsInput,
+} from '../tool-input.js'
 
 describe('parseQueryDocumentsInput', () => {
   it('accepts a valid query without limit', () => {
@@ -111,6 +115,63 @@ describe('parseQueryDocumentsInput', () => {
     expect(() => parseQueryDocumentsInput(raw)).toThrow(
       /scope must be a non-empty string or a non-empty array of non-empty strings/
     )
+  })
+})
+
+describe('parseListFilesInput', () => {
+  it('returns {} when arguments are omitted (undefined)', () => {
+    expect(parseListFilesInput(undefined)).toEqual({})
+  })
+
+  it('returns {} for an empty object (no scope)', () => {
+    expect(parseListFilesInput({})).toEqual({})
+  })
+
+  it('normalizes a string scope to a single-element array', () => {
+    expect(parseListFilesInput({ scope: '/a/b' })).toEqual({ scope: ['/a/b'] })
+  })
+
+  it('passes a string array scope through', () => {
+    expect(parseListFilesInput({ scope: ['/a', '/b'] })).toEqual({ scope: ['/a', '/b'] })
+  })
+
+  it('trims surrounding whitespace from scope values (string and array)', () => {
+    expect(parseListFilesInput({ scope: '  /a/b  ' })).toEqual({ scope: ['/a/b'] })
+    expect(parseListFilesInput({ scope: ['  /a', '/b\t'] })).toEqual({ scope: ['/a', '/b'] })
+  })
+
+  it.each([
+    ['empty array scope', { scope: [] }],
+    ['empty string scope', { scope: '' }],
+    ['whitespace string scope', { scope: '  ' }],
+    ['array with empty-string element', { scope: ['', '/a'] }],
+    ['array with whitespace element', { scope: ['   ', '/a'] }],
+    ['array with non-string element', { scope: ['/a', 5] }],
+    ['number scope', { scope: 42 }],
+    ['object scope', { scope: { path: '/a/b' } }],
+    ['null scope', { scope: null }],
+  ])('rejects %s', (_label, raw) => {
+    expect(() => parseListFilesInput(raw)).toThrow(
+      /scope must be a non-empty string or a non-empty array of non-empty strings/
+    )
+  })
+
+  it.each([
+    ['non-object non-undefined', 42],
+    ['null', null],
+    ['array', ['/a']],
+  ])('rejects %s arguments', (_label, raw) => {
+    expect(() => parseListFilesInput(raw)).toThrow(McpError)
+  })
+
+  it('throws InvalidParams error code for malformed scope', () => {
+    try {
+      parseListFilesInput({ scope: 42 })
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(McpError)
+      expect((error as McpError).code).toBe(ErrorCode.InvalidParams)
+    }
   })
 })
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,6 +34,7 @@ import {
   saveRawData,
 } from '../utils/raw-data-utils.js'
 import { realpathForMatch } from '../utils/scan.js'
+import { nonAbsolutePrefixes } from '../utils/scope-match.js'
 import { type VectorChunk, VectorStore } from '../vectordb/index.js'
 import { DatabaseError } from '../vectordb/types.js'
 import {
@@ -723,6 +724,18 @@ export class RAGServer {
     const content: RagContentBlock[] = [{ type: 'text', text: JSON.stringify(result, null, 2) }]
     for (const w of scanWarnings) {
       content.push({ type: 'text', text: `Warning: ${w}` })
+    }
+    // A non-absolute scope prefix matches nothing (the scan is absolute-path
+    // based) but yields no result-level signal, so surface it as a non-fatal
+    // warning block. Result semantics are unchanged — the prefix still matches
+    // nothing; this only makes the silent miss visible to the client.
+    if (scope !== undefined) {
+      for (const prefix of nonAbsolutePrefixes(scope)) {
+        content.push({
+          type: 'text',
+          text: `Warning: scope prefix "${prefix}" is not absolute; it matches nothing.`,
+        })
+      }
     }
     return { content: this.withWarnings(content) }
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import { parseHtml } from '../parser/html-parser.js'
 import { DocumentParser } from '../parser/index.js'
 import { extractMarkdownTitle, extractTxtTitle } from '../parser/title-extractor.js'
 import type { BaseDirsConfigError } from '../utils/base-dirs.js'
+import { classifyIngestedSources } from '../utils/list-sources.js'
 import {
   type ContentFormat,
   checkRawDataArtifacts,
@@ -45,7 +46,11 @@ import {
 } from './error-utils.js'
 import { normalizeBaseDirs, scanBaseDir } from './list-scanner.js'
 import { toolDefinitions } from './tool-definitions.js'
-import { parseIngestDataInput, parseQueryDocumentsInput } from './tool-input.js'
+import {
+  parseIngestDataInput,
+  parseListFilesInput,
+  parseQueryDocumentsInput,
+} from './tool-input.js'
 import type {
   DeleteFileInput,
   DeleteFileResult,
@@ -53,6 +58,7 @@ import type {
   IngestDataInput,
   IngestFileInput,
   IngestResult,
+  ListFilesInput,
   ListFilesResult,
   QueryDocumentsInput,
   QueryResult,
@@ -263,7 +269,7 @@ export class RAGServer {
                 request.params.arguments as unknown as ReadChunkNeighborsInput
               )
             case 'list_files':
-              return await this.handleListFiles()
+              return await this.handleListFiles(parseListFilesInput(request.params.arguments))
             case 'status':
               return await this.handleStatus()
             default:
@@ -633,11 +639,21 @@ export class RAGServer {
    *   producing-root annotation.
    * - Excludes `dbPath` and `cacheDir` uniformly across every root.
    */
-  async handleListFiles(): Promise<{ content: RagContentBlock[] }> {
+  async handleListFiles(input: ListFilesInput = {}): Promise<{ content: RagContentBlock[] }> {
     // Root-dependent tool: fail fast on configError BEFORE any DB / FS access.
     // `assertConfigOk` throws `BaseDirsConfigError` (mapped to InvalidParams by
     // the central dispatcher); no local error-mapping catch here.
     this.assertConfigOk()
+    // `input.scope` is parser-normalized to `string[]`, but the shared input
+    // type admits `string | string[]`; array-wrap once (mirrors query_documents)
+    // so scope threads uniformly into the walker and the sources classifier.
+    // Undefined scope leaves both the scan and the sources split unchanged.
+    const scope =
+      input.scope === undefined
+        ? undefined
+        : Array.isArray(input.scope)
+          ? input.scope
+          : [input.scope]
     // Get all ingested entries and index them by file IDENTITY (realpath), so
     // a file ingested via a different spelling (symlinked prefix or alias)
     // still matches the scan. Storage/display stay normal-path; realpath is
@@ -659,7 +675,8 @@ export class RAGServer {
     for (const baseDir of this.rawBaseDirs) {
       const { files: scanned, warnings: rootWarnings } = await scanBaseDir(
         baseDir,
-        this.excludePaths
+        this.excludePaths,
+        scope
       )
       for (const w of rootWarnings) {
         scanWarnings.push(`[${baseDir}] ${w}`)
@@ -687,16 +704,10 @@ export class RAGServer {
     }
 
     // Content ingested via ingest_data plus orphaned DB entries: ingested
-    // entries whose identity key matched no scanned file.
-    const sources: SourceEntry[] = ingestedKeyed
-      .filter(({ key }) => !matchedKeys.has(key))
-      .map(({ entry: f }) => {
-        if (looksLikeRawDataPath(f.filePath)) {
-          const source = extractSourceFromPath(f.filePath)
-          if (source) return { source, chunkCount: f.chunkCount, timestamp: f.timestamp }
-        }
-        return { filePath: f.filePath, chunkCount: f.chunkCount, timestamp: f.timestamp }
-      })
+    // entries whose identity key matched no scanned file. With `scope` present,
+    // raw-data sources are always kept while real-file entries are scope-filtered
+    // (see `classifyIngestedSources`); scope-absent behavior is unchanged.
+    const sources: SourceEntry[] = classifyIngestedSources(ingestedKeyed, matchedKeys, scope)
 
     const result: ListFilesResult = {
       baseDir: this.rawBaseDir,

--- a/src/server/list-scanner.ts
+++ b/src/server/list-scanner.ts
@@ -8,7 +8,7 @@ import { extname, join } from 'node:path'
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { displayPath } from '../utils/base-dirs.js'
 import { MAX_SCAN_DEPTH } from '../utils/limits.js'
-import { isUnderOrEqual, matchesAnyScope } from '../utils/scope-match.js'
+import { isInScope, shouldVisitDir } from '../utils/scope-match.js'
 import type { RAGServerConfig } from './types.js'
 
 /**
@@ -40,16 +40,12 @@ export async function scanBaseDir(
   const warnings: string[] = []
   let depthLimited = false
 
-  // Visit `dir` when it is in-scope (a descendant of some prefix) or an
-  // ancestor of some prefix (must descend to reach the scoped subtree). No
-  // scope → visit every directory.
-  const scopePrefixes = scope && scope.length > 0 ? scope : undefined
-  const shouldVisitDir = (dir: string): boolean =>
-    !scopePrefixes ||
-    matchesAnyScope(dir, scopePrefixes) ||
-    scopePrefixes.some((prefix) => isUnderOrEqual(prefix, dir))
-
-  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(baseDir)
+  // Scope pushdown (shared with bfsCollectSupportedFiles via scope-match): visit
+  // a directory only if it is in-scope or an ancestor of the scoped subtree, and
+  // collect a file only if it is in-scope. A baseDir intersecting no prefix is
+  // skipped without any `readdir`; absent scope leaves traversal/collection
+  // unchanged.
+  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(baseDir, scope)
     ? [{ dirPath: baseDir, depth: 0 }]
     : []
 
@@ -84,11 +80,11 @@ export async function scanBaseDir(
       if (entry.isSymbolicLink()) continue
       if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
       if (entry.isDirectory()) {
-        if (shouldVisitDir(fullPath)) {
+        if (shouldVisitDir(fullPath, scope)) {
           queue.push({ dirPath: fullPath, depth: depth + 1 })
         }
       } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
-        if (!scopePrefixes || matchesAnyScope(fullPath, scopePrefixes)) {
+        if (isInScope(fullPath, scope)) {
           files.push(fullPath)
         }
       }

--- a/src/server/list-scanner.ts
+++ b/src/server/list-scanner.ts
@@ -8,6 +8,7 @@ import { extname, join } from 'node:path'
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { displayPath } from '../utils/base-dirs.js'
 import { MAX_SCAN_DEPTH } from '../utils/limits.js'
+import { isUnderOrEqual, matchesAnyScope } from '../utils/scope-match.js'
 import type { RAGServerConfig } from './types.js'
 
 /**
@@ -24,16 +25,33 @@ import type { RAGServerConfig } from './types.js'
  *    hide files under the other roots, so the multi-root contract makes this
  *    asymmetry user-visible, so the policy is now best-effort per root.
  *  - Symlinks are skipped (mirrors the CLI ingest walker).
+ *  - When `scope` is provided (non-empty), the predicate is pushed into the
+ *    traversal: a directory is visited only if it is in-scope or an ancestor of
+ *    some scope prefix, and a file is collected only if it is in-scope. A
+ *    baseDir intersecting no prefix is skipped without any `readdir`. An
+ *    absent/empty `scope` leaves traversal and collection unchanged.
  */
 export async function scanBaseDir(
   baseDir: string,
-  excludePaths: readonly string[]
+  excludePaths: readonly string[],
+  scope?: string[]
 ): Promise<{ files: string[]; warnings: string[] }> {
   const files: string[] = []
   const warnings: string[] = []
   let depthLimited = false
 
-  const queue: { dirPath: string; depth: number }[] = [{ dirPath: baseDir, depth: 0 }]
+  // Visit `dir` when it is in-scope (a descendant of some prefix) or an
+  // ancestor of some prefix (must descend to reach the scoped subtree). No
+  // scope → visit every directory.
+  const scopePrefixes = scope && scope.length > 0 ? scope : undefined
+  const shouldVisitDir = (dir: string): boolean =>
+    !scopePrefixes ||
+    matchesAnyScope(dir, scopePrefixes) ||
+    scopePrefixes.some((prefix) => isUnderOrEqual(prefix, dir))
+
+  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(baseDir)
+    ? [{ dirPath: baseDir, depth: 0 }]
+    : []
 
   while (queue.length > 0) {
     const { dirPath, depth } = queue.shift()!
@@ -66,9 +84,13 @@ export async function scanBaseDir(
       if (entry.isSymbolicLink()) continue
       if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
       if (entry.isDirectory()) {
-        queue.push({ dirPath: fullPath, depth: depth + 1 })
+        if (shouldVisitDir(fullPath)) {
+          queue.push({ dirPath: fullPath, depth: depth + 1 })
+        }
       } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
-        files.push(fullPath)
+        if (!scopePrefixes || matchesAnyScope(fullPath, scopePrefixes)) {
+          files.push(fullPath)
+        }
       }
     }
   }

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -118,14 +118,14 @@ export const toolDefinitions: Tool[] = [
   {
     name: 'list_files',
     description:
-      'List supported files (PDF, DOCX, TXT, MD) under the configured base directories and whether each is ingested. Returns { baseDirs, files, sources }; sources holds ingested items outside the base dirs (web pages, clipboard, etc.).',
+      'List supported files (PDF, DOCX, TXT, MD) under the configured base directories and whether each is ingested. Returns { baseDirs, files, sources }; sources lists ingested items reported apart from the file scan, chiefly ingest_data content (web pages, clipboard, etc.).',
     inputSchema: {
       type: 'object',
       properties: {
         scope: {
           oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
           description:
-            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting the listing to files reachable at a path equal to or under a prefix within the base directories. "/docs/api" matches "/docs/api/x.md" but not "/docs/apiv2". Must be absolute (server OS style); a relative prefix matches nothing.',
+            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting the listing to files reachable at a path equal to or under a prefix within the base directories. "/docs/api" matches "/docs/api/x.md" but not "/docs/apiv2". Must be absolute (server OS style); a relative prefix matches nothing. Scope filters files by their scan path; ingest_data sources, which have no base-directory path, are always listed.',
         },
       },
     },

--- a/src/server/tool-definitions.ts
+++ b/src/server/tool-definitions.ts
@@ -119,7 +119,16 @@ export const toolDefinitions: Tool[] = [
     name: 'list_files',
     description:
       'List supported files (PDF, DOCX, TXT, MD) under the configured base directories and whether each is ingested. Returns { baseDirs, files, sources }; sources holds ingested items outside the base dirs (web pages, clipboard, etc.).',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        scope: {
+          oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+          description:
+            'Optional absolute path prefix(es) — one string or a list (unioned) — restricting the listing to files reachable at a path equal to or under a prefix within the base directories. "/docs/api" matches "/docs/api/x.md" but not "/docs/apiv2". Must be absolute (server OS style); a relative prefix matches nothing.',
+        },
+      },
+    },
   },
   {
     name: 'status',

--- a/src/server/tool-input.ts
+++ b/src/server/tool-input.ts
@@ -10,7 +10,7 @@
 
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import type { ContentFormat } from '../utils/raw-data-utils.js'
-import type { IngestDataInput, QueryDocumentsInput } from './types.js'
+import type { IngestDataInput, ListFilesInput, QueryDocumentsInput } from './types.js'
 
 const CONTENT_FORMATS: readonly ContentFormat[] = ['text', 'html', 'markdown']
 
@@ -74,6 +74,27 @@ export function parseQueryDocumentsInput(raw: unknown): QueryDocumentsInput {
   }
 
   return input
+}
+
+/**
+ * Validate `list_files` arguments. The tool historically takes no arguments, so
+ * an omitted `arguments` (`undefined`) or `{}` is accepted as "no scope". When
+ * `scope` is present, it is normalized the same way as `query_documents`.
+ */
+export function parseListFilesInput(raw: unknown): ListFilesInput {
+  // Preserve the no-argument contract: `asRecord` rejects `undefined`, so
+  // short-circuit before it to avoid a spurious McpError on no-arg calls.
+  if (raw === undefined) {
+    return {}
+  }
+
+  const { scope } = asRecord(raw, 'list_files')
+
+  if (scope === undefined) {
+    return {}
+  }
+
+  return { scope: normalizeScope(scope) }
 }
 
 /**

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -87,6 +87,14 @@ export interface QueryDocumentsInput {
 }
 
 /**
+ * list_files tool input
+ */
+export interface ListFilesInput {
+  /** Path prefix scope (one or a list); the parser normalizes to `string[]`. */
+  scope?: string | string[]
+}
+
+/**
  * ingest_file tool input
  */
 export interface IngestFileInput {

--- a/src/utils/__tests__/list-sources.test.ts
+++ b/src/utils/__tests__/list-sources.test.ts
@@ -1,0 +1,135 @@
+// Unit tests for `classifyIngestedSources` — the pure `sources` classifier
+// shared by the MCP `list_files` handler and the `list` CLI (extracted from the
+// byte-for-byte-identical inline blocks at src/server/index.ts:691-699 and
+// src/cli/list.ts:297-305).
+//
+// @category: unit
+// @lane: unit
+// @dependency: pure (looksLikeRawDataPath / extractSourceFromPath / matchesAnyScope) — no I/O
+// @complexity: medium (raw-data vs real-file branch × scope present/absent)
+// ROI: n/a (pure helper unit)
+
+import { sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { classifyIngestedSources } from '../list-sources.js'
+
+// Build a `<dbPath>/raw-data/<base64url>.md` path whose encoded segment decodes
+// to `source`, so `looksLikeRawDataPath` is true and `extractSourceFromPath`
+// recovers `source` — matching how ingest_data stores raw content.
+function rawDataPath(source: string): string {
+  const encoded = Buffer.from(source, 'utf-8').toString('base64url')
+  return `${sep}db${sep}raw-data${sep}${encoded}.md`
+}
+
+// A real on-disk file path (no `/raw-data/` segment).
+function realFilePath(...segments: string[]): string {
+  return sep + segments.join(sep)
+}
+
+const entry = (filePath: string) => ({
+  entry: { filePath, chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
+  key: `key:${filePath}`,
+})
+
+describe('classifyIngestedSources', () => {
+  it('keeps only entries whose key is absent from matchedKeys (base filter)', () => {
+    const matched = entry(realFilePath('base', 'a.txt'))
+    const orphan = entry(realFilePath('base', 'b.txt'))
+    const matchedKeys = new Set<string>([matched.key])
+
+    const result = classifyIngestedSources([matched, orphan], matchedKeys)
+
+    expect(result).toEqual([
+      {
+        filePath: realFilePath('base', 'b.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('scope absent: raw-data yields {source} and real-file yields {filePath} (byte-for-byte with the pre-extraction block)', () => {
+    const raw = entry(rawDataPath('https://example.com/doc'))
+    const real = entry(realFilePath('base', 'orphan.txt'))
+
+    const result = classifyIngestedSources([raw, real], new Set())
+
+    expect(result).toEqual([
+      { source: 'https://example.com/doc', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
+      {
+        filePath: realFilePath('base', 'orphan.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('scope present: raw-data source is always emitted regardless of scope', () => {
+    const raw = entry(rawDataPath('clipboard://2026-07-09'))
+    // scope points at an unrelated real subtree; the raw-data entry has no
+    // filesystem path under it yet must still be emitted.
+    const scope = [realFilePath('base', 'in-scope')]
+
+    const result = classifyIngestedSources([raw], new Set(), scope)
+
+    expect(result).toEqual([
+      { source: 'clipboard://2026-07-09', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
+    ])
+  })
+
+  it('scope present: real-file entry UNDER scope remains an orphan source', () => {
+    const underScope = entry(realFilePath('base', 'in-scope', 'orphan.txt'))
+    const scope = [realFilePath('base', 'in-scope')]
+
+    const result = classifyIngestedSources([underScope], new Set(), scope)
+
+    expect(result).toEqual([
+      {
+        filePath: realFilePath('base', 'in-scope', 'orphan.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('scope present: real-file entry OUTSIDE scope is dropped from sources (no orphan misclassification)', () => {
+    const outsideScope = entry(realFilePath('base', 'other', 'orphan.txt'))
+    const scope = [realFilePath('base', 'in-scope')]
+
+    const result = classifyIngestedSources([outsideScope], new Set(), scope)
+
+    expect(result).toEqual([])
+  })
+
+  it('scope present: mixes raw-data (kept) + in-scope real (kept) + out-of-scope real (dropped)', () => {
+    const raw = entry(rawDataPath('https://example.com/keep'))
+    const underScope = entry(realFilePath('base', 'in-scope', 'keep.txt'))
+    const outsideScope = entry(realFilePath('base', 'nope', 'drop.txt'))
+    const scope = [realFilePath('base', 'in-scope')]
+
+    const result = classifyIngestedSources([raw, underScope, outsideScope], new Set(), scope)
+
+    expect(result).toEqual([
+      { source: 'https://example.com/keep', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
+      {
+        filePath: realFilePath('base', 'in-scope', 'keep.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('empty scope array is treated as scope-absent (no extra filtering)', () => {
+    const real = entry(realFilePath('base', 'orphan.txt'))
+
+    const result = classifyIngestedSources([real], new Set(), [])
+
+    expect(result).toEqual([
+      {
+        filePath: realFilePath('base', 'orphan.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+})

--- a/src/utils/__tests__/scope-match.test.ts
+++ b/src/utils/__tests__/scope-match.test.ts
@@ -1,9 +1,9 @@
 // Scope-match helper unit tests
 // Test Type: Unit Test
 
+import { isAbsolute } from 'node:path'
 import { describe, expect, it } from 'vitest'
-
-import { isUnderOrEqual, matchesAnyScope } from '../scope-match.js'
+import { isUnderOrEqual, matchesAnyScope, nonAbsolutePrefixes } from '../scope-match.js'
 
 describe('isUnderOrEqual', () => {
   it('should return true when path equals the prefix (exact match)', () => {
@@ -87,5 +87,34 @@ describe('matchesAnyScope', () => {
 
   it('should match on the exact prefix within the union', () => {
     expect(matchesAnyScope('/foo/bar', ['/a', '/foo/bar', '/b'])).toBe(true)
+  })
+})
+
+describe('nonAbsolutePrefixes', () => {
+  // '/foo/bar' etc. are absolute under both posix and win32 isAbsolute (a
+  // leading separator is absolute on both), so these cases are OS-stable.
+  it('should return an empty array when every prefix is absolute', () => {
+    expect(nonAbsolutePrefixes(['/foo/bar', '/docs/api'])).toEqual([])
+  })
+
+  it('should return every non-absolute prefix, preserving input order', () => {
+    expect(nonAbsolutePrefixes(['docs/api', './rel', '../up'])).toEqual([
+      'docs/api',
+      './rel',
+      '../up',
+    ])
+  })
+
+  it('should return only the non-absolute prefixes from a mixed list', () => {
+    expect(nonAbsolutePrefixes(['/abs/one', 'relative', '/abs/two'])).toEqual(['relative'])
+  })
+
+  it('should return an empty array for an empty scope', () => {
+    expect(nonAbsolutePrefixes([])).toEqual([])
+  })
+
+  it('should classify prefixes exactly as node:path isAbsolute (server-OS style)', () => {
+    const prefixes = ['/abs', 'rel', 'a/b/c']
+    expect(nonAbsolutePrefixes(prefixes)).toEqual(prefixes.filter((p) => !isAbsolute(p)))
   })
 })

--- a/src/utils/__tests__/scope-match.test.ts
+++ b/src/utils/__tests__/scope-match.test.ts
@@ -1,0 +1,91 @@
+// Scope-match helper unit tests
+// Test Type: Unit Test
+
+import { describe, expect, it } from 'vitest'
+
+import { isUnderOrEqual, matchesAnyScope } from '../scope-match.js'
+
+describe('isUnderOrEqual', () => {
+  it('should return true when path equals the prefix (exact match)', () => {
+    expect(isUnderOrEqual('/foo/bar', '/foo/bar')).toBe(true)
+  })
+
+  it('should return true when path is a descendant of the prefix', () => {
+    expect(isUnderOrEqual('/foo/bar/baz.md', '/foo/bar')).toBe(true)
+  })
+
+  it('should return false when path shares only a name-prefix (boundary reject)', () => {
+    expect(isUnderOrEqual('/foo/barista', '/foo/bar')).toBe(false)
+  })
+
+  it('should return true for an exact file-level scope', () => {
+    expect(isUnderOrEqual('/foo/bar.md', '/foo/bar.md')).toBe(true)
+  })
+
+  describe('trailing-separator equivalence', () => {
+    it('should treat /a/b, /a/b/ and /a/b// identically for a descendant path', () => {
+      const path = '/a/b/c.md'
+      expect(isUnderOrEqual(path, '/a/b')).toBe(true)
+      expect(isUnderOrEqual(path, '/a/b/')).toBe(true)
+      expect(isUnderOrEqual(path, '/a/b//')).toBe(true)
+    })
+
+    it('should treat /a/b, /a/b/ and /a/b// identically for the exact path', () => {
+      const path = '/a/b'
+      expect(isUnderOrEqual(path, '/a/b')).toBe(true)
+      expect(isUnderOrEqual(path, '/a/b/')).toBe(true)
+      expect(isUnderOrEqual(path, '/a/b//')).toBe(true)
+    })
+
+    it('should treat /a/b, /a/b/ and /a/b// identically for an out-of-scope path', () => {
+      const path = '/a/bc'
+      expect(isUnderOrEqual(path, '/a/b')).toBe(false)
+      expect(isUnderOrEqual(path, '/a/b/')).toBe(false)
+      expect(isUnderOrEqual(path, '/a/b//')).toBe(false)
+    })
+  })
+
+  it('should keep a lone posix root prefix matching any absolute path', () => {
+    expect(isUnderOrEqual('/anything/here.md', '/')).toBe(true)
+    expect(isUnderOrEqual('/', '/')).toBe(true)
+  })
+
+  describe('cross-platform (backslash-style prefix)', () => {
+    it('should match a descendant under a backslash prefix', () => {
+      expect(isUnderOrEqual('C:\\a\\b\\x.md', 'C:\\a\\b')).toBe(true)
+    })
+
+    it('should match the exact backslash path', () => {
+      expect(isUnderOrEqual('C:\\a\\b', 'C:\\a\\b')).toBe(true)
+    })
+
+    it('should reject a name-prefix under a backslash prefix', () => {
+      expect(isUnderOrEqual('C:\\a\\bc', 'C:\\a\\b')).toBe(false)
+    })
+
+    it('should honor trailing-separator equivalence for backslash prefixes', () => {
+      const path = 'C:\\a\\b\\x.md'
+      expect(isUnderOrEqual(path, 'C:\\a\\b')).toBe(true)
+      expect(isUnderOrEqual(path, 'C:\\a\\b\\')).toBe(true)
+      expect(isUnderOrEqual(path, 'C:\\a\\b\\\\')).toBe(true)
+    })
+  })
+})
+
+describe('matchesAnyScope', () => {
+  it('should return true when any prefix matches (union)', () => {
+    expect(matchesAnyScope('/foo/bar/x.md', ['/other', '/foo/bar'])).toBe(true)
+  })
+
+  it('should return false when no prefix matches', () => {
+    expect(matchesAnyScope('/foo/barista', ['/foo/bar', '/other'])).toBe(false)
+  })
+
+  it('should return false for an empty prefix list', () => {
+    expect(matchesAnyScope('/foo/bar', [])).toBe(false)
+  })
+
+  it('should match on the exact prefix within the union', () => {
+    expect(matchesAnyScope('/foo/bar', ['/a', '/foo/bar', '/b'])).toBe(true)
+  })
+})

--- a/src/utils/__tests__/scope-scan-pushdown.int.test.ts
+++ b/src/utils/__tests__/scope-scan-pushdown.int.test.ts
@@ -32,7 +32,7 @@
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, join, sep } from 'node:path'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ============================================================================
@@ -333,11 +333,12 @@ describe.each([0, 1])('walker[%i]', (walkerIndex) => {
   // AC: AC5 — trailing-separator equivalence: /a/b ≡ /a/b/ ≡ /a/b//.
   // Behavior: three trailing-separator spellings of the same prefix yield one result set.
   it('treats /a/b, /a/b/ and /a/b// as the same scope', async () => {
+    // Use the OS separator, not a hardcoded "/", so Windows doesn't get a mixed "\...\a\b/" prefix.
     const plain = walker().files(await walker().run(base, [dirAB]))
     visited.length = 0
-    const oneSlash = walker().files(await walker().run(base, [`${dirAB}/`]))
+    const oneSlash = walker().files(await walker().run(base, [`${dirAB}${sep}`]))
     visited.length = 0
-    const twoSlash = walker().files(await walker().run(base, [`${dirAB}//`]))
+    const twoSlash = walker().files(await walker().run(base, [`${dirAB}${sep}${sep}`]))
     expect(sorted(oneSlash)).toEqual(sorted(plain))
     expect(sorted(twoSlash)).toEqual(sorted(plain))
   })

--- a/src/utils/__tests__/scope-scan-pushdown.int.test.ts
+++ b/src/utils/__tests__/scope-scan-pushdown.int.test.ts
@@ -1,0 +1,411 @@
+// INT-2: Walker-layer traversal-scope pushdown tests (Phase 1 Task 3).
+//
+// Proves the `scope` predicate is pushed INTO the BFS walk (not applied as a
+// post-scan filter) for BOTH walkers, which are separate BFS code paths both
+// changed in Task 02:
+//   - `scanBaseDir`            (src/server/list-scanner.ts)  → { files (sorted), warnings }
+//   - `bfsCollectSupportedFiles` (src/utils/scan.ts)         → { files (discovery order), unreadableDirs, depthLimited }
+//
+// @category: integration
+// @lane: integration
+// @dependency: scope-match + walkers + real-FS fixture (mkdtemp) + readdir/join mocks
+// @complexity: high (dual walker, real-FS + synthetic separator fixtures, EACCES pushdown probe)
+// ROI: 88
+//
+// Mocking strategy (shared-registry safe per project-context: isolate:false,
+// pool forks, maxWorkers 1 → mocked module paths use doMock/doUnmock and the
+// walkers are dynamically imported after doMock):
+//   - `node:fs/promises` readdir is replaced by a wrapper that RECORDS every
+//     queried directory into `visited[]` and (optionally) throws EACCES for a
+//     designated deny-path, otherwise DELEGATES to the real readdir. This is the
+//     deterministic, cross-platform pushdown probe; the fixture FS is otherwise
+//     real (a real mkdtemp tree).
+//   - `node:path` join is a wrapper delegating to the real join by default, and
+//     switched to backslash-join ONLY for the synthetic Windows-separator case
+//     (a real `\`-path tree cannot be created on a POSIX host).
+//
+// Scope boundary: NO `realpathForMatch` assertions here — the walkers never call
+// it (that pushdown proof is Phase 2/3). A chmod-based real-FS unreadable
+// sentinel is auxiliary-only (chmod unreliable on Windows CI); the deterministic
+// EACCES-mock probe below fully discharges the walker-layer proof, so it is not
+// duplicated here.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ============================================================================
+// Mock setup (vi.hoisted for isolate:false; installed via doMock in beforeAll)
+// ============================================================================
+
+const mocks = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  join: vi.fn(),
+  // Captured real implementations, filled by the factories below.
+  actualReaddir: undefined as unknown as typeof import('node:fs/promises').readdir,
+  actualJoin: undefined as unknown as typeof import('node:path').join,
+}))
+
+const fsPromisesFactory = async (
+  importOriginal: () => Promise<typeof import('node:fs/promises')>
+) => {
+  const actual = await importOriginal()
+  mocks.actualReaddir = actual.readdir
+  return { ...actual, readdir: mocks.readdir }
+}
+
+const pathFactory = async (importOriginal: () => Promise<typeof import('node:path')>) => {
+  const actual = await importOriginal()
+  mocks.actualJoin = actual.join
+  return { ...actual, join: mocks.join }
+}
+
+const MOCKED_PATHS = ['node:fs/promises', 'node:path'] as const
+
+// Every directory the walker asked `readdir` for, in call order. Reset per test.
+const visited: string[] = []
+
+let scanBaseDir: typeof import('../../server/list-scanner.js').scanBaseDir
+let bfsCollectSupportedFiles: typeof import('../scan.js').bfsCollectSupportedFiles
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function eaccesError(path: string): NodeJS.ErrnoException {
+  const err = new Error(`EACCES: permission denied, scandir '${path}'`) as NodeJS.ErrnoException
+  err.code = 'EACCES'
+  return err
+}
+
+/**
+ * readdir impl backed by the REAL filesystem: records the queried dir, throws
+ * EACCES for any path in `deny`, otherwise delegates to the real readdir.
+ */
+function realDelegate(deny: Set<string> = new Set()) {
+  return async (dirPath: string, options?: unknown) => {
+    visited.push(dirPath)
+    if (deny.has(dirPath)) throw eaccesError(dirPath)
+    return (mocks.actualReaddir as (p: string, o?: unknown) => Promise<unknown>)(dirPath, options)
+  }
+}
+
+function mockDirent(name: string, type: 'file' | 'directory') {
+  return {
+    name,
+    isFile: () => type === 'file',
+    isDirectory: () => type === 'directory',
+    isSymbolicLink: () => false,
+  }
+}
+
+/**
+ * readdir impl backed by an in-memory tree (used for the synthetic backslash
+ * separator case, which cannot exist on a POSIX filesystem). Also flips `join`
+ * to backslash-join so the walker composes Windows-style child paths.
+ */
+function useSyntheticBackslashTree(dirMap: Map<string, Array<[string, 'file' | 'directory']>>) {
+  mocks.join.mockImplementation((...parts: string[]) => parts.join('\\'))
+  mocks.readdir.mockImplementation(async (dirPath: string) => {
+    visited.push(dirPath)
+    const entries = dirMap.get(dirPath)
+    if (!entries) {
+      const err = new Error(`ENOENT: ${dirPath}`) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    }
+    return entries.map(([name, type]) => mockDirent(name, type))
+  })
+}
+
+// Two walkers behind a uniform adapter so every case runs against both.
+interface WalkerAdapter {
+  name: string
+  run: (root: string, scope?: string[]) => Promise<{ files: string[] }>
+  files: (result: unknown) => string[]
+  warnedFor: (result: unknown, dir: string) => boolean
+  warnCount: (result: unknown) => number
+}
+
+let WALKERS: WalkerAdapter[]
+
+// ============================================================================
+// Real-FS fixture tree (built once):
+//   base/
+//     root.md                  (out of scope /a/b)
+//     bar.md                   (exact-file scope target)
+//     a/
+//       in-a.md                (out of scope /a/b)
+//       b/
+//         in-b.md              (in scope /a/b)
+//         c/ deep.md           (in scope; reached via ancestor descent)
+//       bc/ boundary.md        (name-prefix sibling: /a/bc must NOT match /a/b)
+//     x/ y/ out.md             (non-intersecting branch)
+// ============================================================================
+
+let tmpRoot: string
+let base: string
+let dirA: string
+let dirAB: string
+let dirABC: string
+let dirABc: string
+let dirX: string
+let dirXY: string
+let outsideBase: string
+
+let fRoot: string
+let fBar: string
+let fInA: string
+let fInB: string
+let fDeep: string
+let fBoundary: string
+let fOut: string
+let allFiles: string[]
+let allDirs: string[]
+
+beforeAll(async () => {
+  vi.resetModules()
+  for (const p of MOCKED_PATHS) vi.doUnmock(p)
+  vi.doMock('node:fs/promises', fsPromisesFactory)
+  vi.doMock('node:path', pathFactory)
+  ;({ scanBaseDir } = await import('../../server/list-scanner.js'))
+  ;({ bfsCollectSupportedFiles } = await import('../scan.js'))
+
+  WALKERS = [
+    {
+      name: 'scanBaseDir',
+      run: (root, scope) => scanBaseDir(root, [], scope),
+      files: (r) => (r as { files: string[] }).files,
+      warnedFor: (r, dir) =>
+        (r as { warnings: string[] }).warnings.some((w) => w.includes(basename(dir))),
+      warnCount: (r) =>
+        (r as { warnings: string[] }).warnings.filter((w) => w.includes('cannot read directory'))
+          .length,
+    },
+    {
+      name: 'bfsCollectSupportedFiles',
+      run: (root, scope) => bfsCollectSupportedFiles(root, [], undefined, scope),
+      files: (r) => (r as { files: string[] }).files,
+      warnedFor: (r, dir) =>
+        (r as { unreadableDirs: { dirPath: string }[] }).unreadableDirs.some(
+          (u) => u.dirPath === dir
+        ),
+      warnCount: (r) => (r as { unreadableDirs: unknown[] }).unreadableDirs.length,
+    },
+  ]
+
+  // Build the real fixture tree with the REAL path/fs (test-file top-level
+  // imports are resolved before doMock, so `join`/`mkdirSync` here are genuine).
+  tmpRoot = mkdtempSync(join(tmpdir(), 'scope-scan-'))
+  base = join(tmpRoot, 'base')
+  outsideBase = join(tmpRoot, 'outside')
+
+  dirA = join(base, 'a')
+  dirAB = join(base, 'a', 'b')
+  dirABC = join(base, 'a', 'b', 'c')
+  dirABc = join(base, 'a', 'bc')
+  dirX = join(base, 'x')
+  dirXY = join(base, 'x', 'y')
+
+  mkdirSync(dirABC, { recursive: true })
+  mkdirSync(dirABc, { recursive: true })
+  mkdirSync(dirXY, { recursive: true })
+  mkdirSync(outsideBase, { recursive: true })
+
+  fRoot = join(base, 'root.md')
+  fBar = join(base, 'bar.md')
+  fInA = join(dirA, 'in-a.md')
+  fInB = join(dirAB, 'in-b.md')
+  fDeep = join(dirABC, 'deep.md')
+  fBoundary = join(dirABc, 'boundary.md')
+  fOut = join(dirXY, 'out.md')
+
+  for (const f of [fRoot, fBar, fInA, fInB, fDeep, fBoundary, fOut]) {
+    writeFileSync(f, 'content')
+  }
+
+  allFiles = [fRoot, fBar, fInA, fInB, fDeep, fBoundary, fOut]
+  allDirs = [base, dirA, dirAB, dirABC, dirABc, dirX, dirXY]
+})
+
+afterAll(() => {
+  for (const p of MOCKED_PATHS) vi.doUnmock(p)
+  vi.resetModules()
+  rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  visited.length = 0
+  mocks.readdir.mockImplementation(realDelegate())
+  mocks.join.mockImplementation((...parts: string[]) => mocks.actualJoin(...parts))
+})
+
+const sorted = (a: string[]) => [...a].sort()
+
+// ============================================================================
+// Per-walker cases (both BFS code paths)
+// ============================================================================
+
+describe.each([0, 1])('walker[%i]', (walkerIndex) => {
+  const walker = () => WALKERS[walkerIndex]
+
+  // AC: AC3 — in-scope files returned, out-of-scope excluded.
+  // Behavior: scope=[/base/a/b] → walk under a/b only → files = {in-b.md, deep.md}.
+  it('includes in-scope files and excludes everything outside the scope prefix', async () => {
+    const result = await walker().run(base, [dirAB])
+    const files = walker().files(result)
+    expect(sorted(files)).toEqual(sorted([fInB, fDeep]))
+    for (const excluded of [fRoot, fBar, fInA, fBoundary, fOut]) {
+      expect(files).not.toContain(excluded)
+    }
+  })
+
+  // AC: AC5 — boundary-safe: /a/b must not match the name-prefix sibling /a/bc.
+  // Behavior: scope=[/base/a/b] → /a/bc pruned → boundary.md absent, a/bc never readdir'd.
+  it('does not match the name-prefix sibling directory (/a/b vs /a/bc)', async () => {
+    const result = await walker().run(base, [dirAB])
+    expect(walker().files(result)).not.toContain(fBoundary)
+    expect(visited).not.toContain(dirABc)
+  })
+
+  // AC: AC5 — an exact file-path scope matches exactly that file.
+  // Behavior: scope=[/base/bar.md] → base read (ancestor), sibling dirs pruned → files = {bar.md}.
+  it('matches an exact file-path scope', async () => {
+    const result = await walker().run(base, [fBar])
+    expect(walker().files(result)).toEqual([fBar])
+    expect(visited).not.toContain(dirA)
+    expect(visited).not.toContain(dirX)
+  })
+
+  // AC: AC3/AC5 — a deep scope is reachable via ancestor descent (no false pruning).
+  // Behavior: scope=[/base/a/b/c] → descend base→a→a/b→a/b/c → files = {deep.md}, in-b.md excluded.
+  it('reaches a deep scope by descending its ancestor chain without false pruning', async () => {
+    const result = await walker().run(base, [dirABC])
+    const files = walker().files(result)
+    expect(files).toEqual([fDeep])
+    expect(files).not.toContain(fInB)
+    expect(visited).toEqual(expect.arrayContaining([base, dirA, dirAB, dirABC]))
+    expect(visited).not.toContain(dirABc)
+    expect(visited).not.toContain(dirX)
+  })
+
+  // AC: AC4a — a root intersecting no prefix is skipped entirely (zero readdir);
+  // scope outside the base dir yields an empty result rather than an error.
+  // Behavior: scope=[/tmp/.../outside] on root=/base → root gate false → 0 readdir, files = [].
+  it('skips a non-intersecting root entirely (zero readdir, empty result)', async () => {
+    const result = await walker().run(base, [outsideBase])
+    expect(walker().files(result)).toEqual([])
+    expect(visited).toHaveLength(0)
+  })
+
+  // AC: AC7 — scope absent is byte-for-byte the full traversal (regression guard).
+  // Behavior: scope undefined and scope [] both walk every dir and collect every supported file.
+  it('leaves traversal and collection unchanged when scope is absent (undefined and [])', async () => {
+    const undefinedRun = await walker().run(base, undefined)
+    const undefinedFiles = walker().files(undefinedRun)
+    const undefinedVisited = [...visited]
+
+    visited.length = 0
+    const emptyRun = await walker().run(base, [])
+    const emptyFiles = walker().files(emptyRun)
+    const emptyVisited = [...visited]
+
+    expect(sorted(undefinedFiles)).toEqual(sorted(allFiles))
+    expect(sorted(undefinedVisited)).toEqual(sorted(allDirs))
+    // Empty scope array is treated identically to absent scope.
+    expect(sorted(emptyFiles)).toEqual(sorted(undefinedFiles))
+    expect(sorted(emptyVisited)).toEqual(sorted(undefinedVisited))
+  })
+
+  // AC: AC11 (Reference Contract, structure-order) — scope changes membership
+  // only, never order. The scoped file list equals the unscoped file list
+  // filtered to the surviving members, preserving relative order.
+  // Behavior: scope=[/base/a/b] → scoped files == unscoped files ∩ in-scope, same order.
+  it('preserves file order under scope (membership-only change)', async () => {
+    const unscoped = walker().files(await walker().run(base, undefined))
+    visited.length = 0
+    const scoped = walker().files(await walker().run(base, [dirAB]))
+    const survivors = new Set(scoped)
+    expect(scoped).toEqual(unscoped.filter((f) => survivors.has(f)))
+  })
+
+  // AC: AC5 — trailing-separator equivalence: /a/b ≡ /a/b/ ≡ /a/b//.
+  // Behavior: three trailing-separator spellings of the same prefix yield one result set.
+  it('treats /a/b, /a/b/ and /a/b// as the same scope', async () => {
+    const plain = walker().files(await walker().run(base, [dirAB]))
+    visited.length = 0
+    const oneSlash = walker().files(await walker().run(base, [`${dirAB}/`]))
+    visited.length = 0
+    const twoSlash = walker().files(await walker().run(base, [`${dirAB}//`]))
+    expect(sorted(oneSlash)).toEqual(sorted(plain))
+    expect(sorted(twoSlash)).toEqual(sorted(plain))
+  })
+
+  // AC: AC4a — THE load-bearing pushdown proof. A readdir mock that returns
+  // EACCES for a scope-outside path AND records visits shows that path is never
+  // visited under scope (no recorded call, no warning). The companion sentinel
+  // assertion proves the probe CAN fire when the path is not pruned, so the
+  // non-visitation is real pushdown, not a dead probe.
+  // Behavior: deny=/base/x; scope=[/base/a/b] → x never readdir'd, no warning; unscoped → x readdir'd + warns.
+  it('never descends into a scope-outside subtree (readdir EACCES probe is never called)', async () => {
+    mocks.readdir.mockImplementation(realDelegate(new Set([dirX])))
+    const scopedResult = await walker().run(base, [dirAB])
+
+    // Pruned: the deny-path was never queried and produced no warning.
+    expect(visited).not.toContain(dirX)
+    expect(walker().warnedFor(scopedResult, dirX)).toBe(false)
+    expect(walker().warnCount(scopedResult)).toBe(0)
+    // Result is still correct.
+    expect(sorted(walker().files(scopedResult))).toEqual(sorted([fInB, fDeep]))
+
+    // Sentinel validity: without scope the SAME deny fires — x is read and warns.
+    visited.length = 0
+    const unscopedResult = await walker().run(base, undefined)
+    expect(visited).toContain(dirX)
+    expect(walker().warnedFor(unscopedResult, dirX)).toBe(true)
+  })
+
+  // AC: AC10 — an in-scope unreadable directory still warns exactly as today.
+  // Behavior: deny=/base/a/b (in scope); scope=[/base/a/b] → a/b visited, readdir throws → warning surfaced.
+  it('still warns when an in-scope directory is unreadable', async () => {
+    mocks.readdir.mockImplementation(realDelegate(new Set([dirAB])))
+    const result = await walker().run(base, [dirAB])
+    expect(visited).toContain(dirAB)
+    expect(walker().warnedFor(result, dirAB)).toBe(true)
+  })
+
+  // AC: AC10 — an ancestor directory descended to reach a deep scope still warns.
+  // Behavior: deny=/base/a (ancestor of scope); scope=[/base/a/b/c] → a visited, readdir throws → warning surfaced.
+  it('still warns when an ancestor directory on the descent path is unreadable', async () => {
+    mocks.readdir.mockImplementation(realDelegate(new Set([dirA])))
+    const result = await walker().run(base, [dirABC])
+    expect(visited).toContain(dirA)
+    expect(walker().warnedFor(result, dirA)).toBe(true)
+  })
+
+  // AC: AC8 — cross-platform separator: a `\`-style prefix prunes correctly on a
+  // synthetic Windows-style tree (host-OS independent; proves the walker
+  // delegates separator handling to scope-match, not a hardcoded `/`).
+  // Behavior: scope=[C:\base\a\b] over a backslash tree → in-b.md collected, C:\base\a\bc pruned.
+  it('prunes correctly with a backslash-style separator', async () => {
+    const winBase = 'C:\\base'
+    const dirMap = new Map<string, Array<[string, 'file' | 'directory']>>([
+      ['C:\\base', [['a', 'directory']]],
+      [
+        'C:\\base\\a',
+        [
+          ['b', 'directory'],
+          ['bc', 'directory'],
+        ],
+      ],
+      ['C:\\base\\a\\b', [['in-b.md', 'file']]],
+      ['C:\\base\\a\\bc', [['boundary.md', 'file']]],
+    ])
+    useSyntheticBackslashTree(dirMap)
+
+    const result = await walker().run(winBase, ['C:\\base\\a\\b'])
+    expect(walker().files(result)).toEqual(['C:\\base\\a\\b\\in-b.md'])
+    expect(visited).not.toContain('C:\\base\\a\\bc')
+  })
+})

--- a/src/utils/list-sources.ts
+++ b/src/utils/list-sources.ts
@@ -1,0 +1,72 @@
+// Pure `sources` classifier shared by the MCP `list_files` handler
+// (`src/server/index.ts`) and the `list` CLI (`src/cli/list.ts`). Extracted
+// from the byte-for-byte-identical inline blocks in both surfaces so the
+// raw-data / real-file scope branch lives in one place, mirroring the
+// drift-avoidance rationale behind the shared `scope-match.ts` matcher.
+//
+// `sources` are ingested entries whose identity key matched no scanned file:
+// content ingested via `ingest_data` (raw-data paths) plus orphaned DB entries
+// for real files not currently on disk under a scanned root.
+
+import { extractSourceFromPath, looksLikeRawDataPath } from './raw-data-utils.js'
+import { matchesAnyScope } from './scope-match.js'
+
+/**
+ * An ingested entry paired with its identity key (`realpathForMatch` of the
+ * stored `filePath`). Only the fields the classifier reads are required, so the
+ * caller's richer row type is consumed structurally.
+ */
+export interface KeyedIngestedEntry {
+  entry: { filePath: string; chunkCount: number; timestamp: string }
+  key: string
+}
+
+/**
+ * A classified source: a raw-data entry restored to its original `source`, or a
+ * real-file / orphaned entry keyed by `filePath`. Structurally compatible with
+ * the `SourceEntry` union both surfaces already return (no type-move refactor).
+ */
+export type ClassifiedSource =
+  | { source: string; chunkCount: number; timestamp: string }
+  | { filePath: string; chunkCount: number; timestamp: string }
+
+/**
+ * Classify the ingested entries that matched no scanned file into `sources`.
+ *
+ * Base filter (always): keep only entries whose `key` is absent from
+ * `matchedKeys`.
+ *
+ * When `scope` is present (non-empty): raw-data entries
+ * (`looksLikeRawDataPath`) have no filesystem path under a base directory, so
+ * they are always emitted regardless of scope; real-file entries are kept only
+ * when their stored `filePath` is under scope (`matchesAnyScope`) — a real-file
+ * entry outside scope is dropped so it appears in neither `files[]` (already
+ * pruned from the scan) nor `sources[]` (no orphan misclassification), while an
+ * unmatched real-file entry under scope remains an orphan source.
+ *
+ * When `scope` is absent (or empty): behavior is unchanged from the pre-extraction
+ * inline block — every unmatched entry is emitted, raw-data as `{ source }` when
+ * `extractSourceFromPath` yields one, else as `{ filePath }`.
+ */
+export function classifyIngestedSources(
+  ingestedKeyed: readonly KeyedIngestedEntry[],
+  matchedKeys: ReadonlySet<string>,
+  scope?: string[]
+): ClassifiedSource[] {
+  const scopePrefixes = scope && scope.length > 0 ? scope : undefined
+
+  return ingestedKeyed
+    .filter(({ key }) => !matchedKeys.has(key))
+    .filter(({ entry }) => {
+      if (!scopePrefixes) return true
+      // Raw-data sources are exempt from scope; real-file entries respect it.
+      return looksLikeRawDataPath(entry.filePath) || matchesAnyScope(entry.filePath, scopePrefixes)
+    })
+    .map(({ entry }) => {
+      if (looksLikeRawDataPath(entry.filePath)) {
+        const source = extractSourceFromPath(entry.filePath)
+        if (source) return { source, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
+      }
+      return { filePath: entry.filePath, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
+    })
+}

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -13,6 +13,7 @@ import { readdir, realpath } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { MAX_SCAN_DEPTH } from './limits.js'
+import { isUnderOrEqual, matchesAnyScope } from './scope-match.js'
 
 /**
  * Canonical identity key for the `list`/`list_files` cross-reference: a file's
@@ -53,19 +54,37 @@ export interface DirScanResult {
  * prefix are filtered out. A per-directory `readdir` failure is captured into
  * `unreadableDirs` and does not abort the scan (best-effort per directory).
  *
+ * When `scope` is provided (non-empty), the predicate is pushed into the
+ * traversal: a directory is visited only if it is in-scope or an ancestor of
+ * some scope prefix, and a file is collected only if it is in-scope. A root that
+ * intersects no prefix is skipped without any `readdir`. An absent/empty `scope`
+ * leaves traversal and collection byte-for-byte unchanged.
+ *
  * Does not sort, dedupe, or emit warnings — callers handle those so their
  * existing output contracts are preserved.
  */
 export async function bfsCollectSupportedFiles(
   rootPath: string,
   excludePaths: readonly string[],
-  maxDepth: number = MAX_SCAN_DEPTH
+  maxDepth: number = MAX_SCAN_DEPTH,
+  scope?: string[]
 ): Promise<DirScanResult> {
   const files: string[] = []
   const unreadableDirs: UnreadableDir[] = []
   let depthLimited = false
 
-  const queue: { dirPath: string; depth: number }[] = [{ dirPath: rootPath, depth: 0 }]
+  // Visit `dir` when it is in-scope (a descendant of some prefix) or an
+  // ancestor of some prefix (must descend to reach the scoped subtree). No
+  // scope → visit every directory.
+  const scopePrefixes = scope && scope.length > 0 ? scope : undefined
+  const shouldVisitDir = (dir: string): boolean =>
+    !scopePrefixes ||
+    matchesAnyScope(dir, scopePrefixes) ||
+    scopePrefixes.some((prefix) => isUnderOrEqual(prefix, dir))
+
+  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(rootPath)
+    ? [{ dirPath: rootPath, depth: 0 }]
+    : []
 
   while (queue.length > 0) {
     const { dirPath, depth } = queue.shift()!
@@ -98,9 +117,13 @@ export async function bfsCollectSupportedFiles(
       if (entry.isSymbolicLink()) continue
       if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
       if (entry.isDirectory()) {
-        queue.push({ dirPath: fullPath, depth: depth + 1 })
+        if (shouldVisitDir(fullPath)) {
+          queue.push({ dirPath: fullPath, depth: depth + 1 })
+        }
       } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
-        files.push(fullPath)
+        if (!scopePrefixes || matchesAnyScope(fullPath, scopePrefixes)) {
+          files.push(fullPath)
+        }
       }
     }
   }

--- a/src/utils/scan.ts
+++ b/src/utils/scan.ts
@@ -13,7 +13,7 @@ import { readdir, realpath } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import { SUPPORTED_EXTENSIONS } from '../parser/index.js'
 import { MAX_SCAN_DEPTH } from './limits.js'
-import { isUnderOrEqual, matchesAnyScope } from './scope-match.js'
+import { isInScope, shouldVisitDir } from './scope-match.js'
 
 /**
  * Canonical identity key for the `list`/`list_files` cross-reference: a file's
@@ -73,16 +73,11 @@ export async function bfsCollectSupportedFiles(
   const unreadableDirs: UnreadableDir[] = []
   let depthLimited = false
 
-  // Visit `dir` when it is in-scope (a descendant of some prefix) or an
-  // ancestor of some prefix (must descend to reach the scoped subtree). No
-  // scope → visit every directory.
-  const scopePrefixes = scope && scope.length > 0 ? scope : undefined
-  const shouldVisitDir = (dir: string): boolean =>
-    !scopePrefixes ||
-    matchesAnyScope(dir, scopePrefixes) ||
-    scopePrefixes.some((prefix) => isUnderOrEqual(prefix, dir))
-
-  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(rootPath)
+  // Scope pushdown (shared with scanBaseDir via scope-match): visit a directory
+  // only if it is in-scope or an ancestor of the scoped subtree, and collect a
+  // file only if it is in-scope. A root intersecting no prefix is skipped
+  // without any `readdir`; absent scope leaves traversal/collection unchanged.
+  const queue: { dirPath: string; depth: number }[] = shouldVisitDir(rootPath, scope)
     ? [{ dirPath: rootPath, depth: 0 }]
     : []
 
@@ -117,11 +112,11 @@ export async function bfsCollectSupportedFiles(
       if (entry.isSymbolicLink()) continue
       if (excludePaths.some((ep) => fullPath.startsWith(ep))) continue
       if (entry.isDirectory()) {
-        if (shouldVisitDir(fullPath)) {
+        if (shouldVisitDir(fullPath, scope)) {
           queue.push({ dirPath: fullPath, depth: depth + 1 })
         }
       } else if (entry.isFile() && SUPPORTED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
-        if (!scopePrefixes || matchesAnyScope(fullPath, scopePrefixes)) {
+        if (isInScope(fullPath, scope)) {
           files.push(fullPath)
         }
       }

--- a/src/utils/scope-match.ts
+++ b/src/utils/scope-match.ts
@@ -1,0 +1,56 @@
+// Boundary-safe, exact-or-descendant path prefix matcher shared by both BFS
+// walkers and both list surfaces (MCP `list_files` and the `list` CLI).
+//
+// This is the JS counterpart of `vectordb`'s SQL `buildPrefixPredicate`
+// (`src/vectordb/index.ts`): both implement the same exact-or-descendant
+// contract (`path = prefix OR path startsWith prefix + separator`) with the
+// same separator-boundary and trailing-separator normalization, so `/foo/bar`
+// matches `/foo/bar` and `/foo/bar/x.md` but not `/foo/barista`. Both reference
+// #146's boundary rules — a change to one must be mirrored in the other.
+
+import { sep as PATH_SEP } from 'node:path'
+
+// Derive the boundary separator from the prefix, mirroring `buildPrefixPredicate`:
+// a `\`-style prefix uses `\`, a `/`-style prefix uses `/`, otherwise the
+// platform separator. (Caveat inherited from the SQL side: on posix, `\` is a
+// legal filename char, so a `/`-path containing `\` mis-derives the separator.)
+function deriveSeparator(prefix: string): string {
+  return prefix.includes('\\') ? '\\' : prefix.includes('/') ? '/' : PATH_SEP
+}
+
+// Strip trailing separators so `/a/b`, `/a/b/`, `/a/b//` normalize alike. A
+// prefix of only separators (e.g. a lone posix root `/`) is kept as a single
+// separator so its descendant boundary is `/<sep>` rather than empty.
+function stripTrailingSeparators(prefix: string, separator: string): string {
+  let end = prefix.length
+  while (end > 0 && prefix[end - 1] === separator) {
+    end--
+  }
+  if (end === 0) {
+    return separator
+  }
+  return prefix.slice(0, end)
+}
+
+/**
+ * True when `path` equals `prefix` or is a descendant of it, using a separator
+ * boundary so `/foo/bar` does not match `/foo/barista`. The separator is derived
+ * from `prefix`; trailing separators on `prefix` are normalized so `/a/b`,
+ * `/a/b/`, and `/a/b//` are equivalent. `path` is compared verbatim, matching
+ * the SQL contract in `buildPrefixPredicate`.
+ */
+export function isUnderOrEqual(path: string, prefix: string): boolean {
+  const separator = deriveSeparator(prefix)
+  const normalized = stripTrailingSeparators(prefix, separator)
+  const descendant = normalized.endsWith(separator) ? normalized : normalized + separator
+  return path === normalized || path.startsWith(descendant)
+}
+
+/**
+ * True when `path` is under-or-equal any prefix in `prefixes` (union). Empty or
+ * undefined `prefixes` semantics are the caller's concern; an empty list yields
+ * false (membership against no prefixes).
+ */
+export function matchesAnyScope(path: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => isUnderOrEqual(path, prefix))
+}

--- a/src/utils/scope-match.ts
+++ b/src/utils/scope-match.ts
@@ -54,3 +54,24 @@ export function isUnderOrEqual(path: string, prefix: string): boolean {
 export function matchesAnyScope(path: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => isUnderOrEqual(path, prefix))
 }
+
+/**
+ * Directory-visit predicate for the scoped BFS walk, shared by both walkers so
+ * the boundary semantics live in one place. Visit `dir` when there is no scope,
+ * when `dir` is in-scope (under-or-equal a prefix), or when `dir` is an ancestor
+ * of some prefix (must be descended to reach the scoped subtree). An absent or
+ * empty `scope` visits every directory (traversal unchanged).
+ */
+export function shouldVisitDir(dir: string, scope?: string[]): boolean {
+  if (!scope || scope.length === 0) return true
+  return matchesAnyScope(dir, scope) || scope.some((prefix) => isUnderOrEqual(prefix, dir))
+}
+
+/**
+ * File-collect predicate for the scoped BFS walk, shared by both walkers.
+ * Collect `path` when there is no scope, or when `path` is in-scope. An absent
+ * or empty `scope` collects every supported file (collection unchanged).
+ */
+export function isInScope(path: string, scope?: string[]): boolean {
+  return !scope || scope.length === 0 || matchesAnyScope(path, scope)
+}

--- a/src/utils/scope-match.ts
+++ b/src/utils/scope-match.ts
@@ -8,7 +8,7 @@
 // matches `/foo/bar` and `/foo/bar/x.md` but not `/foo/barista`. Both reference
 // #146's boundary rules — a change to one must be mirrored in the other.
 
-import { sep as PATH_SEP } from 'node:path'
+import { isAbsolute, sep as PATH_SEP } from 'node:path'
 
 // Derive the boundary separator from the prefix, mirroring `buildPrefixPredicate`:
 // a `\`-style prefix uses `\`, a `/`-style prefix uses `/`, otherwise the
@@ -53,6 +53,17 @@ export function isUnderOrEqual(path: string, prefix: string): boolean {
  */
 export function matchesAnyScope(path: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => isUnderOrEqual(path, prefix))
+}
+
+/**
+ * Return the prefixes in `scope` that are NOT absolute paths (server-OS path
+ * style, via `node:path` `isAbsolute` — the same path style scope matching
+ * uses). A non-absolute prefix matches nothing under the exact-or-descendant
+ * contract, so both list surfaces surface these as non-fatal warnings while
+ * preserving the "matches nothing" result semantics. Input order is preserved.
+ */
+export function nonAbsolutePrefixes(scope: string[]): string[] {
+  return scope.filter((prefix) => !isAbsolute(prefix))
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `scope` path-prefix filter to the `list_files` MCP tool and the `list` CLI subcommand, resolving the large-volume timeout reported in #165. `scope` is one absolute path prefix or a list (unioned), matched exact-or-descendant on each file's on-disk **scan path** — reusing the semantics locked for `query_documents` in #146.

The origin is a real timeout: on a volume with several thousand files, `list_files` enumerates the whole tree. Rather than filter the result after the fact (which would leave the walk cost intact), the scope predicate is **pushed into the BFS traversal** — a directory outside every prefix is never `readdir`'d — so a scoped listing costs work proportional to the scoped subtree instead of the whole volume.

Minor release: `0.15.4` → `0.16.0`. Fully backward compatible — omitting `scope` (and calling `list_files` with no arguments) behaves exactly as before.

## Behavior

- **`files[]`** is restricted to entries whose scan path is equal to or under a prefix; boundary-safe (`/docs/api` matches `/docs/api/x.md`, not `/docs/apiv2`).
- **`sources`**: `ingest_data` (raw-data) sources are always listed regardless of scope; real-file source entries respect scope. This split is applied by a shared `classifyIngestedSources` helper used by both surfaces.
- **Non-absolute prefix**: matches nothing (documented), and now surfaces a non-fatal warning (MCP: a warning content block; CLI: a stderr `Warning`, exit 0) so an empty result is explained rather than silent.
- **Empty/whitespace `scope`**: rejected at the boundary (MCP `McpError(InvalidParams)`; CLI non-zero exit).
- **No-arg `list_files`** (`arguments` omitted / `{}`) still returns the full listing — no regression.

## Path basis

`scope` is guaranteed over the on-disk reachable (scan) path, which makes the traversal pushdown exact. Under a symlinked/aliased root the returned `filePath` keeps its stored spelling while scope matches the reachable path; this edge is defined and fixture-covered.

## Implementation

- `src/utils/scope-match.ts` (new) — pure boundary-safe matcher (`isUnderOrEqual`, `matchesAnyScope`, `shouldVisitDir`, `isInScope`, `nonAbsolutePrefixes`), the JS counterpart of the SQL `buildPrefixPredicate`.
- `src/utils/list-sources.ts` (new) — pure `classifyIngestedSources` shared by the MCP handler and the CLI (removes a prior byte-for-byte duplication).
- Scope pushdown threaded into both BFS walkers (`scanBaseDir`, `bfsCollectSupportedFiles`) with a root gate before the first `readdir`.
- MCP boundary: `ListFilesInput` + `parseListFilesInput` (accepts `undefined`/`{}` as no-scope), scope on the `list_files` schema with scan-path-basis wording, warning content block.
- CLI: repeatable `--scope`, threading, and `HELP_TEXT`.
- Tool-schema description clarified so an MCP client learns from the in-protocol description alone that `sources` are `ingest_data` items and that scope filters files (not `ingest_data` sources).

## Tests

- Unit: `scope-match`, `list-sources`, `parseListFilesInput`, schema.
- Integration (real LanceDB + real-FS fixtures):
  - INT-2 — walker pushdown proven directly on **both** walkers via a `readdir` EACCES mock/spy (a scope-outside path is never visited), discriminating real pruning from a post-scan filter.
  - INT-1 / INT-3 — MCP handler / CLI scoped listing, sources split, and a scanned-file `realpath` spy.
  - Non-absolute-prefix warning tests on both surfaces.
- E2E: a service-integration-e2e spawning the real CLI `list --scope` against a real fixture.
- `pnpm run check:all` green (1047 tests); cross-platform-sensitive fixtures (symlink alias) skip on unsupported platforms rather than fail.

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)