### PR TITLE
docs: state the sync instructions positively

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ While a sync is running, that server refuses `sync_start`, `ingest_file`, `inges
 
 The server keeps only the current or latest job: starting a new one replaces a finished record, after which the older `jobId` is reported as unknown, and stopping the server discards the job entirely. Job state lasts only as long as the server process — there is no history and no recovery after a restart, so polling is how a client learns the outcome.
 
-The same reconciliation is available as the CLI [`sync` command](#using-as-cli), which runs in the foreground and prints the counters as JSON. Either way, only one writer may touch a database path at a time: do not run MCP and CLI `ingest`, `delete`, or `sync` mutations against the same `DB_PATH` from different processes — a sync inside the MCP server only excludes mutations in that same process. A background CLI `sync` may run alongside MCP read-only tools.
+The same reconciliation is available as the CLI [`sync` command](#using-as-cli), which runs in the foreground and prints the counters as JSON. Either way, only one writer may touch a database path at a time: keep MCP and CLI `ingest`, `delete`, and `sync` mutations against one `DB_PATH` to a single process — a sync inside the MCP server only excludes mutations in that same process. A background CLI `sync` may run alongside MCP read-only tools.
 
 ### Using as CLI
 
@@ -267,7 +267,7 @@ npx mcp-local-rag delete --source "https://..."  # Remove by source URL
 
 > ⚠️ The CLI does **not** read your MCP client config (`mcp.json`, `config.toml`, etc.). Configure the CLI via flags or environment variables as shown below.
 
-> ⚠️ **One writer at a time.** Do not run CLI or MCP `ingest`, `delete`, or `sync` mutations concurrently against the same database path from different processes. Nothing enforces this across processes — it is an operating constraint you keep. A background CLI `sync` may run alongside MCP read-only tools (`query_documents`, `list_files`, `status`, `read_chunk_neighbors`).
+> ⚠️ **One writer at a time.** Keep CLI and MCP `ingest`, `delete`, and `sync` mutations against one database path to a single process. Nothing enforces this across processes — it is an operating constraint you keep. A background CLI `sync` may run alongside MCP read-only tools (`query_documents`, `list_files`, `status`, `read_chunk_neighbors`).
 
 #### Configuration
 

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -255,8 +255,8 @@ Every run hashes the full bytes of every file it scans, so cost scales with tota
 - **While a sync runs**, `sync_start`, `ingest_file`, `ingest_data`, and `delete_file` return a tool error naming the active `jobId` — poll `sync_status` instead of retrying. `query_documents`, `read_chunk_neighbors`, `list_files`, `status`, and `sync_status` stay callable throughout.
 - **On failure**, report the message and start a new sync once the cause is fixed. There is no retry, resume, or cancel; upserts that already completed are kept and no prune runs.
 - **When you cannot poll to a terminal state**, report the `jobId` and the latest counters and stop. The run continues in the server and the same `jobId` still answers, so it can be re-checked later.
-- **Only the current or latest job is kept.** A new `sync_start` replaces a terminal record, and the older `jobId` then reports as unknown. Server process exit discards the job, so never treat a `jobId` as durable.
-- **One writer at a time.** A running sync only excludes mutations inside this server process: never run CLI or MCP `ingest`, `delete`, or `sync` mutations against the same database path from two processes at once (see [CLI commands](#cli-commands)). Read-only tools stay callable alongside a background CLI `sync`.
+- **Only the current or latest job is kept.** A new `sync_start` replaces a terminal record, and the older `jobId` then reports as unknown. Server process exit discards the job, so treat a `jobId` as valid only for the life of that server process.
+- **One writer at a time.** A running sync only excludes mutations inside this server process, so keep CLI and MCP `ingest`, `delete`, and `sync` mutations against one database path to a single process at a time (see [CLI commands](#cli-commands)). Read-only tools stay callable alongside a background CLI `sync`.
 
 Polling is the only progress mechanism: no notification or client-specific setup is involved.
 
@@ -267,7 +267,7 @@ CLI subcommands mirror MCP tools. Useful for bulk operations, scripting, and env
 - `query`, `list`, `status`, `delete` output JSON to stdout
 - `ingest` outputs progress to stderr
 - `sync [path]` reconciles the index with disk (re-ingest changed and new files, drop entries whose source is gone). Prefer it over re-running `ingest` when the index is already populated and only changed files need reconciling. Counters JSON to stdout; each upserted and pruned path named on stderr as it happens; runs in the foreground and exits non-zero on the first error
-- One writer at a time: never run CLI or MCP `ingest`, `delete`, or `sync` mutations against the same database path from two processes at once. Read-only tools stay callable alongside a background `sync`
+- One writer at a time: keep CLI and MCP `ingest`, `delete`, and `sync` mutations against one database path to a single process at a time. Read-only tools stay callable alongside a background `sync`
 - Use `--help` on any command for options
 - See [cli-reference.md](references/cli-reference.md) for options and config matching
 


### PR DESCRIPTION
Follow-up to #171. Wording only — no behavior change.

`SKILL.md` is read as an instruction, so a prohibition there leaves the model to derive the allowed action from what it may not do. Three directives were phrased as prohibitions:

| Location | Before | After |
|---|---|---|
| Index sync | `never treat a jobId as durable` | `treat a jobId as valid only for the life of that server process` |
| Index sync | `never run ... from two processes at once` | `keep ... to a single process at a time` |
| CLI commands | same rule, second copy | same rewrite |

The prohibition form is legitimate when a positive rewrite would blur the boundary. "Keep mutations against one database path to a single process" is exactly as sharp as forbidding two, so that exemption does not apply here — which is the part I got wrong when these lines were written.

The four remaining negatives in the file describe behavior rather than direct it, and are left alone: a file over `MAX_FILE_SIZE` is never read, `completed` never exceeds `total`, the scan never descends into a symlink, and a nested root is dropped to avoid duplicate results.

`README.md` carries the same concurrent-writer rule for human readers and is aligned in the same change.

`pnpm run check:all` passes (77 files / 1320 tests). Tool descriptions were scanned for the same pattern and needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
