### PR TITLE
Simplify core RAG workflows and prepare v0.16.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,6 @@ tmp/
 # Claude Code related (development guidelines and configurations)
 CLAUDE.md
 .claude/
+.agents/
+AGENTS.md
 docs/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",
@@ -46,7 +46,8 @@
     "watch": "tsx watch src/index.ts",
     "type-check": "tsc --noEmit",
     "type-check:test": "tsc -p tsconfig.test.json",
-    "test": "node scripts/run-vitest-with-device.mjs cpu run --exclude 'src/__tests__/e2e/visual-ingest-e2e.test.ts'",
+    "test": "node scripts/run-vitest-with-device.mjs cpu run --exclude 'src/__tests__/e2e/visual-ingest-e2e.test.ts' --exclude '**/*.perf.test.ts'",
+    "test:perf": "node scripts/run-vitest-with-device.mjs cpu run src/server/__tests__/rag-server.read-neighbors.perf.test.ts",
     "test:webgpu": "pnpm run test:webgpu:main-path",
     "test:webgpu:main-path": "node scripts/run-vitest-with-device.mjs webgpu run src/server/__tests__/rag-server.embedding.integration.test.ts src/server/__tests__/rag-server.ingest.integration.test.ts src/server/__tests__/rag-server.search.integration.test.ts src/__tests__/cli/ingest-cross-path-equivalence.test.ts",
     "test:webgpu:full": "node scripts/run-vitest-with-device.mjs webgpu run --exclude 'src/__tests__/e2e/visual-ingest-e2e.test.ts'",
@@ -76,17 +77,18 @@
     "turndown": "7.2.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
+    "@biomejs/biome": "^2.5.3",
     "@types/jsdom": "^28.0.3",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.1",
     "@types/turndown": "5.0.6",
     "dpdm": "^4.2.0",
     "husky": "^9.1.7",
-    "knip": "^6.23.0",
+    "knip": "^6.25.0",
     "lint-staged": "^17.0.8",
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.9"
+    "vite": "^7.3.6",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.9.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,14 +34,14 @@ importers:
         version: 7.2.4
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.1
-        version: 2.5.1
+        specifier: ^2.5.3
+        version: 2.5.3
       '@types/jsdom':
         specifier: ^28.0.3
         version: 28.0.3
       '@types/node':
-        specifier: ^26.0.1
-        version: 26.0.1
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/turndown':
         specifier: 5.0.6
         version: 5.0.6
@@ -52,20 +52,23 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       knip:
-        specifier: ^6.23.0
-        version: 6.23.0
+        specifier: ^6.25.0
+        version: 6.25.0
       lint-staged:
         specifier: ^17.0.8
         version: 17.0.8
       tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
+        specifier: ^4.23.0
+        version: 4.23.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^7.3.6
+        version: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
-        specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -84,59 +87,59 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@biomejs/biome@2.5.1':
-    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+  '@biomejs/biome@2.5.3':
+    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+  '@biomejs/cli-darwin-arm64@2.5.3':
+    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+  '@biomejs/cli-darwin-x64@2.5.3':
+    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
+    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.1':
-    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+  '@biomejs/cli-linux-arm64@2.5.3':
+    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+  '@biomejs/cli-linux-x64-musl@2.5.3':
+    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.1':
-    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+  '@biomejs/cli-linux-x64@2.5.3':
+    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+  '@biomejs/cli-win32-arm64@2.5.3':
+    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.1':
-    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+  '@biomejs/cli-win32-x64@2.5.3':
+    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -145,8 +148,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.2.1':
@@ -156,8 +159,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.1':
-    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -169,8 +172,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.4':
-    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -187,326 +190,170 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1148,153 +995,150 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
-    resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.62.0':
-    resolution: {integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==}
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.62.0':
-    resolution: {integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==}
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.62.0':
-    resolution: {integrity: sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==}
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
-    resolution: {integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==}
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.62.0':
-    resolution: {integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==}
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
-    resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
-    resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.62.0':
-    resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
-    resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
-    resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
-    resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
-    resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
-    resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
-    resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
-    resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
-    resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.62.0':
-    resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.62.0':
-    resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.62.0':
-    resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.62.0':
-    resolution: {integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==}
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.0':
-    resolution: {integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
-    resolution: {integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
-    resolution: {integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.62.0':
-    resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
@@ -1334,8 +1178,8 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -1343,11 +1187,11 @@ packages:
   '@types/turndown@5.0.6':
     resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
-  '@vitest/expect@4.1.9':
-    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.9':
-    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1357,20 +1201,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.9':
-    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.9':
-    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.9':
-    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.9':
-    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@4.1.9':
-    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -1384,8 +1228,8 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
     engines: {node: '>=12.0'}
 
   agentkeepalive@4.6.0:
@@ -1457,16 +1301,16 @@ packages:
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   bytes@3.1.2:
@@ -1669,8 +1513,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1683,13 +1527,8 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1718,16 +1557,16 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
@@ -1743,8 +1582,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -1799,8 +1638,8 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+  fs-extra@11.3.6:
+    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
@@ -1867,16 +1706,12 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.22:
-    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -1895,8 +1730,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   immediate@3.0.6:
@@ -1978,8 +1813,8 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
-  knip@6.23.0:
-    resolution: {integrity: sha512-2DvAOX2pZWiG4SLvRRxOAU0aWGEn1ZoVblI541xIoXFdHqq2THMZXy66/qcY5WGuW3TXhb9T1x1zd/Hd1u+yqg==}
+  knip@6.25.0:
+    resolution: {integrity: sha512-Q3n41VjOOB/aqsbxb8kallAcFKrUz3b2S5fD5pTODljVpP01t+rvAgy2x3j0Cq8yEpRRHNdar1vHuqFfGuIakQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1991,8 +1826,8 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+  listr2@10.2.2:
+    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
     engines: {node: '>=22.13.0'}
 
   lodash.camelcase@4.3.0:
@@ -2012,8 +1847,8 @@ packages:
   lop@0.4.2:
     resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
 
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -2084,8 +1919,8 @@ packages:
   mupdf@1.28.0:
     resolution: {integrity: sha512-ACUnbpECaQ5JLq04pwd89lS+0IGMest5qL5tb08g9TAR7bDtfqflHEkb2Xm3o4rvC/szguLiV+WEbW9kstj8Sg==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2119,8 +1954,9 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -2166,8 +2002,8 @@ packages:
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
 
-  ora@9.4.0:
-    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+  ora@9.4.1:
+    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
     engines: {node: '>=20'}
 
   oxc-parser@0.137.0:
@@ -2208,8 +2044,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -2219,15 +2055,15 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  protobufjs@7.6.1:
-    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -2238,12 +2074,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
@@ -2274,8 +2110,8 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rollup@4.62.0:
-    resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2296,8 +2132,8 @@ packages:
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2347,8 +2183,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2369,8 +2205,8 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.7.0:
+    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -2390,8 +2226,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -2405,8 +2241,8 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
     engines: {node: '>=20'}
 
   string_decoder@1.1.1:
@@ -2450,19 +2286,19 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.30:
-    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
 
-  tldts@7.0.30:
-    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
     hasBin: true
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
@@ -2475,8 +2311,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.4:
-    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2510,8 +2346,8 @@ packages:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
 
-  unbash@4.0.1:
-    resolution: {integrity: sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==}
+  unbash@4.0.2:
+    resolution: {integrity: sha512-8gwNZ29+0/3zmXw7ToIHZtg6wK37xnniRUdBt7B27xZxaxfgR5tGMaGHT0t0dLtBV9fXE7zurh0s6Z1DHVjfWg==}
     engines: {node: '>=14'}
 
   underscore@1.13.8:
@@ -2523,14 +2359,14 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.25.0:
-    resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
+  undici-types@7.28.0:
+    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
@@ -2548,8 +2384,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@7.1.12:
-    resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2588,20 +2424,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.9:
-    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.9
-      '@vitest/browser-preview': 4.1.9
-      '@vitest/browser-webdriverio': 4.1.9
-      '@vitest/coverage-istanbul': 4.1.9
-      '@vitest/coverage-v8': 4.1.9
-      '@vitest/ui': 4.1.9
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2738,7 +2574,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -2754,55 +2590,55 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@biomejs/biome@2.5.1':
+  '@biomejs/biome@2.5.3':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.1
-      '@biomejs/cli-darwin-x64': 2.5.1
-      '@biomejs/cli-linux-arm64': 2.5.1
-      '@biomejs/cli-linux-arm64-musl': 2.5.1
-      '@biomejs/cli-linux-x64': 2.5.1
-      '@biomejs/cli-linux-x64-musl': 2.5.1
-      '@biomejs/cli-win32-arm64': 2.5.1
-      '@biomejs/cli-win32-x64': 2.5.1
+      '@biomejs/cli-darwin-arm64': 2.5.3
+      '@biomejs/cli-darwin-x64': 2.5.3
+      '@biomejs/cli-linux-arm64': 2.5.3
+      '@biomejs/cli-linux-arm64-musl': 2.5.3
+      '@biomejs/cli-linux-x64': 2.5.3
+      '@biomejs/cli-linux-x64-musl': 2.5.3
+      '@biomejs/cli-win32-arm64': 2.5.3
+      '@biomejs/cli-win32-x64': 2.5.3
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
+  '@biomejs/cli-darwin-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.1':
+  '@biomejs/cli-darwin-x64@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.1':
+  '@biomejs/cli-linux-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
+  '@biomejs/cli-linux-x64-musl@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.1':
+  '@biomejs/cli-linux-x64@2.5.3':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.1':
+  '@biomejs/cli-win32-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.1':
+  '@biomejs/cli-win32-x64@2.5.3':
     optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
+      '@csstools/color-helpers': 6.1.0
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -2811,7 +2647,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -2829,11 +2665,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
@@ -2844,172 +2675,99 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.12':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
-  '@esbuild/linux-s390x@0.28.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
-
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@exodus/bytes@1.15.1': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.22)':
+  '@hono/node-server@1.19.14(hono@4.12.28)':
     dependencies:
-      hono: 4.12.22
+      hono: 4.12.28
 
   '@huggingface/jinja@0.3.4':
     optional: true
@@ -3182,12 +2940,12 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -3254,17 +3012,17 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.22)
+      '@hono/node-server': 1.19.14(hono@4.12.28)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.22
+      hono: 4.12.28
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3431,87 +3189,85 @@ snapshots:
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.2': {}
-
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.2': {}
 
-  '@rollup/rollup-android-arm-eabi@4.62.0':
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.62.0':
+  '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.62.0':
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.62.0':
+  '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.0':
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.62.0':
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.62.0':
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.62.0':
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.0':
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.62.0':
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.0':
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.0':
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.0':
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.62.0':
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.62.0':
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.62.0':
+  '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.62.0':
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.0':
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.0':
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.62.0':
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.62.0':
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
@@ -3540,14 +3296,14 @@ snapshots:
 
   '@types/jsdom@28.0.3':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
-      undici-types: 7.25.0
+      undici-types: 7.28.0
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       form-data: 4.0.6
     optional: true
 
@@ -3560,7 +3316,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@26.0.1':
+  '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -3568,44 +3324,44 @@ snapshots:
 
   '@types/turndown@5.0.6': {}
 
-  '@vitest/expect@4.1.9':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.9
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.9':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.9':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.9
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.9':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/utils': 4.1.9
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.9': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@4.1.9':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.9
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -3621,7 +3377,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.5.18: {}
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -3635,7 +3391,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3689,15 +3445,15 @@ snapshots:
 
   bluebird@3.4.7: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -3705,7 +3461,7 @@ snapshots:
 
   boolean@3.2.0: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3749,7 +3505,7 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   cliui@9.0.1:
     dependencies:
@@ -3872,9 +3628,9 @@ snapshots:
   dpdm@4.2.0:
     dependencies:
       chalk: 5.6.2
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       glob: 13.0.6
-      ora: 9.4.0
+      ora: 9.4.1
       tslib: 2.8.1
       typescript: 5.9.3
       yargs: 18.0.0
@@ -3903,7 +3659,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3914,68 +3670,39 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
     optional: true
 
   es6-error@4.1.1: {}
 
-  esbuild@0.25.12:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.28.0:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -3994,13 +3721,13 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.8: {}
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -4010,7 +3737,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -4029,8 +3756,8 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
+      qs: 6.15.3
+      range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
@@ -4042,15 +3769,15 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   finalhandler@2.1.1:
     dependencies:
@@ -4100,7 +3827,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-extra@11.3.5:
+  fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
@@ -4125,7 +3852,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -4149,7 +3876,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.8.1
+      semver: 7.8.5
       serialize-error: 7.0.1
 
   globalthis@1.0.4:
@@ -4176,16 +3903,11 @@ snapshots:
       has-symbols: 1.1.0
     optional: true
 
-  hasown@2.0.3:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
-  hono@4.12.22: {}
+  hono@4.12.28: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4208,7 +3930,7 @@ snapshots:
 
   husky@9.1.7: {}
 
-  iconv-lite@0.7.2:
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -4251,19 +3973,19 @@ snapshots:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
       '@exodus/bytes': 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.0
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
-      undici: 7.25.0
+      tough-cookie: 6.0.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4293,19 +4015,19 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
-  knip@6.23.0:
+  knip@6.25.0:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       formatly: 0.3.0
       get-tsconfig: 4.14.0
       jiti: 2.7.0
       oxc-parser: 0.137.0
       oxc-resolver: 11.21.3
-      picomatch: 4.0.4
-      smol-toml: 1.6.1
+      picomatch: 4.0.5
+      smol-toml: 1.7.0
       strip-json-comments: 5.0.3
       tinyglobby: 0.2.17
-      unbash: 4.0.1
+      unbash: 4.0.2
       yaml: 2.9.0
       zod: 4.4.3
 
@@ -4315,14 +4037,14 @@ snapshots:
 
   lint-staged@17.0.8:
     dependencies:
-      listr2: 10.2.1
-      picomatch: 4.0.4
+      listr2: 10.2.2
+      picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
-  listr2@10.2.1:
+  listr2@10.2.2:
     dependencies:
       cli-truncate: 5.2.0
       eventemitter3: 5.0.4
@@ -4353,7 +4075,7 @@ snapshots:
       option: 0.2.4
       underscore: 1.13.8
 
-  lru-cache@11.5.0: {}
+  lru-cache@11.5.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4409,7 +4131,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minipass@7.1.3: {}
 
@@ -4422,7 +4144,7 @@ snapshots:
 
   mupdf@1.28.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.15: {}
 
   negotiator@1.0.0: {}
 
@@ -4440,7 +4162,7 @@ snapshots:
 
   object-keys@1.1.1: {}
 
-  obug@2.1.1: {}
+  obug@2.1.3: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -4472,7 +4194,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.5.18
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
 
@@ -4483,7 +4205,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.20.0-dev.20241016-2b8fc5529b
       platform: 1.3.6
-      protobufjs: 7.6.1
+      protobufjs: 7.6.5
     optional: true
 
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
@@ -4493,7 +4215,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
-      protobufjs: 7.6.1
+      protobufjs: 7.6.5
 
   openai@4.29.2:
     dependencies:
@@ -4512,7 +4234,7 @@ snapshots:
 
   option@0.2.4: {}
 
-  ora@9.4.0:
+  ora@9.4.1:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
@@ -4521,7 +4243,7 @@ snapshots:
       is-unicode-supported: 2.1.0
       log-symbols: 7.0.1
       stdin-discarder: 0.3.2
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   oxc-parser@0.137.0:
     dependencies:
@@ -4584,7 +4306,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.0
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
@@ -4593,21 +4315,21 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   pkce-challenge@5.0.1: {}
 
   platform@1.3.6: {}
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   process-nextick-args@2.0.1: {}
 
-  protobufjs@7.6.1:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -4615,11 +4337,10 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 26.0.1
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.1
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -4629,17 +4350,18 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
-  range-parser@1.2.1: {}
+  range-parser@1.3.0: {}
 
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   readable-stream@2.3.8:
@@ -4674,35 +4396,35 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
-  rollup@4.62.0:
+  rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.0
-      '@rollup/rollup-android-arm64': 4.62.0
-      '@rollup/rollup-darwin-arm64': 4.62.0
-      '@rollup/rollup-darwin-x64': 4.62.0
-      '@rollup/rollup-freebsd-arm64': 4.62.0
-      '@rollup/rollup-freebsd-x64': 4.62.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.0
-      '@rollup/rollup-linux-arm64-gnu': 4.62.0
-      '@rollup/rollup-linux-arm64-musl': 4.62.0
-      '@rollup/rollup-linux-loong64-gnu': 4.62.0
-      '@rollup/rollup-linux-loong64-musl': 4.62.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.0
-      '@rollup/rollup-linux-ppc64-musl': 4.62.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.0
-      '@rollup/rollup-linux-riscv64-musl': 4.62.0
-      '@rollup/rollup-linux-s390x-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-gnu': 4.62.0
-      '@rollup/rollup-linux-x64-musl': 4.62.0
-      '@rollup/rollup-openbsd-x64': 4.62.0
-      '@rollup/rollup-openharmony-arm64': 4.62.0
-      '@rollup/rollup-win32-arm64-msvc': 4.62.0
-      '@rollup/rollup-win32-ia32-msvc': 4.62.0
-      '@rollup/rollup-win32-x64-gnu': 4.62.0
-      '@rollup/rollup-win32-x64-msvc': 4.62.0
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -4725,7 +4447,7 @@ snapshots:
 
   semver-compare@1.0.0: {}
 
-  semver@7.8.1: {}
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -4738,7 +4460,7 @@ snapshots:
       mime-types: 3.0.2
       ms: 2.1.3
       on-finished: 2.4.1
-      range-parser: 1.2.1
+      range-parser: 1.3.0
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4764,7 +4486,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -4791,7 +4513,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -4844,7 +4566,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -4871,7 +4593,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.7.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -4883,7 +4605,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.2.0: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -4895,7 +4617,7 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.1:
+  string-width@8.2.2:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
@@ -4936,22 +4658,22 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.30: {}
+  tldts-core@7.4.8: {}
 
-  tldts@7.0.30:
+  tldts@7.4.8:
     dependencies:
-      tldts-core: 7.0.30
+      tldts-core: 7.4.8
 
   toidentifier@1.0.1: {}
 
-  tough-cookie@6.0.1:
+  tough-cookie@6.0.2:
     dependencies:
-      tldts: 7.0.30
+      tldts: 7.4.8
 
   tr46@0.0.3:
     optional: true
@@ -4962,9 +4684,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.22.4:
+  tsx@4.23.0:
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -4988,7 +4710,7 @@ snapshots:
 
   typical@7.3.0: {}
 
-  unbash@4.0.1: {}
+  unbash@4.0.2: {}
 
   underscore@1.13.8: {}
 
@@ -4997,11 +4719,11 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.25.0: {}
+  undici-types@7.28.0: {}
 
   undici-types@8.3.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   universalify@2.0.1: {}
 
@@ -5011,45 +4733,45 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.62.0
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
-      tsx: 4.22.4
+      tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@26.0.1)(jsdom@29.1.1)(vite@7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.1.12(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -5101,7 +4823,7 @@ snapshots:
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
-      string-width: 8.2.1
+      string-width: 8.2.2
       strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/__tests__/cli/delete.test.ts
+++ b/src/__tests__/cli/delete.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     initialize: vi.fn(),
     deleteChunks: vi.fn(),
     optimize: vi.fn(),
+    close: vi.fn(),
     // fs.unlink
     unlink: vi.fn(),
   }
@@ -27,6 +28,7 @@ const cliCommonFactory = () => ({
     initialize: mocks.initialize,
     deleteChunks: mocks.deleteChunks,
     optimize: mocks.optimize,
+    close: mocks.close,
   })),
   // Catch-block renderer; faithful shim preserves the `Error: <message>`
   // stderr behavior the tests assert.
@@ -113,6 +115,7 @@ describe('CLI delete', () => {
     mocks.initialize.mockResolvedValue(undefined)
     mocks.deleteChunks.mockResolvedValue(0)
     mocks.optimize.mockResolvedValue(undefined)
+    mocks.close.mockResolvedValue(undefined)
     mocks.unlink.mockResolvedValue(undefined)
   })
 
@@ -221,7 +224,7 @@ describe('CLI delete', () => {
     const { generateMetaJsonPath, generateRawDataPath } = await import(
       '../../utils/raw-data-utils.js'
     )
-    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/meta-only', 'markdown')
+    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/meta-only')
     await mkdir(resolve(cleanupDbPath, 'raw-data'), { recursive: true })
     await writeFile(generateMetaJsonPath(mdPath), '{}')
 
@@ -272,7 +275,7 @@ describe('CLI delete', () => {
     // resolves and the cleanup branch runs. `unlink` is mocked so the file
     // stays on disk and is removed by the afterAll cleanup below.
     const { generateRawDataPath } = await import('../../utils/raw-data-utils.js')
-    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/page', 'markdown')
+    const mdPath = generateRawDataPath(cleanupDbPath, 'https://example.com/page')
     await mkdir(resolve(cleanupDbPath, 'raw-data'), { recursive: true })
     await writeFile(mdPath, 'fixture')
 
@@ -402,8 +405,8 @@ describe('CLI delete', () => {
 
     const { output, error } = await captureStderr(() => runDelete(['/path/to/file.md']))
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
 
     const joined = output.join('\n')
     expect(joined).toContain('DB write failed')
@@ -414,8 +417,8 @@ describe('CLI delete', () => {
 
     const { output, error } = await captureStderr(() => runDelete(['/path/to/file.md']))
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
 
     const joined = output.join('\n')
     expect(joined).toContain('Init failed')

--- a/src/__tests__/cli/ingest-cross-path-equivalence.test.ts
+++ b/src/__tests__/cli/ingest-cross-path-equivalence.test.ts
@@ -126,7 +126,7 @@ async function cliInlineIngest(
     title = result.title || null
   }
 
-  const { chunks, embeddings } = await buildChunksAndEmbeddings(text, title, chunker, embedder)
+  const { chunks, embeddings } = await buildChunksAndEmbeddings(text, chunker, embedder)
   if (chunks.length === 0) {
     return 0
   }

--- a/src/__tests__/cli/ingest-default-mode.test.ts
+++ b/src/__tests__/cli/ingest-default-mode.test.ts
@@ -191,19 +191,10 @@ let VectorStore: VectorStoreCtor
 // ============================================
 
 const GENERIC_PDF_PATH = '/tmp/test/default-mode-generic.pdf'
-const FIGURE_HEAVY_PDF_PATH = '/tmp/test/default-mode-figure-heavy.pdf'
 
 // Variant (a): generic content — no figure references.
 const GENERIC_PDF_CONTENT = 'plain pdf content for default-mode test'
 const GENERIC_PDF_TITLE = 'Generic Test Document'
-
-// Variant (b): figure-heavy content — names figures, tables, captions so the
-// adversarial intent is visible in the fixture. The dispatch site MUST still
-// stay on the default branch because `visual` is omitted.
-const FIGURE_HEAVY_PDF_CONTENT =
-  'Figure 1: Architecture diagram. Table 2: Benchmark results. ' +
-  'See caption below the inset image for details.'
-const FIGURE_HEAVY_PDF_TITLE = 'Figure-Heavy Test Document'
 
 // Deterministic chunker output — exactly 2 chunks regardless of input text.
 // Mirrors the shape used by `src/__tests__/cli/ingest.test.ts:163-167`.
@@ -424,87 +415,6 @@ describe('VLM PDF Enrichment - Default Mode (no --visual)', () => {
       expect(accessed.touched).toBe(false)
       expect(mocks.parsePdf).toHaveBeenCalledTimes(1)
       expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-    })
-  })
-
-  // AC-001 (NFR-1 strict): even if the file is a PDF that WOULD have visual
-  // candidates, the default path must not reach into pdf-visual. This is the
-  // adversarial form of the sentinel assertion — a fixture chosen to be the
-  // worst case for accidental dynamic import.
-  // ROI: 88 (BV:9 × Freq:8 + Legal:0 + Defect:8) — variant of AC-001
-  // Behavior: Ingest figure-heavy PDF without visual flag → sentinel stays false
-  // @category: core-functionality
-  // @lane: integration
-  // @dependency: ingestSingleFile, RAGServer.handleIngestFile, pdf-visual (Proxy sentinel)
-  // @complexity: medium
-  describe('AC-001 (NFR-1 strict): figure-heavy PDF in default mode does not trigger pdf-visual dynamic import', () => {
-    it('handleIngestFile: figure-heavy PDF default path keeps pdf-visual untouched', async () => {
-      // Arrange — parser is mocked, so the "figure-heavy" nature lives in the
-      // content string. The dispatch decision is purely based on `visual`
-      // (omitted) and file extension (.pdf), so this is the adversarial case:
-      // a reader inspecting the fixture sees content that screams "VLM-ready",
-      // yet the default branch must not reach pdf-visual.
-      mocks.parsePdf.mockResolvedValue({
-        content: FIGURE_HEAVY_PDF_CONTENT,
-        title: FIGURE_HEAVY_PDF_TITLE,
-      })
-      const server = buildServer()
-
-      // Act
-      await server.handleIngestFile({ filePath: FIGURE_HEAVY_PDF_PATH })
-
-      // Assert: NFR-1 strict — sentinel untouched even on adversarial fixture
-      expect(accessed.touched).toBe(false)
-      expect(accessed.prop).toBeUndefined()
-
-      // Assert: default PDF parser reached; visual parser NOT reached
-      expect(mocks.parsePdf).toHaveBeenCalledTimes(1)
-      expect(mocks.parsePdf).toHaveBeenCalledWith(FIGURE_HEAVY_PDF_PATH, expect.anything())
-      expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-
-      // Assert: chunks produced (count > 0 per task)
-      expect(mocks.insertChunks).toHaveBeenCalledTimes(1)
-      const insertedChunks = mocks.insertChunks.mock.calls[0]?.[0] as Array<unknown>
-      expect(insertedChunks.length).toBeGreaterThan(0)
-      expect(insertedChunks).toHaveLength(2)
-    })
-
-    it('ingestSingleFile: figure-heavy PDF default path keeps pdf-visual untouched', async () => {
-      // Arrange
-      mocks.parsePdf.mockResolvedValue({
-        content: FIGURE_HEAVY_PDF_CONTENT,
-        title: FIGURE_HEAVY_PDF_TITLE,
-      })
-      const parser = new DocumentParser({ baseDir: '/tmp/test', maxFileSize: 1024 * 1024 })
-      const chunker = new SemanticChunker({})
-      const embedder = new Embedder({
-        modelPath: 'mock-model',
-        batchSize: 16,
-        cacheDir: '/tmp/test/cache',
-      })
-      const vectorStore = new VectorStore({ dbPath: '/tmp/test/db', tableName: 'chunks' })
-
-      // Act — omit visual entirely
-      const chunkCount = await ingestSingleFile(
-        FIGURE_HEAVY_PDF_PATH,
-        parser,
-        chunker,
-        embedder,
-        vectorStore
-      )
-
-      // Assert: NFR-1 strict — sentinel untouched
-      expect(accessed.touched).toBe(false)
-      expect(accessed.prop).toBeUndefined()
-
-      // Assert: default PDF parser reached; visual parser NOT reached
-      expect(mocks.parsePdf).toHaveBeenCalledTimes(1)
-      expect(mocks.parsePdf).toHaveBeenCalledWith(FIGURE_HEAVY_PDF_PATH, expect.anything())
-      expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-
-      // Assert: chunks produced (count > 0 per task)
-      expect(chunkCount).toBe(2)
-      expect(mocks.insertChunks).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/__tests__/cli/list.test.ts
+++ b/src/__tests__/cli/list.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
     // VectorStore instance methods
     initialize: vi.fn().mockResolvedValue(undefined),
     listFiles: vi.fn().mockResolvedValue([]),
+    close: vi.fn().mockResolvedValue(undefined),
 
     // Shared CLI base-dirs resolver. Per-test impls can mirror precedence
     // (CLI roots replace env roots, env falls through to cwd) or simulate
@@ -41,6 +42,7 @@ const cliCommonFactory = () => ({
   createVectorStore: vi.fn().mockImplementation(() => ({
     initialize: mocks.initialize,
     listFiles: mocks.listFiles,
+    close: mocks.close,
   })),
   resolveCliBaseDirsOrExit: vi
     .fn()
@@ -202,7 +204,7 @@ describe('CLI list', () => {
     ])
 
     // Act
-    const { stdout, error } = await captureOutput(() => runList([]))
+    const { stdout, error } = await captureOutput(() => runList([], { dbPath: '/some/db' }))
 
     // Assert: no error
     expect(error).toBeUndefined()
@@ -281,7 +283,7 @@ describe('CLI list', () => {
     mocks.listFiles.mockResolvedValue([])
 
     // Act
-    const { stdout, error } = await captureOutput(() => runList([]))
+    const { stdout, error } = await captureOutput(() => runList([], { dbPath: '/some/db' }))
 
     // Assert
     expect(error).toBeUndefined()
@@ -325,7 +327,7 @@ describe('CLI list', () => {
     ])
 
     // Act
-    const { stdout, error } = await captureOutput(() => runList([]))
+    const { stdout, error } = await captureOutput(() => runList([], { dbPath: '/some/db' }))
 
     // Assert
     expect(error).toBeUndefined()
@@ -381,8 +383,8 @@ describe('CLI list', () => {
     const { stderr, error } = await captureOutput(() => runList([]))
 
     // Assert
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
     const joined = stderr.join('\n')
     expect(joined).toContain('DB connection failed')
   })

--- a/src/__tests__/cli/options.test.ts
+++ b/src/__tests__/cli/options.test.ts
@@ -263,29 +263,6 @@ describe('CLI global options', () => {
   })
 
   // ============================================
-  // ROOT_HELP_TEXT content
-  // ============================================
-  describe('ROOT_HELP_TEXT', () => {
-    it('should contain global options', () => {
-      expect(ROOT_HELP_TEXT).toContain('--db-path')
-      expect(ROOT_HELP_TEXT).toContain('--cache-dir')
-      expect(ROOT_HELP_TEXT).toContain('--model-name')
-      expect(ROOT_HELP_TEXT).toContain('-h, --help')
-    })
-
-    it('should contain available commands', () => {
-      expect(ROOT_HELP_TEXT).toContain('ingest')
-      expect(ROOT_HELP_TEXT).toContain('skills install')
-    })
-
-    it('should contain default values', () => {
-      expect(ROOT_HELP_TEXT).toContain('./lancedb/')
-      expect(ROOT_HELP_TEXT).toContain('./models/')
-      expect(ROOT_HELP_TEXT).toContain('Xenova/all-MiniLM-L6-v2')
-    })
-  })
-
-  // ============================================
   // validatePath
   // ============================================
   describe('validatePath', () => {

--- a/src/__tests__/cli/query.test.ts
+++ b/src/__tests__/cli/query.test.ts
@@ -38,11 +38,11 @@ const cliCommonFactory = () => ({
 })
 
 // NOTE: the mock factory below mirrors the NEW raw-data-utils contract.
-// `looksLikeRawDataPath` is the display-only heuristic CLI query uses; the
+// Managed raw-data detection is based on the configured database path; the
 // boundary check `isPathInRawDataDir` is exported for parity but unused by
 // the query subcommand (no path traversal surface).
 const rawDataUtilsFactory = () => ({
-  looksLikeRawDataPath: vi
+  isManagedRawDataPath: vi
     .fn()
     .mockImplementation((filePath: string) => filePath.includes('/raw-data/')),
   isPathInRawDataDir: vi.fn().mockResolvedValue(false),

--- a/src/__tests__/cli/read-neighbors.test.ts
+++ b/src/__tests__/cli/read-neighbors.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     // VectorStore instance methods used by runReadNeighbors
     initialize: vi.fn(),
     getChunksByRange: vi.fn(),
+    close: vi.fn(),
   }
 })
 
@@ -28,6 +29,7 @@ const cliCommonFactory = () => ({
   createVectorStore: vi.fn().mockImplementation(() => ({
     initialize: mocks.initialize,
     getChunksByRange: mocks.getChunksByRange,
+    close: mocks.close,
   })),
   // Catch-block renderer; faithful shim renders the full cause chain + stack
   // so the cause-chain-to-stderr assertions exercise real behavior, not a stub.
@@ -96,6 +98,7 @@ describe('CLI read-neighbors', () => {
     // Default: VectorStore methods succeed
     mocks.initialize.mockResolvedValue(undefined)
     mocks.getChunksByRange.mockResolvedValue([])
+    mocks.close.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -139,8 +142,8 @@ describe('CLI read-neighbors', () => {
       ])
     )
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
     expect(output.join('\n')).toContain('Cannot specify both --file-path and --source')
     expect(mocks.getChunksByRange).not.toHaveBeenCalled()
   })
@@ -151,8 +154,8 @@ describe('CLI read-neighbors', () => {
   it('should exit 1 when neither --file-path nor --source is provided', async () => {
     const { output, error } = await captureStderr(() => runReadNeighbors(['--chunk-index', '5']))
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
     expect(output.join('\n')).toContain('Either --file-path or --source is required')
     expect(mocks.getChunksByRange).not.toHaveBeenCalled()
   })
@@ -165,8 +168,8 @@ describe('CLI read-neighbors', () => {
       runReadNeighbors(['--file-path', '/abs/path.md'])
     )
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
     expect(output.join('\n')).toContain('--chunk-index')
     expect(mocks.getChunksByRange).not.toHaveBeenCalled()
   })
@@ -221,8 +224,8 @@ describe('CLI read-neighbors', () => {
       runReadNeighbors(['--file-path', '/abs/path.md', '--chunk-index', '5', '--before', '51'])
     )
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
     expect(output.join('\n')).toContain('before must be between 0 and 50')
     expect(mocks.getChunksByRange).not.toHaveBeenCalled()
   })
@@ -242,8 +245,8 @@ describe('CLI read-neighbors', () => {
     )
 
     // Exit code preserved (1).
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
 
     // Both the outer message and the root cause reach stderr (CLI is
     // operator-facing → cause chain printed, unlike the MCP boundary).

--- a/src/__tests__/cli/status.test.ts
+++ b/src/__tests__/cli/status.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     // VectorStore instance methods
     initialize: vi.fn(),
     getStatus: vi.fn(),
+    close: vi.fn(),
   }
 })
 
@@ -23,6 +24,7 @@ const cliCommonFactory = () => ({
   createVectorStore: vi.fn().mockImplementation(() => ({
     initialize: mocks.initialize,
     getStatus: mocks.getStatus,
+    close: mocks.close,
   })),
   // Catch-block renderer; faithful shim preserves the `Error: <message>`
   // stderr behavior the tests assert.
@@ -86,6 +88,7 @@ describe('CLI status', () => {
       })
     // Spy on process.stdout.write to capture JSON output
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    mocks.close.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -177,8 +180,8 @@ describe('CLI status', () => {
 
     const { output, error } = await captureStderr(() => runStatus([]))
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
 
     const joined = output.join('\n')
     expect(joined).toContain('DB connection failed')
@@ -189,8 +192,8 @@ describe('CLI status', () => {
 
     const { output, error } = await captureStderr(() => runStatus([]))
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).toBe('process.exit(1)')
+    expect(error).toBeUndefined()
+    expect(process.exitCode).toBe(1)
 
     const joined = output.join('\n')
     expect(joined).toContain('Init failed')

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -407,12 +407,6 @@ This is markdown content with **bold** and _italic_ text.
       const targetAfter = filesAfter.sources.find((f: { source: string }) => f.source === source)
       expect(targetAfter).toBeUndefined()
     })
-
-    it('delete_file throws error when neither filePath nor source provided', async () => {
-      await expect(server.handleDeleteFile({})).rejects.toThrow(
-        'Either filePath or source must be provided'
-      )
-    })
   })
 
   // --------------------------------------------

--- a/src/__tests__/server/raw-data-utils.test.ts
+++ b/src/__tests__/server/raw-data-utils.test.ts
@@ -9,11 +9,9 @@ import {
   decodeBase64Url,
   encodeBase64Url,
   extractSourceFromPath,
-  formatToExtension,
   generateRawDataPath,
   getRawDataDir,
   isPathInRawDataDir,
-  looksLikeRawDataPath,
   normalizeSource,
   saveRawData,
 } from '../../utils/raw-data-utils.js'
@@ -118,19 +116,6 @@ describe('Raw Data Utilities', () => {
   })
 
   // --------------------------------------------
-  // Format to Extension
-  // --------------------------------------------
-  describe('Format to Extension', () => {
-    it('returns .md for all formats (unified extension)', () => {
-      // All formats now return .md for consistency
-      // This allows generating unique path from source without knowing original format
-      expect(formatToExtension('html')).toBe('md')
-      expect(formatToExtension('markdown')).toBe('md')
-      expect(formatToExtension('text')).toBe('md')
-    })
-  })
-
-  // --------------------------------------------
   // Raw Data Directory
   // --------------------------------------------
   describe('Raw Data Directory', () => {
@@ -149,9 +134,7 @@ describe('Raw Data Utilities', () => {
     it('generates correct path with base64url encoded filename', () => {
       const dbPath = '/path/to/lancedb'
       const source = 'https://example.com/page'
-      const format = 'html' as const
-
-      const path = generateRawDataPath(dbPath, source, format)
+      const path = generateRawDataPath(dbPath, source)
 
       expect(path).toContain(`raw-data${sep}`)
       expect(path).toMatch(/\.md$/) // All formats use .md extension
@@ -166,9 +149,9 @@ describe('Raw Data Utilities', () => {
       const source2 = 'https://example.com/page#section'
       const source3 = 'https://example.com/page'
 
-      const path1 = generateRawDataPath(dbPath, source1, 'html')
-      const path2 = generateRawDataPath(dbPath, source2, 'html')
-      const path3 = generateRawDataPath(dbPath, source3, 'html')
+      const path1 = generateRawDataPath(dbPath, source1)
+      const path2 = generateRawDataPath(dbPath, source2)
+      const path3 = generateRawDataPath(dbPath, source3)
 
       // All should generate the same path (normalized source is the same)
       expect(path1).toBe(path2)
@@ -183,9 +166,7 @@ describe('Raw Data Utilities', () => {
     it('saves content to raw-data directory and returns file path', async () => {
       const source = 'https://example.com/test-page'
       const content = '<html><body>Test content</body></html>'
-      const format = 'html' as const
-
-      const savedPath = await saveRawData(testDbPath, source, content, format)
+      const savedPath = await saveRawData(testDbPath, source, content)
 
       // Verify file was saved
       const savedContent = await readFile(savedPath, 'utf-8')
@@ -202,9 +183,7 @@ describe('Raw Data Utilities', () => {
 
       const source = 'https://example.com/new-page'
       const content = 'Test content'
-      const format = 'text' as const
-
-      const savedPath = await saveRawData(newDbPath, source, content, format)
+      const savedPath = await saveRawData(newDbPath, source, content)
 
       // Verify file was saved
       const savedContent = await readFile(savedPath, 'utf-8')
@@ -216,32 +195,15 @@ describe('Raw Data Utilities', () => {
 
     it('overwrites existing file with same source', async () => {
       const source = 'https://example.com/overwrite-test'
-      const format = 'text' as const
-
       // Save initial content
-      await saveRawData(testDbPath, source, 'Original content', format)
+      await saveRawData(testDbPath, source, 'Original content')
 
       // Save updated content
-      const savedPath = await saveRawData(testDbPath, source, 'Updated content', format)
+      const savedPath = await saveRawData(testDbPath, source, 'Updated content')
 
       // Verify content was updated
       const savedContent = await readFile(savedPath, 'utf-8')
       expect(savedContent).toBe('Updated content')
-    })
-  })
-
-  // --------------------------------------------
-  // Path Detection
-  // --------------------------------------------
-  describe('Path Detection (display heuristic)', () => {
-    it('looksLikeRawDataPath returns true for raw-data paths', () => {
-      expect(looksLikeRawDataPath('/path/to/lancedb/raw-data/abc123.html')).toBe(true)
-      expect(looksLikeRawDataPath('./lancedb/raw-data/xyz.txt')).toBe(true)
-    })
-
-    it('looksLikeRawDataPath returns false for non-raw-data paths', () => {
-      expect(looksLikeRawDataPath('/path/to/documents/file.pdf')).toBe(false)
-      expect(looksLikeRawDataPath('/home/user/raw-data-backup/file.txt')).toBe(false)
     })
   })
 
@@ -321,7 +283,7 @@ describe('Raw Data Utilities', () => {
   describe('Source Extraction', () => {
     it('extractSourceFromPath extracts original source from raw-data path', () => {
       const originalSource = 'https://example.com/page'
-      const filePath = generateRawDataPath(testDbPath, originalSource, 'html')
+      const filePath = generateRawDataPath(testDbPath, originalSource)
 
       const extractedSource = extractSourceFromPath(filePath)
 
@@ -344,7 +306,7 @@ describe('Raw Data Utilities', () => {
       ]
 
       for (const source of sources) {
-        const savedPath = await saveRawData(testDbPath, source, 'content', 'text')
+        const savedPath = await saveRawData(testDbPath, source, 'content')
         const extractedSource = extractSourceFromPath(savedPath)
 
         // For URLs, the source will be normalized

--- a/src/cli/delete.ts
+++ b/src/cli/delete.ts
@@ -122,10 +122,9 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
 
   // Resolve global config
   const globalConfig = resolveGlobalConfig(globalOptions)
+  const vectorStore = createVectorStore(globalConfig)
 
   try {
-    // Create and initialize VectorStore (no Embedder needed for delete)
-    const vectorStore = createVectorStore(globalConfig)
     await vectorStore.initialize()
 
     // Determine target file path
@@ -133,7 +132,7 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
 
     if (parsed.source) {
       // Generate raw-data path from source URL
-      targetPath = generateRawDataPath(globalConfig.dbPath, parsed.source, 'markdown')
+      targetPath = generateRawDataPath(globalConfig.dbPath, parsed.source)
     } else {
       // DB key is the resolve()'d ingest path, so look up by resolve() (never
       // realpath) — realpath stays in validatePath/validateFilePath.
@@ -196,6 +195,8 @@ export async function runDelete(args: string[], globalOptions: GlobalOptions = {
   } catch (error) {
     const reason = formatCliError(error)
     console.error(`Error: ${reason}`)
-    process.exit(1)
+    process.exitCode = 1
+  } finally {
+    await vectorStore.close()
   }
 }

--- a/src/cli/ingest.ts
+++ b/src/cli/ingest.ts
@@ -376,7 +376,7 @@ export async function ingestSingleFile(
   }
 
   // Chunk text + generate embeddings via the shared computation layer.
-  const { chunks, embeddings } = await buildChunksAndEmbeddings(text, title, chunker, embedder)
+  const { chunks, embeddings } = await buildChunksAndEmbeddings(text, chunker, embedder)
   if (chunks.length === 0) {
     console.error(`  Warning: 0 chunks generated (file may be empty or too short)`)
     return 0
@@ -448,10 +448,8 @@ export async function runIngest(args: string[], globalOptions: GlobalOptions = {
     console.error(warning.message)
   }
 
-  // Collect files: when `targetPath` is a directory, the scan iterates every
-  // effective root in `config.baseDirs.baseDirs`; the positional directory
-  // only triggers directory mode and is no longer the scan target.
-  // Single-file mode is unchanged. See `collectFiles` for the full rationale.
+  // Directory mode scans only the positional directory; configured roots are
+  // the containment boundary used by collectFiles and DocumentParser.
   const files = await collectFiles(targetPath, config.baseDirs.baseDirs, excludePaths)
   if (files.length === 0) {
     console.error('No supported files found.')

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -2,10 +2,10 @@
 
 import { resolve, sep } from 'node:path'
 
+import { listDocuments } from '../features/list.js'
 import { displayPath } from '../utils/base-dirs.js'
 import { MAX_SCAN_DEPTH } from '../utils/limits.js'
-import { classifyIngestedSources } from '../utils/list-sources.js'
-import { bfsCollectSupportedFiles, realpathForMatch } from '../utils/scan.js'
+import { bfsCollectSupportedFiles } from '../utils/scan.js'
 import { nonAbsolutePrefixes } from '../utils/scope-match.js'
 import { createVectorStore, formatCliError, resolveCliBaseDirsOrExit } from './common.js'
 import type { GlobalOptions } from './options.js'
@@ -281,9 +281,8 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
   }
   const baseDir = firstRawBaseDir
 
+  const vectorStore = createVectorStore(globalConfig)
   try {
-    // Initialize VectorStore only (no Embedder needed for list)
-    const vectorStore = createVectorStore(globalConfig)
     await vectorStore.initialize()
 
     // Build exclude paths (resolved to absolute, platform-aware trailing
@@ -295,68 +294,21 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
       `${resolve(globalConfig.cacheDir)}${sep}`,
     ]
 
-    // Get ingested entries and index by file IDENTITY (realpath), so a file
-    // ingested via a different spelling (symlinked prefix or alias) still
-    // matches the scan. realpath is used only for this "same file?" comparison;
-    // storage/display stay normal-path (see utils/base-dirs.ts BaseDirsConfig).
     const ingested = await vectorStore.listFiles()
-    const ingestedKeyed = await Promise.all(
-      ingested.map(async (f) => ({ entry: f, key: await realpathForMatch(f.filePath) }))
-    )
-    const ingestedByKey = new Map(ingestedKeyed.map(({ entry, key }) => [key, entry]))
-
-    // Scan every effective root, deduping by identity key (a file reachable
-    // from multiple roots — via symlinks/bind mounts — appears once, first root
-    // wins). Per-root errors are non-fatal stderr warnings.
-    const keyToRoot = new Map<string, string>()
-    const keyToScanned = new Map<string, string>()
-    for (const root of rawBaseDirs) {
-      const { files: perRoot, warnings: rootWarnings } = await scanRoot(
-        root,
-        excludePaths,
-        options.scope
-      )
-      for (const warning of rootWarnings) {
-        console.error(`Warning [${root}]: ${warning}`)
-      }
-      for (const scannedPath of perRoot) {
-        const key = await realpathForMatch(scannedPath)
-        if (!keyToRoot.has(key)) {
-          keyToRoot.set(key, root)
-          keyToScanned.set(key, scannedPath)
-        }
-      }
+    const listed = await listDocuments({
+      roots: rawBaseDirs,
+      dbPath: globalConfig.dbPath,
+      ingested,
+      scope: options.scope,
+      scan: (root, scope) => scanRoot(root, excludePaths, scope),
+    })
+    for (const warning of listed.warnings) {
+      console.error(`Warning [${warning.baseDir}]: ${warning.message}`)
     }
 
-    // Ingested rows display the stored (normal) path so it round-trips into
-    // delete/read; not-ingested rows display the scanned path.
-    const matchedKeys = new Set<string>()
-    const files: FileEntry[] = [...keyToRoot.entries()].map(([key, producingRoot]) => {
-      const entry = ingestedByKey.get(key)
-      if (entry) {
-        matchedKeys.add(key)
-        return {
-          filePath: entry.filePath,
-          baseDir: producingRoot,
-          ingested: true,
-          chunkCount: entry.chunkCount,
-          timestamp: entry.timestamp,
-        }
-      }
-      return { filePath: keyToScanned.get(key) ?? key, baseDir: producingRoot, ingested: false }
-    })
+    const files: FileEntry[] = listed.files
     files.sort((a, b) => (a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0))
-
-    // Content ingested via ingest_data plus orphaned DB entries: ingested
-    // entries whose identity key matched no scanned file. With `scope` present,
-    // raw-data sources are always kept while real-file entries are scope-filtered
-    // (see `classifyIngestedSources`); scope-absent behavior is unchanged. The
-    // same helper backs the MCP `list_files` surface, so both stay identical.
-    const sources: SourceEntry[] = classifyIngestedSources(
-      ingestedKeyed,
-      matchedKeys,
-      options.scope
-    )
+    const sources: SourceEntry[] = listed.sources
 
     const result: ListResult = {
       baseDirs: [...rawBaseDirs],
@@ -370,6 +322,8 @@ export async function runList(args: string[], globalOptions: GlobalOptions = {})
   } catch (error) {
     const message = formatCliError(error)
     console.error(`Failed to list files: ${message}`)
-    process.exit(1)
+    process.exitCode = 1
+  } finally {
+    await vectorStore.close()
   }
 }

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -1,6 +1,6 @@
 // CLI query subcommand — search ingested documents
 
-import { extractSourceFromPath, looksLikeRawDataPath } from '../utils/raw-data-utils.js'
+import { extractSourceFromPath, isManagedRawDataPath } from '../utils/raw-data-utils.js'
 import { createEmbedder, createVectorStore, formatCliError } from './common.js'
 import type { GlobalOptions } from './options.js'
 import { requireFlagValue, resolveGlobalConfig } from './options.js'
@@ -201,7 +201,7 @@ export async function runQuery(args: string[], globalOptions: GlobalOptions = {}
         fileTitle: result.fileTitle ?? null,
       }
 
-      if (looksLikeRawDataPath(result.filePath)) {
+      if (isManagedRawDataPath(result.filePath, globalConfig.dbPath)) {
         const source = extractSourceFromPath(result.filePath)
         if (source) {
           output.source = source

--- a/src/cli/read-neighbors.ts
+++ b/src/cli/read-neighbors.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 import {
   extractSourceFromPath,
   generateRawDataPath,
-  looksLikeRawDataPath,
+  isManagedRawDataPath,
 } from '../utils/raw-data-utils.js'
 import { createVectorStore, formatCliError } from './common.js'
 import type { GlobalOptions } from './options.js'
@@ -202,7 +202,7 @@ export async function runReadNeighbors(
     let targetPath: string
     if (parsed.source !== undefined) {
       // Generate raw-data path from source identifier.
-      targetPath = generateRawDataPath(globalConfig.dbPath, parsed.source, 'markdown')
+      targetPath = generateRawDataPath(globalConfig.dbPath, parsed.source)
     } else {
       // DB key is the resolve()'d ingest path, so look up by resolve() (never
       // realpath); validate below (mirrors runDelete; realpath stays there).
@@ -214,44 +214,42 @@ export async function runReadNeighbors(
       }
     }
 
-    // Create and initialize VectorStore (no embedder needed for index-only read).
     const vectorStore = createVectorStore(globalConfig)
-    await vectorStore.initialize()
+    try {
+      await vectorStore.initialize()
 
-    // Range composition (handler-side clamp; primitive stays feature-agnostic).
-    const minIdx = Math.max(0, chunkIndex - before)
-    const maxIdx = chunkIndex + after
+      const minIdx = Math.max(0, chunkIndex - before)
+      const maxIdx = chunkIndex + after
+      const rows = await vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
 
-    // Primitive call.
-    const rows = await vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
+      const isRaw = isManagedRawDataPath(targetPath, globalConfig.dbPath)
+      const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
+      const items = rows.map((row) => {
+        const item: {
+          filePath: string
+          chunkIndex: number
+          text: string
+          isTarget: boolean
+          fileTitle: string | null
+          source?: string
+        } = {
+          filePath: row.filePath,
+          chunkIndex: row.chunkIndex,
+          text: row.text,
+          isTarget: row.chunkIndex === chunkIndex,
+          fileTitle: row.fileTitle ?? null,
+        }
+        if (sourceForAll) item.source = sourceForAll
+        return item
+      })
 
-    // Post-fetch marking: isTarget per item; source attached for raw-data rows.
-    const isRaw = looksLikeRawDataPath(targetPath)
-    const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
-    const items = rows.map((row) => {
-      const item: {
-        filePath: string
-        chunkIndex: number
-        text: string
-        isTarget: boolean
-        fileTitle: string | null
-        source?: string
-      } = {
-        filePath: row.filePath,
-        chunkIndex: row.chunkIndex,
-        text: row.text,
-        isTarget: row.chunkIndex === chunkIndex,
-        fileTitle: row.fileTitle ?? null,
-      }
-      if (sourceForAll) item.source = sourceForAll
-      return item
-    })
-
-    // Output JSON to stdout (2-space indent per query.ts convention).
-    process.stdout.write(`${JSON.stringify(items, null, 2)}\n`)
+      process.stdout.write(`${JSON.stringify(items, null, 2)}\n`)
+    } finally {
+      await vectorStore.close()
+    }
   } catch (error) {
     const reason = formatCliError(error)
     console.error(`Error: ${reason}`)
-    process.exit(1)
+    process.exitCode = 1
   }
 }

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -70,10 +70,9 @@ export async function runStatus(args: string[], globalOptions: GlobalOptions = {
 
   // Resolve global config
   const globalConfig = resolveGlobalConfig(globalOptions)
+  const vectorStore = createVectorStore(globalConfig)
 
   try {
-    // Create and initialize VectorStore (no Embedder needed for status)
-    const vectorStore = createVectorStore(globalConfig)
     await vectorStore.initialize()
 
     // Get status
@@ -84,6 +83,8 @@ export async function runStatus(args: string[], globalOptions: GlobalOptions = {
   } catch (error) {
     const reason = formatCliError(error)
     console.error(`Error: ${reason}`)
-    process.exit(1)
+    process.exitCode = 1
+  } finally {
+    await vectorStore.close()
   }
 }

--- a/src/features/list.ts
+++ b/src/features/list.ts
@@ -1,0 +1,77 @@
+import { type ClassifiedSource, classifyIngestedSources } from '../utils/list-sources.js'
+import { realpathForMatch } from '../utils/scan.js'
+
+export interface IngestedFileSummary {
+  filePath: string
+  chunkCount: number
+  timestamp: string
+}
+
+export type ListedFile =
+  | {
+      filePath: string
+      baseDir: string
+      ingested: true
+      chunkCount: number
+      timestamp: string
+    }
+  | { filePath: string; baseDir: string; ingested: false }
+
+export interface RootScanResult {
+  files: string[]
+  warnings: string[]
+}
+
+export interface ListDocumentsResult {
+  files: ListedFile[]
+  sources: ClassifiedSource[]
+  warnings: Array<{ baseDir: string; message: string }>
+}
+
+export async function listDocuments(input: {
+  roots: readonly string[]
+  dbPath: string
+  ingested: IngestedFileSummary[]
+  scope?: string[] | undefined
+  scan: (root: string, scope?: string[] | undefined) => Promise<RootScanResult>
+}): Promise<ListDocumentsResult> {
+  const ingestedKeyed = await Promise.all(
+    input.ingested.map(async (entry) => ({ entry, key: await realpathForMatch(entry.filePath) }))
+  )
+  const ingestedByKey = new Map(ingestedKeyed.map(({ entry, key }) => [key, entry]))
+  const seenKeys = new Set<string>()
+  const matchedKeys = new Set<string>()
+  const files: ListedFile[] = []
+  const warnings: Array<{ baseDir: string; message: string }> = []
+
+  for (const baseDir of input.roots) {
+    const scanned = await input.scan(baseDir, input.scope)
+    warnings.push(...scanned.warnings.map((message) => ({ baseDir, message })))
+
+    for (const scannedPath of scanned.files) {
+      const key = await realpathForMatch(scannedPath)
+      if (seenKeys.has(key)) continue
+      seenKeys.add(key)
+
+      const entry = ingestedByKey.get(key)
+      if (entry) {
+        matchedKeys.add(key)
+        files.push({
+          filePath: entry.filePath,
+          baseDir,
+          ingested: true,
+          chunkCount: entry.chunkCount,
+          timestamp: entry.timestamp,
+        })
+      } else {
+        files.push({ filePath: scannedPath, baseDir, ingested: false })
+      }
+    }
+  }
+
+  return {
+    files,
+    sources: classifyIngestedSources(ingestedKeyed, matchedKeys, input.dbPath, input.scope),
+    warnings,
+  }
+}

--- a/src/ingest/compute.ts
+++ b/src/ingest/compute.ts
@@ -30,7 +30,6 @@ import type { VectorChunk } from '../vectordb/index.js'
 export interface BuildChunksAndEmbeddingsResult {
   chunks: TextChunk[]
   embeddings: number[][]
-  title: string | null
 }
 
 /**
@@ -55,7 +54,6 @@ export interface BuildChunksAndEmbeddingsResult {
  */
 export async function buildChunksAndEmbeddings(
   text: string,
-  title: string | null,
   chunker: SemanticChunker,
   embedder: EmbedderInterface
 ): Promise<BuildChunksAndEmbeddingsResult> {
@@ -65,10 +63,10 @@ export async function buildChunksAndEmbeddings(
   // cold cache) BEFORE checking for the empty-array short-circuit, so an
   // empty file would otherwise pay the model-load cost for no work.
   if (chunks.length === 0) {
-    return { chunks: [], embeddings: [], title }
+    return { chunks: [], embeddings: [] }
   }
   const embeddings = await embedder.embedBatch(chunks.map((chunk) => chunk.text))
-  return { chunks, embeddings, title }
+  return { chunks, embeddings }
 }
 
 /**

--- a/src/ingest/visual.ts
+++ b/src/ingest/visual.ts
@@ -134,7 +134,7 @@ export async function prepareVisualPdfChunks(
     // emitted as dedicated chunks below so the semantic chunker cannot split
     // their internal Summary / Keywords structure on sentence-boundary
     // vocabulary shifts.
-    const { chunks, embeddings } = await buildChunksAndEmbeddings(text, null, chunker, embedder)
+    const { chunks, embeddings } = await buildChunksAndEmbeddings(text, chunker, embedder)
 
     const titleResult = extractPdfTitle(
       metadataTitle,

--- a/src/server/__tests__/rag-server.metadata.integration.test.ts
+++ b/src/server/__tests__/rag-server.metadata.integration.test.ts
@@ -139,11 +139,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
     expect(ingestData.chunkCount).toBeGreaterThan(0)
 
     // Derive the raw-data .md path and .meta.json path
-    const rawDataPath = generateRawDataPath(
-      localTestDbPath,
-      'https://example.com/meta-json-test',
-      'markdown'
-    )
+    const rawDataPath = generateRawDataPath(localTestDbPath, 'https://example.com/meta-json-test')
     const metaJsonPath = generateMetaJsonPath(rawDataPath)
 
     // Verify .meta.json exists and has correct content (read raw file, not via loadMetaJson)
@@ -175,8 +171,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
     // Verify .meta.json (read raw file, not via loadMetaJson)
     const rawDataPath = generateRawDataPath(
       localTestDbPath,
-      'https://example.com/markdown-meta-test',
-      'markdown'
+      'https://example.com/markdown-meta-test'
     )
     const metaJsonPath = generateMetaJsonPath(rawDataPath)
     const metaRaw = JSON.parse(await readFile(metaJsonPath, 'utf-8'))
@@ -203,11 +198,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
     })
 
     // Verify .meta.json (read raw file, not via loadMetaJson)
-    const rawDataPath = generateRawDataPath(
-      localTestDbPath,
-      'https://example.com/text-meta-test',
-      'markdown'
-    )
+    const rawDataPath = generateRawDataPath(localTestDbPath, 'https://example.com/text-meta-test')
     const metaJsonPath = generateMetaJsonPath(rawDataPath)
     const metaRaw = JSON.parse(await readFile(metaJsonPath, 'utf-8'))
     expect(metaRaw.title).toBe('My Text Document Title')
@@ -250,8 +241,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
     // Find results from this specific source
     const rawDataPath = generateRawDataPath(
       localTestDbPath,
-      'https://example.com/duplication-check',
-      'markdown'
+      'https://example.com/duplication-check'
     )
     const relevantResults = results.filter((r: { filePath: string }) => r.filePath === rawDataPath)
     expect(relevantResults.length).toBeGreaterThan(0)
@@ -294,11 +284,7 @@ describe('Meta JSON Sidecar Pipeline', () => {
     })
 
     // Verify files exist before deletion
-    const rawDataPath = generateRawDataPath(
-      localTestDbPath,
-      'https://example.com/delete-meta-test',
-      'markdown'
-    )
+    const rawDataPath = generateRawDataPath(localTestDbPath, 'https://example.com/delete-meta-test')
     const metaJsonPath = generateMetaJsonPath(rawDataPath)
 
     expect(existsSync(rawDataPath)).toBe(true)

--- a/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.integration.test.ts
@@ -14,14 +14,13 @@
 //   - afterAll: rmSync tmp dirs recursively
 //   - Use handleIngestFile / handleIngestData to seed real chunks
 
-import { randomUUID } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
-import { looksLikeRawDataPath } from '../../utils/raw-data-utils.js'
-import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
+import { isManagedRawDataPath } from '../../utils/raw-data-utils.js'
+import type { VectorStore } from '../../vectordb/index.js'
 import { RAGServer } from '../index.js'
 import type { ReadChunkNeighborsInput, ReadChunkNeighborsResultItem } from '../types.js'
 
@@ -523,7 +522,7 @@ describe('read_chunk_neighbors integration', () => {
       const filePaths = new Set(items.map((i) => i.filePath))
       expect(filePaths.size).toBe(1)
       const sharedPath = items[0]?.filePath ?? ''
-      expect(looksLikeRawDataPath(sharedPath)).toBe(true)
+      expect(isManagedRawDataPath(sharedPath, testDbPath)).toBe(true)
 
       const targets = items.filter((i) => i.isTarget)
       expect(targets).toHaveLength(1)
@@ -630,167 +629,6 @@ describe('read_chunk_neighbors integration', () => {
         // source key is either absent or undefined on file-backed items
         expect(item.source).toBeUndefined()
       }
-    })
-  })
-
-  // =============================================================================
-  // Test 7: P95 under 100ms on 10k chunk document (NFR)
-  // =============================================================================
-  // AC: PRD Non-Functional Requirement "P95 under 100 ms for a window of
-  //     before=2, after=2 on a document with up to 10,000 chunks, measured in
-  //     CI on the default GitHub Actions runner."
-  // ROI: 85 (BV:8 x Freq:10 + Legal:0 + Defect:5)
-  // Behavior: Seed a LanceDB table with 10,000 chunks for a single filePath ->
-  //   warm up with 3 discarded calls -> measure 20 consecutive neighbor calls
-  //   -> assert computed P95 < 100 ms.
-  // @category: core-functionality
-  // @dependency: RAGServer, VectorStore, LanceDB
-  // @complexity: high
-  //
-  // Setup (per Design Doc §Performance Measurement Mechanism):
-  //   - Insert 10,000 contiguous chunks for one synthetic filePath. Use a
-  //     small constant vector (e.g., zeros of embedding dimension) to keep
-  //     insertion fast; this is setup, not part of the measured section.
-  //   - Consider bypassing the full handleIngestFile pipeline (which invokes
-  //     the real embedder) by inserting directly through vectorStore if the
-  //     existing test helper (createTestChunk from vectordb unit tests)
-  //     allows — otherwise accept longer setup and rely on vitest's 10s
-  //     default timeout; if setup exceeds that, split via beforeAll so only
-  //     the measured section runs under the per-test timeout.
-  //
-  // Measurement protocol:
-  //   - Warm up: call handleReadChunkNeighbors 3 times with before=2, after=2
-  //     on varied chunkIndex values (e.g., 100, 5000, 9500); discard timings.
-  //   - Measurement: call handleReadChunkNeighbors 20 times with before=2,
-  //     after=2 on a varied set of chunkIndex values spanning start / middle /
-  //     end (e.g., a cycle through [50, 2500, 5000, 7500, 9950] four times).
-  //   - Record per-call wall-clock using performance.now() deltas (start
-  //     BEFORE the call, end AFTER the awaited promise resolves).
-  //   - Sort timings ascending; P95 = timings[Math.ceil(0.95 * 20) - 1]
-  //     (index 18 of the sorted 20-element array, i.e., the 19th smallest).
-  //
-  // Verification items:
-  //   - All 20 measured calls resolve without throwing
-  //   - P95 value is a finite number > 0 (sanity)
-  //   - P95 < 100 (milliseconds)
-  //   - Emit the observed P95 via console.error(`P95: ${p95.toFixed(2)} ms`)
-  //     so CI logs capture the value for the PR description (PRD Success
-  //     Criteria 2)
-  //
-  // Pass criteria:
-  //   - P95 strictly below 100 ms.
-  //   - On failure, the failure message includes the full timings array for
-  //     the PR author (Design Doc §Performance Measurement Mechanism).
-  //
-  // Flake mitigation note:
-  //   - The 100 ms target includes headroom vs. the expected operation cost
-  //     on GitHub Actions shared runners (Design Doc §Risks). If the test
-  //     flakes in practice, relax to P95 < 150 ms and record the observed
-  //     distribution per Design Doc mitigation guidance.
-  describe('Test 7: P95 under 100ms on 10k chunk document (NFR)', () => {
-    let ragServer: RAGServer
-    const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-t7')
-    const testDataDir = resolve('./tmp/test-data-read-neighbors-t7')
-    // Synthetic path must live under baseDir so validateFilePath accepts it.
-    // The file itself need not exist on disk (must exist as a real path for
-    // validation: writeFileSync an empty file).
-    const syntheticFilePath = resolve(testDataDir, 'read-neighbors-perf.txt')
-    const TOTAL_CHUNKS = 10000
-    const EMBEDDING_DIM = 384
-
-    beforeAll(async () => {
-      mkdirSync(testDbPath, { recursive: true })
-      mkdirSync(testDataDir, { recursive: true })
-      // Create a minimal placeholder file so validateFilePath's realpath/BASE_DIR
-      // check succeeds. Content is irrelevant — we bypass ingest and write chunks
-      // directly via vectorStore.insertChunks.
-      writeFileSync(syntheticFilePath, 'placeholder')
-      ragServer = createTestRagServer({
-        dbPath: testDbPath,
-        modelName: 'Xenova/all-MiniLM-L6-v2',
-        cacheDir: testModelCacheDir(),
-        baseDir: testDataDir,
-        maxFileSize: 100 * 1024 * 1024,
-      })
-      await ragServer.initialize()
-
-      // Direct vectorStore insertion bypasses the embedder pipeline for speed.
-      // Use a constant small vector — content matters for predicate filtering,
-      // not for the (unused-here) search pathway.
-      const vectorStore = getVectorStore(ragServer)
-      const timestamp = new Date().toISOString()
-      const constantVector = new Array(EMBEDDING_DIM).fill(0.01)
-
-      // Insert in batches of 1000 to keep each insert call modest.
-      const BATCH = 1000
-      for (let start = 0; start < TOTAL_CHUNKS; start += BATCH) {
-        const end = Math.min(start + BATCH, TOTAL_CHUNKS)
-        const batch: VectorChunk[] = []
-        for (let i = start; i < end; i++) {
-          batch.push({
-            id: randomUUID(),
-            filePath: syntheticFilePath,
-            chunkIndex: i,
-            text: `synthetic chunk ${i}`,
-            vector: constantVector,
-            metadata: {
-              fileName: 'read-neighbors-perf.txt',
-              fileSize: 0,
-              fileType: 'txt',
-            },
-            fileTitle: null,
-            timestamp,
-          })
-        }
-        await vectorStore.insertChunks(batch)
-      }
-      await vectorStore.optimize()
-    }, 120000)
-
-    afterAll(async () => {
-      await ragServer.close()
-      rmSync(testDbPath, { recursive: true, force: true })
-      rmSync(testDataDir, { recursive: true, force: true })
-    })
-
-    it('P95 of 20 neighbor reads under 100 ms', async () => {
-      // Warm-up (discard timings): varied indices to avoid cold-cache bias
-      for (const warmIdx of [100, 5000, 9500]) {
-        await ragServer.handleReadChunkNeighbors({
-          filePath: syntheticFilePath,
-          chunkIndex: warmIdx,
-        })
-      }
-
-      // Measurement: 20 calls cycling through start/middle/end indices
-      const cycle = [50, 2500, 5000, 7500, 9950]
-      const timings: number[] = []
-      for (let iter = 0; iter < 4; iter++) {
-        for (const idx of cycle) {
-          const start = performance.now()
-          await ragServer.handleReadChunkNeighbors({
-            filePath: syntheticFilePath,
-            chunkIndex: idx,
-          })
-          timings.push(performance.now() - start)
-        }
-      }
-
-      expect(timings).toHaveLength(20)
-      const sorted = [...timings].sort((a, b) => a - b)
-      // P95 at n=20: Math.ceil(0.95 * 20) - 1 = index 18 (19th smallest)
-      const p95 = sorted[Math.ceil(0.95 * 20) - 1] ?? Number.NaN
-
-      // Emit for PR description capture (PRD Success Criteria 2)
-      console.error(`P95: ${p95.toFixed(2)} ms`)
-
-      expect(Number.isFinite(p95)).toBe(true)
-      expect(p95).toBeGreaterThan(0)
-
-      expect(
-        p95,
-        `P95 latency ${p95.toFixed(2)} ms exceeds 100 ms threshold. Timings: ${JSON.stringify(timings)}`
-      ).toBeLessThan(100)
     })
   })
 
@@ -1092,7 +930,7 @@ describe('read_chunk_neighbors integration', () => {
       expect(items.length).toBeGreaterThan(0)
       const filePaths = new Set(items.map((i) => i.filePath))
       expect(filePaths.size).toBe(1)
-      expect(looksLikeRawDataPath(items[0]?.filePath ?? '')).toBe(true)
+      expect(isManagedRawDataPath(items[0]?.filePath ?? '', testDbPath)).toBe(true)
       for (const item of items) {
         expect(item.source).toBe(SOURCE)
       }

--- a/src/server/__tests__/rag-server.read-neighbors.perf.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.perf.test.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { testModelCacheDir, withTestDevice } from '../../__tests__/test-device.js'
+import type { VectorChunk, VectorStore } from '../../vectordb/index.js'
+import { RAGServer } from '../index.js'
+
+function createTestRagServer(config: ConstructorParameters<typeof RAGServer>[0]): RAGServer {
+  return new RAGServer(withTestDevice(config))
+}
+
+function getVectorStore(server: RAGServer): VectorStore {
+  return (server as unknown as { vectorStore: VectorStore }).vectorStore
+}
+
+describe('read_chunk_neighbors performance', () => {
+  let ragServer: RAGServer
+  const testDbPath = resolve('./tmp/test-lancedb-read-neighbors-perf')
+  const testDataDir = resolve('./tmp/test-data-read-neighbors-perf')
+  const syntheticFilePath = resolve(testDataDir, 'read-neighbors-perf.txt')
+
+  beforeAll(async () => {
+    mkdirSync(testDbPath, { recursive: true })
+    mkdirSync(testDataDir, { recursive: true })
+    writeFileSync(syntheticFilePath, 'placeholder')
+    ragServer = createTestRagServer({
+      dbPath: testDbPath,
+      modelName: 'Xenova/all-MiniLM-L6-v2',
+      cacheDir: testModelCacheDir(),
+      baseDir: testDataDir,
+      maxFileSize: 100 * 1024 * 1024,
+    })
+    await ragServer.initialize()
+
+    const vectorStore = getVectorStore(ragServer)
+    const timestamp = new Date().toISOString()
+    const vector = new Array(384).fill(0.01)
+    for (let start = 0; start < 10_000; start += 1_000) {
+      const batch: VectorChunk[] = []
+      for (let index = start; index < start + 1_000; index++) {
+        batch.push({
+          id: randomUUID(),
+          filePath: syntheticFilePath,
+          chunkIndex: index,
+          text: `synthetic chunk ${index}`,
+          vector,
+          metadata: { fileName: 'read-neighbors-perf.txt', fileSize: 0, fileType: 'txt' },
+          fileTitle: null,
+          timestamp,
+        })
+      }
+      await vectorStore.insertChunks(batch)
+    }
+    await vectorStore.optimize()
+  }, 120_000)
+
+  afterAll(async () => {
+    await ragServer.close()
+    rmSync(testDbPath, { recursive: true, force: true })
+    rmSync(testDataDir, { recursive: true, force: true })
+  })
+
+  it('keeps P95 below 100 ms for a 10,000-chunk document', async () => {
+    for (const chunkIndex of [100, 5_000, 9_500]) {
+      await ragServer.handleReadChunkNeighbors({ filePath: syntheticFilePath, chunkIndex })
+    }
+
+    const timings: number[] = []
+    for (let iteration = 0; iteration < 4; iteration++) {
+      for (const chunkIndex of [50, 2_500, 5_000, 7_500, 9_950]) {
+        const start = performance.now()
+        await ragServer.handleReadChunkNeighbors({ filePath: syntheticFilePath, chunkIndex })
+        timings.push(performance.now() - start)
+      }
+    }
+
+    const p95 = [...timings].sort((a, b) => a - b)[18] ?? Number.NaN
+    console.error(`P95: ${p95.toFixed(2)} ms`)
+    expect(Number.isFinite(p95)).toBe(true)
+    expect(
+      p95,
+      `P95 latency ${p95.toFixed(2)} ms exceeds 100 ms. Timings: ${JSON.stringify(timings)}`
+    ).toBeLessThan(100)
+  })
+})

--- a/src/server/__tests__/tool-input.test.ts
+++ b/src/server/__tests__/tool-input.test.ts
@@ -1,9 +1,12 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { describe, expect, it } from 'vitest'
 import {
+  parseDeleteFileInput,
   parseIngestDataInput,
+  parseIngestFileInput,
   parseListFilesInput,
   parseQueryDocumentsInput,
+  parseReadChunkNeighborsInput,
 } from '../tool-input.js'
 
 describe('parseQueryDocumentsInput', () => {
@@ -210,5 +213,69 @@ describe('parseIngestDataInput', () => {
     ['non-string format', { content: 'b', metadata: { source: 's', format: 1 } }],
   ])('rejects %s', (_label, raw) => {
     expect(() => parseIngestDataInput(raw)).toThrow(/metadata\.format must be one of/)
+  })
+})
+
+describe('parseIngestFileInput', () => {
+  it('accepts and preserves valid options', () => {
+    expect(
+      parseIngestFileInput({ filePath: '/docs/a.pdf', visual: true, visualQuality: 'quality' })
+    ).toEqual({
+      filePath: '/docs/a.pdf',
+      visual: true,
+      visualQuality: 'quality',
+    })
+  })
+
+  it.each([
+    undefined,
+    null,
+    {},
+    { filePath: '' },
+    { filePath: 1 },
+  ])('rejects malformed input %#', (raw) =>
+    expect(() => parseIngestFileInput(raw)).toThrow(McpError))
+
+  it.each(['true', 1, null])('rejects visual=%j', (visual) => {
+    expect(() => parseIngestFileInput({ filePath: '/docs/a.pdf', visual })).toThrow(
+      /visual.*boolean/
+    )
+  })
+})
+
+describe('parseDeleteFileInput', () => {
+  it.each([
+    [{ filePath: '/docs/a.md' }, { filePath: '/docs/a.md' }],
+    [{ source: 'https://example.com' }, { source: 'https://example.com' }],
+  ])('accepts one document reference', (raw, expected) => {
+    expect(parseDeleteFileInput(raw)).toEqual(expected)
+  })
+
+  it.each([
+    undefined,
+    null,
+    {},
+    { filePath: '', source: '' },
+    { filePath: '/a', source: 's' },
+  ])('rejects malformed or non-XOR input %#', (raw) =>
+    expect(() => parseDeleteFileInput(raw)).toThrow(McpError))
+})
+
+describe('parseReadChunkNeighborsInput', () => {
+  it('accepts a valid range request', () => {
+    expect(
+      parseReadChunkNeighborsInput({ filePath: '/docs/a.md', chunkIndex: 3, before: 1, after: 4 })
+    ).toEqual({ filePath: '/docs/a.md', chunkIndex: 3, before: 1, after: 4 })
+  })
+
+  it.each([
+    undefined,
+    {},
+    { filePath: '/a', chunkIndex: -1 },
+    { filePath: '/a', chunkIndex: 1.5 },
+    { filePath: '/a', chunkIndex: 0, before: 51 },
+    { filePath: '/a', chunkIndex: 0, after: -1 },
+  ])('rejects malformed input %#', (raw) => {
+    expect(() => parseReadChunkNeighborsInput(raw)).toThrow(McpError)
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 // RAGServer implementation with MCP tools
 
 import { readFile, unlink } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { resolve, sep } from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
@@ -12,28 +13,26 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { DEFAULT_MIN_CHUNK_LENGTH, SemanticChunker } from '../chunker/index.js'
 import { Embedder } from '../embedder/index.js'
+import { listDocuments } from '../features/list.js'
 import { buildChunksAndEmbeddings, buildVectorChunks } from '../ingest/compute.js'
 import { prepareVisualPdfChunks } from '../ingest/visual.js'
 import { parseHtml } from '../parser/html-parser.js'
 import { DocumentParser } from '../parser/index.js'
 import { extractMarkdownTitle, extractTxtTitle } from '../parser/title-extractor.js'
 import type { BaseDirsConfigError } from '../utils/base-dirs.js'
-import { classifyIngestedSources } from '../utils/list-sources.js'
 import {
-  type ContentFormat,
   checkRawDataArtifacts,
   extractSourceFromPath,
   generateMetaJsonPath,
   generateRawDataPath,
   isEnoent,
+  isManagedRawDataPath,
   isPathInRawDataDir,
   isPathInRawDataDirLexical,
   loadMetaJson,
-  looksLikeRawDataPath,
   saveMetaJson,
   saveRawData,
 } from '../utils/raw-data-utils.js'
-import { realpathForMatch } from '../utils/scan.js'
 import { nonAbsolutePrefixes } from '../utils/scope-match.js'
 import { type VectorChunk, VectorStore } from '../vectordb/index.js'
 import { DatabaseError } from '../vectordb/types.js'
@@ -48,23 +47,23 @@ import {
 import { normalizeBaseDirs, scanBaseDir } from './list-scanner.js'
 import { toolDefinitions } from './tool-definitions.js'
 import {
+  parseDeleteFileInput,
   parseIngestDataInput,
+  parseIngestFileInput,
   parseListFilesInput,
   parseQueryDocumentsInput,
+  parseReadChunkNeighborsInput,
 } from './tool-input.js'
 import type {
-  DeleteFileInput,
   DeleteFileResult,
   FileEntry,
   IngestDataInput,
-  IngestFileInput,
   IngestResult,
   ListFilesInput,
   ListFilesResult,
   QueryDocumentsInput,
   QueryResult,
   RAGServerConfig,
-  ReadChunkNeighborsInput,
   ReadChunkNeighborsResultItem,
   SourceEntry,
 } from './types.js'
@@ -89,6 +88,9 @@ const TOOL_ERROR_CONTEXT: Record<string, ToMcpErrorContext> = {
   list_files: {},
   status: {},
 }
+
+const packageVersion = (createRequire(import.meta.url)('../../package.json') as { version: string })
+  .version
 
 /** RAG server compliant with MCP Protocol */
 export class RAGServer {
@@ -149,7 +151,7 @@ export class RAGServer {
     this.device = config.device
     this.excludePaths = [`${resolve(this.dbPath)}${sep}`, `${resolve(this.cacheDir)}${sep}`]
     this.server = new Server(
-      { name: 'rag-mcp-server', version: '1.0.0' },
+      { name: 'rag-mcp-server', version: packageVersion },
       { capabilities: { tools: {} } }
     )
 
@@ -256,19 +258,13 @@ export class RAGServer {
                 parseQueryDocumentsInput(request.params.arguments)
               )
             case 'ingest_file':
-              return await this.handleIngestFile(
-                request.params.arguments as unknown as IngestFileInput
-              )
+              return await this.handleIngestFile(request.params.arguments)
             case 'ingest_data':
               return await this.handleIngestData(parseIngestDataInput(request.params.arguments))
             case 'delete_file':
-              return await this.handleDeleteFile(
-                request.params.arguments as unknown as DeleteFileInput
-              )
+              return await this.handleDeleteFile(request.params.arguments)
             case 'read_chunk_neighbors':
-              return await this.handleReadChunkNeighbors(
-                request.params.arguments as unknown as ReadChunkNeighborsInput
-              )
+              return await this.handleReadChunkNeighbors(request.params.arguments)
             case 'list_files':
               return await this.handleListFiles(parseListFilesInput(request.params.arguments))
             case 'status':
@@ -327,7 +323,7 @@ export class RAGServer {
         fileTitle: result.fileTitle ?? null,
       }
 
-      if (looksLikeRawDataPath(result.filePath)) {
+      if (isManagedRawDataPath(result.filePath, this.dbPath)) {
         const source = extractSourceFromPath(result.filePath)
         if (source) {
           queryResult.source = source
@@ -352,7 +348,8 @@ export class RAGServer {
   /**
    * ingest_file tool handler (re-ingestion support, transaction processing, rollback capability)
    */
-  async handleIngestFile(args: IngestFileInput): Promise<{ content: RagContentBlock[] }> {
+  async handleIngestFile(raw: unknown): Promise<{ content: RagContentBlock[] }> {
+    const args = parseIngestFileInput(raw)
     // Skip the configError gate only for paths structurally inside
     // `<dbPath>/raw-data/` (internal invocation from handleIngestData).
     if (!(await isPathInRawDataDir(args.filePath, this.dbPath))) {
@@ -361,32 +358,8 @@ export class RAGServer {
     // `args.filePath` is the DB key (backup/delete/insert/result), stored
     // verbatim so lookups match (realpath stays in validateFilePath; see
     // BaseDirsConfig for the path policy).
-    // Runtime validation: the MCP JSON Schema declares `visual` as a
-    // boolean and `IngestFileInput.visual` types it as `boolean | undefined`,
-    // but tool arguments arrive as `unknown` at the SDK boundary so the
-    // structural type is not enforced by the compiler. Validation fires
-    // BEFORE any parser/chunker/embedder/vectorStore access.
-    const visualArg: unknown = args.visual
-    if (visualArg !== undefined && typeof visualArg !== 'boolean') {
-      throw new McpError(ErrorCode.InvalidParams, "'visual' must be a boolean if provided")
-    }
-
-    // Runtime validation + normalization of `visualQuality`. The MCP boundary
-    // receives `unknown`, so the JSON Schema enum is necessary but not
-    // sufficient. Some MCP clients send `""` for unspecified optional
-    // parameters; accept both `undefined` and `""` and normalize to `'fast'`
-    // so the internal `QualityProfile` type stays narrow.
-    const visualQualityArg: unknown = (args as { visualQuality?: unknown }).visualQuality
-    let visualQuality: 'fast' | 'quality' = 'fast'
-    if (visualQualityArg !== undefined && visualQualityArg !== '') {
-      if (visualQualityArg !== 'fast' && visualQualityArg !== 'quality') {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          "'visualQuality' must be 'fast' or 'quality' if provided"
-        )
-      }
-      visualQuality = visualQualityArg
-    }
+    const visualArg = args.visual
+    const visualQuality = args.visualQuality ?? 'fast'
 
     let backup: VectorChunk[] | null = null
 
@@ -407,12 +380,7 @@ export class RAGServer {
       const meta = await loadMetaJson(args.filePath)
       title = meta?.title ?? null
       console.error(`Read raw-data file: ${args.filePath} (${text.length} characters)`)
-      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(
-        text,
-        title,
-        this.chunker,
-        this.embedder
-      ))
+      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(text, this.chunker, this.embedder))
     } else if (visualArg === true && isPdf) {
       // Visual dispatch delegates to `prepareVisualPdfChunks`, which owns
       // the dynamic `pdf-visual` import so the default path does not load
@@ -437,22 +405,12 @@ export class RAGServer {
       const result = await this.parser.parsePdf(args.filePath, this.embedder)
       text = result.content
       title = result.title || null
-      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(
-        text,
-        title,
-        this.chunker,
-        this.embedder
-      ))
+      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(text, this.chunker, this.embedder))
     } else {
       const result = await this.parser.parseFile(args.filePath)
       text = result.content
       title = result.title || null
-      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(
-        text,
-        title,
-        this.chunker,
-        this.embedder
-      ))
+      ;({ chunks, embeddings } = await buildChunksAndEmbeddings(text, this.chunker, this.embedder))
     }
 
     // Fail-fast: Prevent data loss when chunking produces 0 chunks
@@ -558,7 +516,6 @@ export class RAGServer {
     // to the central dispatcher mapper. The inner raw-data rollback try/catch
     // below is retained — it is local-effect (file cleanup) only.
     let contentToSave = args.content
-    let formatToSave: ContentFormat = args.metadata.format
     let title: string | null = null
 
     // Per-format title extraction and content preparation
@@ -577,7 +534,6 @@ export class RAGServer {
 
       title = htmlTitle || null
       contentToSave = markdown
-      formatToSave = 'markdown' // Save as .md file
       console.error(`Converted HTML to Markdown: ${markdown.length} characters`)
     } else if (args.metadata.format === 'markdown') {
       const result = extractMarkdownTitle(args.content, args.metadata.source)
@@ -589,12 +545,7 @@ export class RAGServer {
     }
 
     // Save content to raw-data directory
-    const rawDataPath = await saveRawData(
-      this.dbPath,
-      args.metadata.source,
-      contentToSave,
-      formatToSave
-    )
+    const rawDataPath = await saveRawData(this.dbPath, args.metadata.source, contentToSave)
 
     // Save metadata sidecar (.meta.json) alongside the raw-data file
     await saveMetaJson(rawDataPath, {
@@ -655,60 +606,16 @@ export class RAGServer {
         : Array.isArray(input.scope)
           ? input.scope
           : [input.scope]
-    // Get all ingested entries and index them by file IDENTITY (realpath), so
-    // a file ingested via a different spelling (symlinked prefix or alias)
-    // still matches the scan. Storage/display stay normal-path; realpath is
-    // used here only for the "same file?" comparison (see BaseDirsConfig).
     const ingested = await this.vectorStore.listFiles()
-    const ingestedKeyed = await Promise.all(
-      ingested.map(async (f) => ({ entry: f, key: await realpathForMatch(f.filePath) }))
-    )
-    const ingestedByKey = new Map(ingestedKeyed.map(({ entry, key }) => [key, entry]))
-
-    // Scan each effective root (normal-path `rawBaseDirs`), dedup by identity
-    // key (a file reachable from multiple roots appears once, first root wins),
-    // and cross-reference by that key. Per-root scan warnings are surfaced via
-    // `withWarnings` below.
-    const files: FileEntry[] = []
-    const seenKeys = new Set<string>()
-    const matchedKeys = new Set<string>()
-    const scanWarnings: string[] = []
-    for (const baseDir of this.rawBaseDirs) {
-      const { files: scanned, warnings: rootWarnings } = await scanBaseDir(
-        baseDir,
-        this.excludePaths,
-        scope
-      )
-      for (const w of rootWarnings) {
-        scanWarnings.push(`[${baseDir}] ${w}`)
-      }
-      for (const scannedPath of scanned) {
-        const key = await realpathForMatch(scannedPath)
-        if (seenKeys.has(key)) continue
-        seenKeys.add(key)
-        const entry = ingestedByKey.get(key)
-        // Ingested rows display the stored (normal) path so it round-trips
-        // into delete/read; not-ingested rows display the scanned path.
-        files.push(
-          entry
-            ? {
-                filePath: entry.filePath,
-                baseDir,
-                ingested: true,
-                chunkCount: entry.chunkCount,
-                timestamp: entry.timestamp,
-              }
-            : { filePath: scannedPath, baseDir, ingested: false }
-        )
-        if (entry) matchedKeys.add(key)
-      }
-    }
-
-    // Content ingested via ingest_data plus orphaned DB entries: ingested
-    // entries whose identity key matched no scanned file. With `scope` present,
-    // raw-data sources are always kept while real-file entries are scope-filtered
-    // (see `classifyIngestedSources`); scope-absent behavior is unchanged.
-    const sources: SourceEntry[] = classifyIngestedSources(ingestedKeyed, matchedKeys, scope)
+    const listed = await listDocuments({
+      roots: this.rawBaseDirs,
+      dbPath: this.dbPath,
+      ingested,
+      scope,
+      scan: (baseDir, scanScope) => scanBaseDir(baseDir, this.excludePaths, scanScope),
+    })
+    const files: FileEntry[] = listed.files
+    const sources: SourceEntry[] = listed.sources
 
     const result: ListFilesResult = {
       baseDir: this.rawBaseDir,
@@ -722,8 +629,11 @@ export class RAGServer {
     // to inspect stderr. Config-level warnings (`configWarnings`) are
     // still appended via `withWarnings`.
     const content: RagContentBlock[] = [{ type: 'text', text: JSON.stringify(result, null, 2) }]
-    for (const w of scanWarnings) {
-      content.push({ type: 'text', text: `Warning: ${w}` })
+    for (const warning of listed.warnings) {
+      content.push({
+        type: 'text',
+        text: `Warning: [${warning.baseDir}] ${warning.message}`,
+      })
     }
     // A non-absolute scope prefix matches nothing (the scan is absolute-path
     // based) but yields no result-level signal, so surface it as a non-fatal
@@ -773,7 +683,8 @@ export class RAGServer {
    * Deletes chunks from VectorDB and physical raw-data files
    * Supports both filePath (for ingest_file) and source (for ingest_data)
    */
-  async handleDeleteFile(args: DeleteFileInput): Promise<{ content: RagContentBlock[] }> {
+  async handleDeleteFile(raw: unknown): Promise<{ content: RagContentBlock[] }> {
+    const args = parseDeleteFileInput(raw)
     // No outer error-mapping catch: the inline `McpError(InvalidParams)` and
     // `assertConfigOk` throw propagate with original identity to the central
     // dispatcher mapper. The inner unlink try/catch blocks below are
@@ -781,14 +692,14 @@ export class RAGServer {
     let targetPath: string
     let skipValidation = false
 
-    if (args.source) {
+    if ('source' in args) {
       // Generate raw-data path from source (extension is always .md)
       // Internal path generation is secure, skip baseDir validation.
       // The `source` branch never touches `baseDirs`, so it stays callable
       // in degraded mode (configError present).
-      targetPath = generateRawDataPath(this.dbPath, args.source, 'markdown')
+      targetPath = generateRawDataPath(this.dbPath, args.source)
       skipValidation = true
-    } else if (args.filePath) {
+    } else {
       // Root-dependent branch: a user-supplied filePath is validated against
       // the configured roots, so we must fail fast when the config is
       // invalid. Placed AFTER the `source` branch so source-mode requests
@@ -797,10 +708,6 @@ export class RAGServer {
       // DB key = the verbatim resolve()-stored path; look up as-is (realpath
       // stays in validateFilePath; see BaseDirsConfig for the path policy).
       targetPath = args.filePath
-    } else {
-      // Missing required input is a client error → InvalidParams (matches
-      // read_chunk_neighbors); a plain Error would surface as InternalError.
-      throw new McpError(ErrorCode.InvalidParams, 'Either filePath or source must be provided')
     }
 
     // Only validate user-provided filePath (not internally generated paths)
@@ -867,41 +774,14 @@ export class RAGServer {
    * Context-expansion utility — not a search tool. Mirrors handleDeleteFile's
    * dual-input (filePath XOR source) resolution pattern.
    */
-  async handleReadChunkNeighbors(
-    args: ReadChunkNeighborsInput
-  ): Promise<{ content: RagContentBlock[] }> {
-    // No local error-mapping catch: the inline `McpError(InvalidParams)` input
-    // checks and `assertConfigOk` throw propagate with original identity to the
+  async handleReadChunkNeighbors(raw: unknown): Promise<{ content: RagContentBlock[] }> {
+    const args = parseReadChunkNeighborsInput(raw)
+    // No local error-mapping catch: `assertConfigOk` errors propagate with original identity to the
     // central dispatcher mapper. A `DatabaseError` reaches the mapper as a
     // recognized `AppError` and so stays prefix-less (no "Failed to read chunk
     // neighbors" prefix); only a native error picks up that prefix.
-    // Validate everything before DB access. This handler intentionally uses
-    // structured InvalidParams errors for input validation.
-    if (!Number.isInteger(args.chunkIndex) || args.chunkIndex < 0) {
-      throw new McpError(ErrorCode.InvalidParams, 'chunkIndex must be a non-negative integer')
-    }
     const before = args.before ?? 2
-    if (!Number.isInteger(before) || before < 0) {
-      throw new McpError(ErrorCode.InvalidParams, 'before must be a non-negative integer')
-    }
-    if (before > 50) {
-      throw new McpError(ErrorCode.InvalidParams, `before must be between 0 and 50 (got ${before})`)
-    }
     const after = args.after ?? 2
-    if (!Number.isInteger(after) || after < 0) {
-      throw new McpError(ErrorCode.InvalidParams, 'after must be a non-negative integer')
-    }
-    if (after > 50) {
-      throw new McpError(ErrorCode.InvalidParams, `after must be between 0 and 50 (got ${after})`)
-    }
-    const hasFilePath = typeof args.filePath === 'string' && args.filePath.trim().length > 0
-    const hasSource = typeof args.source === 'string' && args.source.trim().length > 0
-    if (hasFilePath && hasSource) {
-      throw new McpError(ErrorCode.InvalidParams, 'Provide either filePath or source, not both')
-    }
-    if (!hasFilePath && !hasSource) {
-      throw new McpError(ErrorCode.InvalidParams, 'Either filePath or source must be provided')
-    }
 
     // Dual-input resolution (mirrors handleDeleteFile).
     // Use the same non-empty predicates as the XOR check above so an empty
@@ -914,15 +794,14 @@ export class RAGServer {
     // depends on the configured roots being valid.
     let targetPath: string
     let skipValidation = false
-    if (hasSource) {
-      targetPath = generateRawDataPath(this.dbPath, args.source as string, 'markdown')
+    if ('source' in args) {
+      targetPath = generateRawDataPath(this.dbPath, args.source)
       skipValidation = true
     } else {
-      // XOR + hasSource === false guarantees filePath is a non-empty string here.
       this.assertConfigOk()
       // DB key = the verbatim resolve()-stored path; look up as-is (realpath
       // stays in validateFilePath; see BaseDirsConfig for the path policy).
-      targetPath = args.filePath as string
+      targetPath = args.filePath
     }
     if (!skipValidation) {
       await this.parser.validateFilePath(targetPath)
@@ -936,7 +815,7 @@ export class RAGServer {
     const rows = await this.vectorStore.getChunksByRange(targetPath, minIdx, maxIdx)
 
     // Post-fetch marking: isTarget per item; source attached for raw-data rows.
-    const isRaw = looksLikeRawDataPath(targetPath)
+    const isRaw = isManagedRawDataPath(targetPath, this.dbPath)
     const sourceForAll = isRaw ? extractSourceFromPath(targetPath) : null
     const items: ReadChunkNeighborsResultItem[] = rows.map((row) => {
       const item: ReadChunkNeighborsResultItem = {

--- a/src/server/tool-input.ts
+++ b/src/server/tool-input.ts
@@ -10,7 +10,14 @@
 
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import type { ContentFormat } from '../utils/raw-data-utils.js'
-import type { IngestDataInput, ListFilesInput, QueryDocumentsInput } from './types.js'
+import type {
+  DeleteFileInput,
+  IngestDataInput,
+  IngestFileInput,
+  ListFilesInput,
+  QueryDocumentsInput,
+  ReadChunkNeighborsInput,
+} from './types.js'
 
 const CONTENT_FORMATS: readonly ContentFormat[] = ['text', 'html', 'markdown']
 
@@ -125,4 +132,79 @@ export function parseIngestDataInput(raw: unknown): IngestDataInput {
   }
 
   return { content, metadata: { source, format: format as ContentFormat } }
+}
+
+export function parseIngestFileInput(raw: unknown): IngestFileInput {
+  const { filePath, visual, visualQuality } = asRecord(raw, 'ingest_file')
+  if (typeof filePath !== 'string' || filePath.trim().length === 0) {
+    throw new McpError(ErrorCode.InvalidParams, 'filePath must be a non-empty string')
+  }
+  if (visual !== undefined && typeof visual !== 'boolean') {
+    throw new McpError(ErrorCode.InvalidParams, "'visual' must be a boolean if provided")
+  }
+  if (
+    visualQuality !== undefined &&
+    visualQuality !== '' &&
+    visualQuality !== 'fast' &&
+    visualQuality !== 'quality'
+  ) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "'visualQuality' must be 'fast' or 'quality' if provided"
+    )
+  }
+
+  return {
+    filePath,
+    ...(visual !== undefined ? { visual } : {}),
+    ...(visualQuality === 'fast' || visualQuality === 'quality' ? { visualQuality } : {}),
+  }
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export function parseDeleteFileInput(raw: unknown): DeleteFileInput {
+  const { filePath, source } = asRecord(raw, 'delete_file')
+  const hasFilePath = nonEmptyString(filePath)
+  const hasSource = nonEmptyString(source)
+  if (hasFilePath === hasSource) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      hasFilePath
+        ? 'Provide either filePath or source, not both'
+        : 'Either filePath or source must be provided'
+    )
+  }
+  return hasFilePath ? { filePath } : { source: source as string }
+}
+
+export function parseReadChunkNeighborsInput(raw: unknown): ReadChunkNeighborsInput {
+  const { filePath, source, chunkIndex, before, after } = asRecord(raw, 'read_chunk_neighbors')
+  if (!Number.isInteger(chunkIndex) || (chunkIndex as number) < 0) {
+    throw new McpError(ErrorCode.InvalidParams, 'chunkIndex must be a non-negative integer')
+  }
+  for (const [label, value] of [
+    ['before', before],
+    ['after', after],
+  ] as const) {
+    if (value !== undefined && (!Number.isInteger(value) || (value as number) < 0)) {
+      throw new McpError(ErrorCode.InvalidParams, `${label} must be a non-negative integer`)
+    }
+    if (typeof value === 'number' && value > 50) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `${label} must be between 0 and 50 (got ${value})`
+      )
+    }
+  }
+
+  const ref = parseDeleteFileInput({ filePath, source })
+  return {
+    ...ref,
+    chunkIndex: chunkIndex as number,
+    ...(before !== undefined ? { before: before as number } : {}),
+    ...(after !== undefined ? { after: after as number } : {}),
+  }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -110,12 +110,10 @@ export interface IngestFileInput {
   visual?: boolean
   /**
    * Visual-quality profile when `visual` is true. Some MCP clients send the
-   * empty string for unspecified optional parameters, so the boundary
-   * handler also accepts `""` and normalizes it to `'fast'`. The internal
-   * `QualityProfile` type stays narrow (`'fast' | 'quality'`); `""` does
-   * not propagate past `handleIngestFile`.
+   * empty string for unspecified optional parameters; the transport decoder
+   * normalizes it before this type reaches the handler.
    */
-  visualQuality?: 'fast' | 'quality' | ''
+  visualQuality?: 'fast' | 'quality'
 }
 
 /**
@@ -142,12 +140,9 @@ export interface IngestDataInput {
  * delete_file tool input
  * Either filePath or source must be provided
  */
-export interface DeleteFileInput {
-  /** File path (for files ingested via ingest_file) */
-  filePath?: string
-  /** Source identifier (for data ingested via ingest_data) */
-  source?: string
-}
+export type DeleteFileInput =
+  | { filePath: string; source?: never }
+  | { source: string; filePath?: never }
 
 /**
  * delete_file tool output
@@ -250,11 +245,7 @@ export interface QueryResult {
  * read_chunk_neighbors tool input.
  * Exactly one of filePath / source must be provided (XOR).
  */
-export interface ReadChunkNeighborsInput {
-  /** File path (for files ingested via ingest_file). Absolute path required. */
-  filePath?: string
-  /** Source identifier (for data ingested via ingest_data). */
-  source?: string
+export type ReadChunkNeighborsInput = DeleteFileInput & {
   /** Target chunk index (zero-based, required, non-negative integer). */
   chunkIndex: number
   /** Number of chunks before the target to include (default 2, non-negative integer). */

--- a/src/utils/__tests__/list-sources.test.ts
+++ b/src/utils/__tests__/list-sources.test.ts
@@ -30,6 +30,7 @@ const entry = (filePath: string) => ({
   entry: { filePath, chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
   key: `key:${filePath}`,
 })
+const dbPath = realFilePath('db')
 
 describe('classifyIngestedSources', () => {
   it('keeps only entries whose key is absent from matchedKeys (base filter)', () => {
@@ -37,7 +38,7 @@ describe('classifyIngestedSources', () => {
     const orphan = entry(realFilePath('base', 'b.txt'))
     const matchedKeys = new Set<string>([matched.key])
 
-    const result = classifyIngestedSources([matched, orphan], matchedKeys)
+    const result = classifyIngestedSources([matched, orphan], matchedKeys, dbPath)
 
     expect(result).toEqual([
       {
@@ -52,7 +53,7 @@ describe('classifyIngestedSources', () => {
     const raw = entry(rawDataPath('https://example.com/doc'))
     const real = entry(realFilePath('base', 'orphan.txt'))
 
-    const result = classifyIngestedSources([raw, real], new Set())
+    const result = classifyIngestedSources([raw, real], new Set(), dbPath)
 
     expect(result).toEqual([
       { source: 'https://example.com/doc', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
@@ -70,7 +71,7 @@ describe('classifyIngestedSources', () => {
     // filesystem path under it yet must still be emitted.
     const scope = [realFilePath('base', 'in-scope')]
 
-    const result = classifyIngestedSources([raw], new Set(), scope)
+    const result = classifyIngestedSources([raw], new Set(), dbPath, scope)
 
     expect(result).toEqual([
       { source: 'clipboard://2026-07-09', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
@@ -81,7 +82,7 @@ describe('classifyIngestedSources', () => {
     const underScope = entry(realFilePath('base', 'in-scope', 'orphan.txt'))
     const scope = [realFilePath('base', 'in-scope')]
 
-    const result = classifyIngestedSources([underScope], new Set(), scope)
+    const result = classifyIngestedSources([underScope], new Set(), dbPath, scope)
 
     expect(result).toEqual([
       {
@@ -96,7 +97,7 @@ describe('classifyIngestedSources', () => {
     const outsideScope = entry(realFilePath('base', 'other', 'orphan.txt'))
     const scope = [realFilePath('base', 'in-scope')]
 
-    const result = classifyIngestedSources([outsideScope], new Set(), scope)
+    const result = classifyIngestedSources([outsideScope], new Set(), dbPath, scope)
 
     expect(result).toEqual([])
   })
@@ -107,7 +108,12 @@ describe('classifyIngestedSources', () => {
     const outsideScope = entry(realFilePath('base', 'nope', 'drop.txt'))
     const scope = [realFilePath('base', 'in-scope')]
 
-    const result = classifyIngestedSources([raw, underScope, outsideScope], new Set(), scope)
+    const result = classifyIngestedSources(
+      [raw, underScope, outsideScope],
+      new Set(),
+      dbPath,
+      scope
+    )
 
     expect(result).toEqual([
       { source: 'https://example.com/keep', chunkCount: 3, timestamp: '2026-07-09T00:00:00.000Z' },
@@ -122,11 +128,23 @@ describe('classifyIngestedSources', () => {
   it('empty scope array is treated as scope-absent (no extra filtering)', () => {
     const real = entry(realFilePath('base', 'orphan.txt'))
 
-    const result = classifyIngestedSources([real], new Set(), [])
+    const result = classifyIngestedSources([real], new Set(), dbPath, [])
 
     expect(result).toEqual([
       {
         filePath: realFilePath('base', 'orphan.txt'),
+        chunkCount: 3,
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ])
+  })
+
+  it('does not classify a normal file merely because its directory is named raw-data', () => {
+    const normal = entry(realFilePath('base', 'raw-data', 'plain.md'))
+
+    expect(classifyIngestedSources([normal], new Set(), dbPath)).toEqual([
+      {
+        filePath: normal.entry.filePath,
         chunkCount: 3,
         timestamp: '2026-07-09T00:00:00.000Z',
       },

--- a/src/utils/__tests__/scope-match.test.ts
+++ b/src/utils/__tests__/scope-match.test.ts
@@ -50,6 +50,11 @@ describe('isUnderOrEqual', () => {
     expect(isUnderOrEqual('/', '/')).toBe(true)
   })
 
+  it('treats a backslash inside a slash-style POSIX name as a normal character', () => {
+    expect(isUnderOrEqual('/docs/a\\b/file.md', '/docs/a\\b')).toBe(true)
+    expect(isUnderOrEqual('/docs/a\\bc/file.md', '/docs/a\\b')).toBe(false)
+  })
+
   describe('cross-platform (backslash-style prefix)', () => {
     it('should match a descendant under a backslash prefix', () => {
       expect(isUnderOrEqual('C:\\a\\b\\x.md', 'C:\\a\\b')).toBe(true)

--- a/src/utils/list-sources.ts
+++ b/src/utils/list-sources.ts
@@ -8,7 +8,7 @@
 // content ingested via `ingest_data` (raw-data paths) plus orphaned DB entries
 // for real files not currently on disk under a scanned root.
 
-import { extractSourceFromPath, looksLikeRawDataPath } from './raw-data-utils.js'
+import { extractSourceFromPath, isManagedRawDataPath } from './raw-data-utils.js'
 import { matchesAnyScope } from './scope-match.js'
 
 /**
@@ -37,7 +37,7 @@ export type ClassifiedSource =
  * `matchedKeys`.
  *
  * When `scope` is present (non-empty): raw-data entries
- * (`looksLikeRawDataPath`) have no filesystem path under a base directory, so
+ * Managed raw-data entries have no filesystem path under a base directory, so
  * they are always emitted regardless of scope; real-file entries are kept only
  * when their stored `filePath` is under scope (`matchesAnyScope`) — a real-file
  * entry outside scope is dropped so it appears in neither `files[]` (already
@@ -51,6 +51,7 @@ export type ClassifiedSource =
 export function classifyIngestedSources(
   ingestedKeyed: readonly KeyedIngestedEntry[],
   matchedKeys: ReadonlySet<string>,
+  dbPath: string,
   scope?: string[]
 ): ClassifiedSource[] {
   const scopePrefixes = scope && scope.length > 0 ? scope : undefined
@@ -60,10 +61,13 @@ export function classifyIngestedSources(
     .filter(({ entry }) => {
       if (!scopePrefixes) return true
       // Raw-data sources are exempt from scope; real-file entries respect it.
-      return looksLikeRawDataPath(entry.filePath) || matchesAnyScope(entry.filePath, scopePrefixes)
+      return (
+        isManagedRawDataPath(entry.filePath, dbPath) ||
+        matchesAnyScope(entry.filePath, scopePrefixes)
+      )
     })
     .map(({ entry }) => {
-      if (looksLikeRawDataPath(entry.filePath)) {
+      if (isManagedRawDataPath(entry.filePath, dbPath)) {
         const source = extractSourceFromPath(entry.filePath)
         if (source) return { source, chunkCount: entry.chunkCount, timestamp: entry.timestamp }
       }

--- a/src/utils/raw-data-utils.ts
+++ b/src/utils/raw-data-utils.ts
@@ -2,7 +2,7 @@
 // Handles: base64url encoding, source normalization, file saving, source extraction
 
 import { access, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve, sep } from 'node:path'
+import { basename, dirname, join, resolve, sep } from 'node:path'
 
 // ============================================
 // Base64URL Encoding/Decoding
@@ -78,19 +78,7 @@ export function normalizeSource(source: string): string {
  */
 export type ContentFormat = 'text' | 'html' | 'markdown'
 
-/**
- * Get file extension from content format
- *
- * All formats return .md for consistency.
- * This allows generating unique path from source without knowing original format,
- * which is essential for delete_file with source parameter.
- *
- * @param _format - Content format (ignored, always returns 'md')
- * @returns File extension (without dot) - always 'md'
- */
-export function formatToExtension(_format: ContentFormat): string {
-  return 'md'
-}
+const RAW_DATA_EXTENSION = 'md'
 
 // ============================================
 // Path Generation
@@ -115,12 +103,11 @@ export function getRawDataDir(dbPath: string): string {
  * @param format - Content format
  * @returns Generated file path
  */
-export function generateRawDataPath(dbPath: string, source: string, format: ContentFormat): string {
+export function generateRawDataPath(dbPath: string, source: string): string {
   const normalizedSource = normalizeSource(source)
   const encoded = encodeBase64Url(normalizedSource)
-  const extension = formatToExtension(format)
   // Use resolve to ensure absolute path (required by validateFilePath)
-  return resolve(getRawDataDir(dbPath), `${encoded}.${extension}`)
+  return resolve(getRawDataDir(dbPath), `${encoded}.${RAW_DATA_EXTENSION}`)
 }
 
 // ============================================
@@ -140,10 +127,9 @@ export function generateRawDataPath(dbPath: string, source: string, format: Cont
 export async function saveRawData(
   dbPath: string,
   source: string,
-  content: string,
-  format: ContentFormat
+  content: string
 ): Promise<string> {
-  const filePath = generateRawDataPath(dbPath, source, format)
+  const filePath = generateRawDataPath(dbPath, source)
 
   // Ensure directory exists
   await mkdir(dirname(filePath), { recursive: true })
@@ -158,13 +144,11 @@ export async function saveRawData(
 // Path Detection and Source Extraction
 // ============================================
 
-/**
- * Display-only heuristic. NOT a security boundary — use
- * {@link isPathInRawDataDir} when the result gates filesystem access.
- */
-export function looksLikeRawDataPath(filePath: string): boolean {
-  const normalized = filePath.replace(/\\/g, '/')
-  return normalized.includes('/raw-data/')
+/** True only for managed raw-data content files under this database. */
+export function isManagedRawDataPath(filePath: string, dbPath: string): boolean {
+  return (
+    isPathInRawDataDirLexical(filePath, dbPath) && /^[A-Za-z0-9_-]+\.md$/.test(basename(filePath))
+  )
 }
 
 /**

--- a/src/utils/scope-match.ts
+++ b/src/utils/scope-match.ts
@@ -10,12 +10,10 @@
 
 import { isAbsolute, sep as PATH_SEP } from 'node:path'
 
-// Derive the boundary separator from the prefix, mirroring `buildPrefixPredicate`:
-// a `\`-style prefix uses `\`, a `/`-style prefix uses `/`, otherwise the
-// platform separator. (Caveat inherited from the SQL side: on posix, `\` is a
-// legal filename char, so a `/`-path containing `\` mis-derives the separator.)
+// A slash identifies slash-style paths even when a legal filename segment
+// contains a backslash. Pure backslash-style paths retain Windows support.
 function deriveSeparator(prefix: string): string {
-  return prefix.includes('\\') ? '\\' : prefix.includes('/') ? '/' : PATH_SEP
+  return prefix.includes('/') ? '/' : prefix.includes('\\') ? '\\' : PATH_SEP
 }
 
 // Strip trailing separators so `/a/b`, `/a/b/`, `/a/b//` normalize alike. A
@@ -32,6 +30,21 @@ function stripTrailingSeparators(prefix: string, separator: string): string {
   return prefix.slice(0, end)
 }
 
+export interface NormalizedScopePrefix {
+  exact: string
+  descendant: string
+}
+
+/** Normalize one scope prefix for both in-memory and LanceDB matching. */
+export function normalizeScopePrefix(prefix: string): NormalizedScopePrefix {
+  const separator = deriveSeparator(prefix)
+  const exact = stripTrailingSeparators(prefix, separator)
+  return {
+    exact,
+    descendant: exact.endsWith(separator) ? exact : exact + separator,
+  }
+}
+
 /**
  * True when `path` equals `prefix` or is a descendant of it, using a separator
  * boundary so `/foo/bar` does not match `/foo/barista`. The separator is derived
@@ -40,10 +53,8 @@ function stripTrailingSeparators(prefix: string, separator: string): string {
  * the SQL contract in `buildPrefixPredicate`.
  */
 export function isUnderOrEqual(path: string, prefix: string): boolean {
-  const separator = deriveSeparator(prefix)
-  const normalized = stripTrailingSeparators(prefix, separator)
-  const descendant = normalized.endsWith(separator) ? normalized : normalized + separator
-  return path === normalized || path.startsWith(descendant)
+  const { exact, descendant } = normalizeScopePrefix(prefix)
+  return path === exact || path.startsWith(descendant)
 }
 
 /**

--- a/src/vectordb/__tests__/vectordb.test.ts
+++ b/src/vectordb/__tests__/vectordb.test.ts
@@ -1623,6 +1623,18 @@ describe('VectorStore', () => {
       })
     })
 
+    it('treats backslash as a legal character inside a slash-style scope', async () => {
+      await withTempDb('scope-posix-backslash-name', async (store) => {
+        await store.insertChunks([
+          createTestChunk('inside', '/docs/a\\b/in.md', 0, createNormalizedVector(1)),
+          createTestChunk('boundary', '/docs/a\\bc/out.md', 0, createNormalizedVector(2)),
+        ])
+
+        const paths = await scopedFilePaths(store, ['/docs/a\\b'])
+        expect(paths).toEqual(['/docs/a\\b/in.md'])
+      })
+    })
+
     it('matches everything under a backslash root scope (C:\\) without doubling', async () => {
       await withTempDb('scope-backslash-root', async (store) => {
         await store.insertChunks([

--- a/src/vectordb/index.ts
+++ b/src/vectordb/index.ts
@@ -1,7 +1,7 @@
 // VectorStore implementation with LanceDB integration
 
-import { sep as PATH_SEP } from 'node:path'
 import { type Connection, connect, Index, type Table } from '@lancedb/lancedb'
+import { normalizeScopePrefix } from '../utils/scope-match.js'
 import { applyFileFilter, applyGrouping, applyKeywordBoost } from './search-filters.js'
 import {
   type ChunkRow,
@@ -435,28 +435,10 @@ export class VectorStore {
 
   /** Build the exact-or-descendant predicate for a single prefix. */
   private buildPrefixPredicate(prefix: string): string {
-    // Caveat: on posix `\` is a legal filename char, so a `/`-path containing `\` mis-derives the separator.
-    const sep = prefix.includes('\\') ? '\\' : prefix.includes('/') ? '/' : PATH_SEP
-    const normalized = this.stripTrailingSeparators(prefix, sep)
-    const descendant = normalized.endsWith(sep) ? normalized : normalized + sep
-    const exactTerm = `\`filePath\` = '${this.escapeQuotes(normalized)}'`
+    const { exact, descendant } = normalizeScopePrefix(prefix)
+    const exactTerm = `\`filePath\` = '${this.escapeQuotes(exact)}'`
     const descendantTerm = `\`filePath\` LIKE '${this.escapeLike(descendant)}%' ESCAPE '\\'`
     return `(${exactTerm} OR ${descendantTerm})`
-  }
-
-  /**
-   * Strip trailing separators. A posix root `/` (only separators) is kept as a
-   * single `/` so its descendant term becomes `/%` instead of an empty prefix.
-   */
-  private stripTrailingSeparators(prefix: string, sep: string): string {
-    let end = prefix.length
-    while (end > 0 && prefix[end - 1] === sep) {
-      end--
-    }
-    if (end === 0) {
-      return sep
-    }
-    return prefix.slice(0, end)
   }
 
   /** Escape single quotes for a SQL string literal (mirrors deleteChunks). */


### PR DESCRIPTION
## Summary

- centralize MCP input decoding at the handler boundary and remove duplicate validation rules
- fix POSIX scope normalization, managed raw-data classification, CLI connection cleanup, and server version reporting
- extract list reconciliation into one feature module and document the measured vertical-slice pilot
- remove low-value test duplication and move the 10,000-chunk latency gate to a dedicated performance suite
- refresh dependencies without overrides, resolving all 19 reported advisories
- synchronize package and registry metadata at version 0.16.1

## User-visible changes

- invalid MCP arguments are rejected consistently before tool work starts
- POSIX scope prefixes containing backslashes are handled correctly
- ordinary files inside unrelated `raw-data` directories are no longer reported as managed sources
- CLI commands close their vector-store connection before returning failures
- MCP `serverInfo.version` is derived from the package version

## Dependency updates

- update Biome, Knip, tsx, Vitest, and Node type definitions
- make the patched Vite version explicit in the test toolchain
- refresh transitive esbuild, Hono, protobufjs, and Undici versions
- `pnpm audit`: 19 advisories -> 0

## Validation

- `pnpm run check:all`
- `pnpm run test:perf`
- 70 test files / 1,063 regular tests passed
- 1 dedicated performance test passed
