### PR TITLE
test: drop assertions that cannot fail or restate another test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,10 @@ jobs:
         key: hf-model-allMiniLM-${{ env.HF_MODEL_REVISION }}
         enableCrossOsArchive: true
 
+    # `pnpm test` excludes two suites and CI registers no job for either, on
+    # purpose: `test:e2e` needs a pre-cached VLM (prepare-models pins the
+    # embedding model only, so it would fetch from HuggingFace mid-test), and
+    # `test:perf` asserts a wall-clock P95 that shared runners cannot hold.
     - name: Run tests
       run: pnpm test
 

--- a/src/__tests__/cli/common.test.ts
+++ b/src/__tests__/cli/common.test.ts
@@ -33,7 +33,6 @@ const MOCKED_PATHS = ['../../vectordb/index.js', '../../embedder/index.js'] as c
 // ============================================
 
 let createEmbedder: typeof import('../../cli/common.js').createEmbedder
-let createVectorStore: typeof import('../../cli/common.js').createVectorStore
 let formatCliError: typeof import('../../cli/common.js').formatCliError
 type ResolvedGlobalConfig = import('../../cli/options.js').ResolvedGlobalConfig
 
@@ -59,28 +58,14 @@ describe('cli/common', () => {
     vi.resetModules()
     vi.doMock('../../vectordb/index.js', vectordbFactory)
     vi.doMock('../../embedder/index.js', embedderFactory)
-    ;({ createEmbedder, createVectorStore, formatCliError } = await import('../../cli/common.js'))
+    // The vectordb mock stays installed so importing cli/common.js does not pull
+    // in the real LanceDB module under `isolate: false`.
+    ;({ createEmbedder, formatCliError } = await import('../../cli/common.js'))
   })
 
   afterAll(() => {
     for (const p of MOCKED_PATHS) vi.doUnmock(p)
     vi.resetModules()
-  })
-
-  describe('createVectorStore', () => {
-    afterEach(() => {
-      mocks.VectorStore.mockReset()
-    })
-
-    it('should construct VectorStore with dbPath from config', () => {
-      createVectorStore(makeConfig({ dbPath: '/data/my-db' }))
-
-      expect(mocks.VectorStore).toHaveBeenCalledOnce()
-      expect(mocks.VectorStore).toHaveBeenCalledWith({
-        dbPath: '/data/my-db',
-        tableName: 'chunks',
-      })
-    })
   })
 
   describe('formatCliError', () => {

--- a/src/__tests__/e2e/html-workflow.e2e.test.ts
+++ b/src/__tests__/e2e/html-workflow.e2e.test.ts
@@ -5,7 +5,7 @@
 import { mkdir, rm } from 'node:fs/promises'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RAGServer } from '../../server/index.js'
-import { withTestDevice } from '../test-device.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
 
 // ============================================
 // Test Configuration
@@ -15,7 +15,8 @@ const testDbPath = './tmp/test-html-workflow-db'
 const testConfig = {
   dbPath: testDbPath,
   modelName: 'Xenova/all-MiniLM-L6-v2',
-  cacheDir: './tmp/test-model-cache',
+  // The prewarmed cache, so ingest and search never reach HuggingFace.
+  cacheDir: testModelCacheDir(),
   baseDir: '.',
   maxFileSize: 10 * 1024 * 1024,
 }

--- a/src/__tests__/e2e/visual-ingest-e2e.test.ts
+++ b/src/__tests__/e2e/visual-ingest-e2e.test.ts
@@ -34,7 +34,8 @@
 // CI gate:
 //   describe.skipIf(process.env['RUN_E2E'] !== '1')(...)
 // also lives in package.json as a dedicated `test:e2e` script so the
-// default `pnpm test` never pulls the VLM model.
+// default `pnpm test` never pulls the VLM model. No workflow sets RUN_E2E=1
+// either, so this runs nowhere automatically — on purpose (see ci.yml).
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'

--- a/src/__tests__/server/config-warnings.test.ts
+++ b/src/__tests__/server/config-warnings.test.ts
@@ -11,7 +11,7 @@ import {
   parseMaxDistance,
   parseMaxFiles,
 } from '../../server-main.js'
-import { withTestDevice } from '../test-device.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
 
 // ============================================
 // Unit Tests: Parser Functions
@@ -192,7 +192,8 @@ const testDbPath = './tmp/test-config-warnings-db'
 const baseConfig = {
   dbPath: testDbPath,
   modelName: 'Xenova/all-MiniLM-L6-v2',
-  cacheDir: './tmp/test-model-cache',
+  // The prewarmed cache: handleQueryDocuments below embeds the query for real.
+  cacheDir: testModelCacheDir(),
   baseDir: '.',
   maxFileSize: 10 * 1024 * 1024,
 }

--- a/src/__tests__/server/handleIngestFile-visual-validation.test.ts
+++ b/src/__tests__/server/handleIngestFile-visual-validation.test.ts
@@ -251,190 +251,35 @@ describe('handleIngestFile - `visual` Runtime Validation (AC-012)', () => {
     mocks.embedBatch.mockResolvedValue([[0.1, 0.2]])
   })
 
-  // AC-012: "handleIngestFile rejects args.visual values that are neither
-  //         undefined nor a boolean with McpError(ErrorCode.InvalidParams,
-  //         \"'visual' must be a boolean if provided\"). Tested with
-  //         visual: 'true' (string), visual: 1 (number), visual: null."
-  // ROI: 49 (BV:7 × Freq:3 + Legal:0 + Defect:7)
-  // Behavior: Non-boolean `visual` → McpError(InvalidParams) before any I/O
-  // Verification items (one parametrized case per invalid value):
-  //   - Error thrown is McpError
-  //   - ErrorCode === InvalidParams
-  //   - Message includes "'visual' must be a boolean if provided"
-  //   - No parser/chunker/embedder/vectorStore method was reached
-  // @category: edge-case
+  // AC-012: non-boolean `visual` is rejected before the handler touches any
+  // collaborator. The per-value rejection itself is covered on the parse
+  // function in server/__tests__/tool-input.test.ts; what is proved here is that
+  // handleIngestFile runs that validation ahead of its first I/O call.
+  //
+  // The positive dispatch cases (visual undefined / false / true) are proved
+  // observably in __tests__/cli/ingest-default-mode.test.ts (pdf-visual Proxy
+  // sentinel + persisted chunk rows) and __tests__/cli/ingest-visual.test.ts
+  // (enriched caption content), so they are not re-asserted here as call counts.
   // @lane: integration
-  // @dependency: handleIngestFile, defensive stubs (must NOT be called)
-  // @complexity: low
-  it("AC-012: handleIngestFile throws McpError(InvalidParams) when visual === 'true' (string)", async () => {
-    // Arrange
-    const server = buildServer()
+  it.each(['true', 1, null])(
+    'rejects visual=%j before reaching any collaborator',
+    async (visual) => {
+      const server = buildServer()
 
-    // Act
-    let caught: unknown
-    try {
-      await server.handleIngestFile({
-        filePath: FIXTURE_PDF_PATH,
-        visual: 'true',
-      } as unknown as { filePath: string })
-    } catch (error) {
-      caught = error
+      await expect(
+        server.handleIngestFile({ filePath: FIXTURE_PDF_PATH, visual } as unknown as {
+          filePath: string
+        })
+      ).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+        message: expect.stringContaining(INVALID_PARAMS_MESSAGE),
+      })
+
+      expect(mocks.parsePdf).not.toHaveBeenCalled()
+      expect(mocks.parsePdfPages).not.toHaveBeenCalled()
+      expect(mocks.parseFile).not.toHaveBeenCalled()
     }
-
-    // Assert: error shape
-    expect(caught).toBeInstanceOf(McpError)
-    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams)
-    expect((caught as McpError).message).toContain(INVALID_PARAMS_MESSAGE)
-
-    // Assert: no downstream side effect (validation short-circuited)
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(0)
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-    expect(mocks.parseFile).toHaveBeenCalledTimes(0)
-    expect(mocks.chunkText).toHaveBeenCalledTimes(0)
-    expect(mocks.embedBatch).toHaveBeenCalledTimes(0)
-    expect(mocks.deleteChunks).toHaveBeenCalledTimes(0)
-    expect(mocks.insertChunks).toHaveBeenCalledTimes(0)
-  })
-
-  it('AC-012: handleIngestFile throws McpError(InvalidParams) when visual === 1 (number)', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act
-    let caught: unknown
-    try {
-      await server.handleIngestFile({
-        filePath: FIXTURE_PDF_PATH,
-        visual: 1,
-      } as unknown as { filePath: string })
-    } catch (error) {
-      caught = error
-    }
-
-    // Assert: error shape
-    expect(caught).toBeInstanceOf(McpError)
-    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams)
-    expect((caught as McpError).message).toContain(INVALID_PARAMS_MESSAGE)
-
-    // Assert: no downstream side effect
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(0)
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-    expect(mocks.parseFile).toHaveBeenCalledTimes(0)
-    expect(mocks.chunkText).toHaveBeenCalledTimes(0)
-    expect(mocks.embedBatch).toHaveBeenCalledTimes(0)
-    expect(mocks.deleteChunks).toHaveBeenCalledTimes(0)
-    expect(mocks.insertChunks).toHaveBeenCalledTimes(0)
-  })
-
-  it('AC-012: handleIngestFile throws McpError(InvalidParams) when visual === null', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act
-    let caught: unknown
-    try {
-      await server.handleIngestFile({
-        filePath: FIXTURE_PDF_PATH,
-        visual: null,
-      } as unknown as { filePath: string })
-    } catch (error) {
-      caught = error
-    }
-
-    // Assert: error shape
-    expect(caught).toBeInstanceOf(McpError)
-    expect((caught as McpError).code).toBe(ErrorCode.InvalidParams)
-    expect((caught as McpError).message).toContain(INVALID_PARAMS_MESSAGE)
-
-    // Assert: no downstream side effect
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(0)
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-    expect(mocks.parseFile).toHaveBeenCalledTimes(0)
-    expect(mocks.chunkText).toHaveBeenCalledTimes(0)
-    expect(mocks.embedBatch).toHaveBeenCalledTimes(0)
-    expect(mocks.deleteChunks).toHaveBeenCalledTimes(0)
-    expect(mocks.insertChunks).toHaveBeenCalledTimes(0)
-  })
-
-  // AC-012 (positive — validation does NOT fire for valid values):
-  // ROI: 28 (BV:7 × Freq:4 + Legal:0 + Defect:0)
-  // Behavior: undefined / true / false → no validation error; the call proceeds
-  //           into the dispatch (parser etc.).
-  // Verification items:
-  //   - No McpError(InvalidParams) thrown specifically for `visual` shape
-  //   - For visual === undefined and visual === false, the default-path parser
-  //     (parser.parsePdf for PDFs, parser.parseFile for non-PDFs) is reached
-  //   - For visual === true on a `.pdf`, the visual-path parser
-  //     (parser.parsePdfPages) is reached
-  // @category: edge-case
-  // @lane: integration
-  // @dependency: handleIngestFile
-  // @complexity: low
-  it('AC-012 (positive): handleIngestFile dispatches to the default PDF path when visual is undefined', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act: omit `visual` from args (undefined) — must NOT throw InvalidParams
-    await server.handleIngestFile({ filePath: FIXTURE_PDF_PATH })
-
-    // Assert: default PDF parser reached; visual parser NOT reached
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(1)
-    expect(mocks.parsePdf).toHaveBeenCalledWith(FIXTURE_PDF_PATH, expect.anything())
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-  })
-
-  it('AC-012 (positive): handleIngestFile dispatches to the default PDF path when visual === false', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act
-    await server.handleIngestFile({
-      filePath: FIXTURE_PDF_PATH,
-      visual: false,
-    } as unknown as { filePath: string })
-
-    // Assert: default PDF parser reached; visual parser NOT reached
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(1)
-    expect(mocks.parsePdf).toHaveBeenCalledWith(FIXTURE_PDF_PATH, expect.anything())
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-  })
-
-  it('AC-012 (positive): handleIngestFile dispatches to the non-PDF default path when visual === false on a .md file', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act
-    await server.handleIngestFile({
-      filePath: FIXTURE_NON_PDF_PATH,
-      visual: false,
-    } as unknown as { filePath: string })
-
-    // Assert: non-PDF parser reached
-    expect(mocks.parseFile).toHaveBeenCalledTimes(1)
-    expect(mocks.parseFile).toHaveBeenCalledWith(FIXTURE_NON_PDF_PATH)
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(0)
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(0)
-  })
-
-  it('AC-012 (positive): handleIngestFile dispatches to the visual path when visual === true on a .pdf', async () => {
-    // Arrange
-    const server = buildServer()
-
-    // Act
-    await server.handleIngestFile({
-      filePath: FIXTURE_PDF_PATH,
-      visual: true,
-    } as unknown as { filePath: string })
-
-    // Assert: visual parser reached; default PDF parser NOT reached
-    expect(mocks.parsePdfPages).toHaveBeenCalledTimes(1)
-    expect(mocks.parsePdfPages).toHaveBeenCalledWith(FIXTURE_PDF_PATH, expect.anything())
-    expect(mocks.parsePdf).toHaveBeenCalledTimes(0)
-    // pdf-visual barrel exports were invoked
-    expect(mocks.createCaptioner).toHaveBeenCalledTimes(1)
-    expect(mocks.detectVisualCandidates).toHaveBeenCalledTimes(1)
-    expect(mocks.enrichPagesWithCaptions).toHaveBeenCalledTimes(1)
-  })
+  )
 })
 
 // =============================================================================

--- a/src/__tests__/server/ingest-data.test.ts
+++ b/src/__tests__/server/ingest-data.test.ts
@@ -6,7 +6,7 @@ import { mkdir, readFile, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { RAGServer } from '../../server/index.js'
-import { withTestDevice } from '../test-device.js'
+import { testModelCacheDir, withTestDevice } from '../test-device.js'
 
 // ============================================
 // Test Configuration
@@ -16,7 +16,9 @@ const testDbPath = './tmp/test-ingest-data-db'
 const testConfig = {
   dbPath: testDbPath,
   modelName: 'Xenova/all-MiniLM-L6-v2',
-  cacheDir: './tmp/test-model-cache',
+  // The prewarmed cache, so the embedder never reaches HuggingFace. A private
+  // cacheDir here downloaded the model on every CI run and failed on HTTP 429.
+  cacheDir: testModelCacheDir(),
   // Absolute root, matching the production contract (server-main.ts always
   // resolves roots to absolute). A relative '.' would make the scan emit
   // relative paths that never match the absolute excludePaths, so the raw-data

--- a/src/embedder/__tests__/lazy-initialization.test.ts
+++ b/src/embedder/__tests__/lazy-initialization.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getTestDevice, testModelCacheDir } from '../../__tests__/test-device.js'
 import type { EmbedderConfig } from '../index.js'
-import { Embedder, EmbeddingError } from '../index.js'
+import { Embedder } from '../index.js'
 
 describe('Embedder - Lazy Initialization', () => {
   let testConfig: EmbedderConfig
@@ -95,22 +95,9 @@ describe('Embedder - Lazy Initialization', () => {
     expect(result.length).toBe(384)
   }, 180000)
 
-  // Test 5: Init failure surfaces transformers.js' own message as an EmbeddingError.
-  // Use an invalid DEVICE (a local, network-independent failure) rather than a
-  // nonexistent model: a missing model triggers a live network fetch whose error
-  // text varies by connectivity (HF-hub 404 with the path when online, "fetch
-  // failed" offline), which would make a message-content assertion flaky.
-  // Device validation fails locally with a deterministic message.
-  it('should surface the underlying transformers.js message as an EmbeddingError on init failure', async () => {
-    const embedderWithBadDevice = new Embedder({
-      ...testConfig,
-      device: 'definitely-not-a-real-device',
-    })
-
-    const error = await embedderWithBadDevice.embed('test').catch((e) => e as Error)
-    expect(error).toBeInstanceOf(EmbeddingError)
-    expect((error as EmbeddingError).message).toMatch(/definitely-not-a-real-device/)
-  }, 30000)
+  // Init-failure surfacing on the lazy path is covered in
+  // __tests__/embedder/embedder.test.ts ('device validation'), which asserts the
+  // same EmbeddingError plus the underlying `Unsupported device` text.
 
   // Test 6: Explicit initialize() should still work (backward compatibility)
   it('should still work with explicit initialize() call for backward compatibility', async () => {

--- a/src/pdf-visual/__tests__/captioner-quality.test.ts
+++ b/src/pdf-visual/__tests__/captioner-quality.test.ts
@@ -241,15 +241,6 @@ describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-O
     expect(result).toBe('Summary: a figure.\n\nKeywords: alpha; beta')
   })
 
-  it('returns null when decoded output is whitespace-only (shared postProcess applies)', async () => {
-    mocks.state.decodedText = '   \n\t  '
-    const captioner = createCaptioner(BASE_CONFIG)
-
-    const result = await captioner.caption(PNG_BYTES, 1)
-
-    expect(result).toBeNull()
-  })
-
   it('wraps model-load failure in VlmError with pageNum + Qwen model identifier in the cause', async () => {
     const originalErr = new Error('boom-quality-load')
     mocks.state.fromPretrainedThrows = originalErr

--- a/src/pdf-visual/__tests__/captioner.test.ts
+++ b/src/pdf-visual/__tests__/captioner.test.ts
@@ -19,9 +19,9 @@
 //     resolved device.
 //   - `model.generate` receives the `fast`-profile decoding options
 //     (`max_new_tokens`, `repetition_penalty`, `no_repeat_ngram_size`).
-//   - Post-decode boundary cases: 1000 chars passes through unchanged, 1001
-//     chars truncated to 1000 + `…` (final length 1001), empty/whitespace-only/
-//     control-char-only inputs return `null` without throwing.
+//   - The decoded text is returned through `shared.postProcess`. The control-char,
+//     trim, emptiness, and length-cap rules are pinned directly on that function
+//     in `captioners-shared.test.ts`, which both profiles share.
 //   - Load / decode / generate failures throw `VlmError` with `pageNum` + `cause`.
 //
 // `@huggingface/transformers` is mocked via `vi.hoisted` per the project-wide
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => {
   // Default behaviour: processor returns inputs with a 4-token prompt;
   // model.generate returns a 6-token output (4 prompt + 2 generated). The
   // mock processor.batch_decode returns whatever string the test has staged
-  // in `mocks.decodedText` so each AC-011 boundary case can be exercised.
+  // in `mocks.decodedText`.
   const state: {
     decodedText: string
     fromPretrainedThrows: Error | null
@@ -148,7 +148,7 @@ const BASE_CONFIG = {
   cacheDir: '/tmp/cache',
 }
 
-describe('createCaptioner — fast profile dispatch (CaptionerConfig flow + AC-011 length / emptiness)', () => {
+describe('createCaptioner — fast profile dispatch (CaptionerConfig flow)', () => {
   beforeAll(async () => {
     vi.resetModules()
     vi.doMock('@huggingface/transformers', transformersFactory)
@@ -236,79 +236,17 @@ describe('createCaptioner — fast profile dispatch (CaptionerConfig flow + AC-0
     expect(mocks.mockModelFromPretrained).not.toHaveBeenCalled()
   })
 
-  // ----- AC-011: 1000 chars -----
+  // ----- postProcess wiring -----
 
-  it('returns the caption unchanged when decoded length is exactly 1000', async () => {
-    // Arrange
-    const text = 'a'.repeat(1000)
-    mocks.state.decodedText = text
+  it('returns the decoded text through postProcess, not the raw decode', async () => {
+    // The rules themselves are pinned on postProcess in captioners-shared.test.ts;
+    // this only proves the captioner routes its decode through it.
+    mocks.state.decodedText = 'b'.repeat(1001)
     const captioner = createCaptioner(BASE_CONFIG)
 
-    // Act
     const result = await captioner.caption(PNG_BYTES, 1)
 
-    // Assert
-    expect(result).toBe(text)
-    expect(result?.length).toBe(1000)
-  })
-
-  // ----- AC-011: 1001 chars (truncated) -----
-
-  it('truncates to 1000 chars + … when decoded length is 1001', async () => {
-    // Arrange
-    const text = 'b'.repeat(1001)
-    mocks.state.decodedText = text
-    const captioner = createCaptioner(BASE_CONFIG)
-
-    // Act
-    const result = await captioner.caption(PNG_BYTES, 1)
-
-    // Assert: 1000 chars of 'b' + '…' = length 1001 ending in '…'.
-    expect(result?.length).toBe(1001)
-    expect(result?.endsWith('…')).toBe(true)
-    expect(result?.slice(0, 1000)).toBe('b'.repeat(1000))
-  })
-
-  // ----- AC-011: empty -----
-
-  it('returns null when decoded output is the empty string', async () => {
-    // Arrange
-    mocks.state.decodedText = ''
-    const captioner = createCaptioner(BASE_CONFIG)
-
-    // Act
-    const result = await captioner.caption(PNG_BYTES, 1)
-
-    // Assert
-    expect(result).toBeNull()
-  })
-
-  // ----- AC-011: whitespace-only -----
-
-  it('returns null when decoded output is whitespace-only', async () => {
-    // Arrange
-    mocks.state.decodedText = '   \n\t  '
-    const captioner = createCaptioner(BASE_CONFIG)
-
-    // Act
-    const result = await captioner.caption(PNG_BYTES, 1)
-
-    // Assert
-    expect(result).toBeNull()
-  })
-
-  // ----- AC-011: control-char-only -----
-
-  it('returns null when decoded output contains only control chars (except \\n, \\t)', async () => {
-    // Arrange: C0 control chars 0x00..0x08, 0x0b, 0x0c, 0x0e..0x1f and a C1 (0x80).
-    mocks.state.decodedText = ' '
-    const captioner = createCaptioner(BASE_CONFIG)
-
-    // Act
-    const result = await captioner.caption(PNG_BYTES, 1)
-
-    // Assert
-    expect(result).toBeNull()
+    expect(result).toBe(`${'b'.repeat(1000)}…`)
   })
 
   // ----- generate options -----

--- a/src/pdf-visual/__tests__/captioners-shared.test.ts
+++ b/src/pdf-visual/__tests__/captioners-shared.test.ts
@@ -1,0 +1,80 @@
+// Both captioner profiles route decoded output through `postProcess`, so its
+// rules are pinned here once instead of through each profile's mock stack.
+
+import { describe, expect, it } from 'vitest'
+import { postProcess } from '../captioners/shared.js'
+
+// Built from code points rather than written as escapes: a literal control
+// character in a fixture is invisible in review, which is how an earlier version
+// of this coverage came to assert on a plain space.
+const chars = (...codes: number[]): string => codes.map((c) => String.fromCharCode(c)).join('')
+
+const C0_LOW = chars(0x00, 0x01, 0x08)
+const C0_ABOVE_LF = chars(0x0b, 0x0c, 0x1f)
+const DEL_AND_C1 = chars(0x7f, 0x80, 0x9f)
+const NBSP = chars(0xa0)
+const TAB = chars(0x09)
+const LF = chars(0x0a)
+
+describe('postProcess — control character stripping', () => {
+  it('strips the low C0 range (0x00-0x08)', () => {
+    expect(postProcess(`a${C0_LOW}b`)).toBe('ab')
+  })
+
+  it('strips the C0 range above LF (0x0b-0x1f)', () => {
+    expect(postProcess(`a${C0_ABOVE_LF}b`)).toBe('ab')
+  })
+
+  it('strips DEL and the C1 range (0x7f-0x9f)', () => {
+    expect(postProcess(`a${DEL_AND_C1}b`)).toBe('ab')
+  })
+
+  it('keeps tab and newline verbatim', () => {
+    expect(postProcess(`one${LF}two${TAB}three`)).toBe(`one${LF}two${TAB}three`)
+  })
+
+  it('keeps U+00A0, the code point immediately past the C1 range', () => {
+    // Boundary pair with the C1 case: 0x9f is stripped, 0xa0 is content. Placed
+    // mid-string so `trim()` cannot remove it.
+    expect(postProcess(`a${NBSP}b`)).toBe(`a${NBSP}b`)
+  })
+
+  it('returns null for control characters only', () => {
+    expect(postProcess(`${C0_LOW}${C0_ABOVE_LF}${DEL_AND_C1}`)).toBeNull()
+  })
+
+  it('trims the whitespace that stripping exposes at the edges', () => {
+    expect(postProcess(`${C0_LOW}  hello ${C0_LOW}`)).toBe('hello')
+  })
+})
+
+describe('postProcess — emptiness', () => {
+  it('returns null for the empty string', () => {
+    expect(postProcess('')).toBeNull()
+  })
+
+  it('returns null for whitespace-only input', () => {
+    expect(postProcess(`  ${TAB}${LF} `)).toBeNull()
+  })
+})
+
+describe('postProcess — length cap', () => {
+  it('returns a 1000-character caption unchanged', () => {
+    const text = 'a'.repeat(1000)
+
+    expect(postProcess(text)).toBe(text)
+  })
+
+  it('truncates a 1001-character caption to 1000 characters plus an ellipsis', () => {
+    const result = postProcess('b'.repeat(1001))
+
+    expect(result).toBe(`${'b'.repeat(1000)}…`)
+    expect(result).toHaveLength(1001)
+  })
+
+  it('measures length after stripping, so control characters never trigger truncation', () => {
+    const text = `${'c'.repeat(1000)}${chars(0x00).repeat(500)}`
+
+    expect(postProcess(text)).toBe('c'.repeat(1000))
+  })
+})

--- a/src/server/__tests__/rag-server.config.test.ts
+++ b/src/server/__tests__/rag-server.config.test.ts
@@ -12,6 +12,7 @@ import { mkdirSync, rmSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { testModelCacheDir } from '../../__tests__/test-device.js'
+import type { DocumentParser } from '../../parser/index.js'
 import { BaseDirsConfigError } from '../../utils/base-dirs.js'
 import { RAGServer } from '../index.js'
 
@@ -56,8 +57,7 @@ describe('RAGServerConfig degraded-mode construction guards (P3-T1)', () => {
       maxFileSize: 100 * 1024 * 1024,
       configError,
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const parser = (server as any).parser
+    const { parser } = server as unknown as { parser: DocumentParser }
     await expect(parser.validateFilePath('/tmp/anything.txt')).rejects.toThrow(
       /No configured base directory/
     )

--- a/src/server/__tests__/rag-server.read-neighbors.perf.test.ts
+++ b/src/server/__tests__/rag-server.read-neighbors.perf.test.ts
@@ -1,3 +1,7 @@
+// The `.perf.test.ts` suffix keeps this out of `pnpm test`; run `pnpm run
+// test:perf`. No CI job runs it either, on purpose: the P95 below is wall-clock
+// and shared runners cannot hold it (see ci.yml).
+
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'

--- a/src/server/__tests__/tool-definitions.test.ts
+++ b/src/server/__tests__/tool-definitions.test.ts
@@ -1,7 +1,6 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 import { describe, expect, it } from 'vitest'
 import { toolDefinitions } from '../tool-definitions.js'
-import type { SyncStatusResult } from '../types.js'
 
 const findTool = (name: string): Tool => {
   const tool = toolDefinitions.find((t) => t.name === name)
@@ -28,18 +27,11 @@ describe('list_files tool definition scope', () => {
     expect(scope?.oneOf).toEqual([{ type: 'string' }, { type: 'array', items: { type: 'string' } }])
   })
 
-  it('describes scope on a reachable/scan-path basis, not the query stored-filePath phrasing', () => {
-    const description = scope?.description as string
-    expect(description).toMatch(/reachable/i)
-    // MUST NOT copy the query_documents wording, which contradicts the scan-path basis
-    expect(description).not.toMatch(/filePath equal to or under/)
-  })
-
-  it('keeps boundary-safe and absolute-path guidance', () => {
-    const description = scope?.description as string
-    expect(description).toContain('/docs/api')
-    expect(description).toContain('/docs/apiv2')
-    expect(description).toMatch(/absolute/i)
+  // Regression guard with provenance: the description once carried the
+  // query_documents wording, which claims stored-filePath semantics and
+  // contradicts the scan-path basis list_files actually filters on.
+  it('does not claim the query_documents stored-filePath semantics', () => {
+    expect(scope?.description as string).not.toMatch(/filePath equal to or under/)
   })
 })
 
@@ -59,15 +51,6 @@ describe('declared tool surface', () => {
       'sync_start',
       'sync_status',
     ])
-  })
-
-  it('declares no sync tool beyond sync_start and sync_status', () => {
-    const syncTools = toolDefinitions
-      .filter((tool) => tool.name.startsWith('sync_'))
-      .map((tool) => tool.name)
-    expect(syncTools).toEqual(['sync_start', 'sync_status'])
-    expect(syncTools).not.toContain('sync_cancel')
-    expect(syncTools).not.toContain('sync_list_jobs')
   })
 
   // SYNC-006 / ADR decision 1: the sync tools are ordinary tools/call entries.
@@ -94,18 +77,6 @@ describe('sync_start tool definition', () => {
     expect(Object.keys(syncStart.inputSchema.properties ?? {})).toEqual(['path'])
   })
 
-  it('states that the call returns a jobId without waiting for the run and is polled via sync_status', () => {
-    const description = syncStart.description as string
-    expect(description).toMatch(/jobId/)
-    expect(description).toMatch(/without waiting for the run to finish/i)
-    // Not "before scanning or hashing starts": `handleSyncStart` calls
-    // `void this.runSyncJob(...)`, which runs synchronously up to its first
-    // `await`, so the scan has already been started by the time the reply
-    // resolves — only hashing has not.
-    expect(description).not.toMatch(/before scanning/i)
-    expect(description).toMatch(/sync_status/)
-  })
-
   it('exposes no visual PDF option', () => {
     expect(JSON.stringify(syncStart)).not.toMatch(/visual/i)
   })
@@ -117,52 +88,5 @@ describe('sync_status tool definition', () => {
   it('declares jobId as a required string', () => {
     expect(propertyOf(syncStatus, 'jobId').type).toBe('string')
     expect(syncStatus.inputSchema.required).toEqual(['jobId'])
-  })
-
-  it('describes the returned record as the current or latest job', () => {
-    const description = syncStatus.description as string
-    expect(description).toMatch(/current or latest/i)
-  })
-})
-
-describe('sync status record contract', () => {
-  const record: SyncStatusResult = {
-    jobId: '8f2d1c34-1f9a-4f1e-9a3f-6d1b2c3e4f50',
-    state: 'running',
-    total: null,
-    completed: 0,
-    summary: { upserted: 0, skipped: 0, empty: 0, pruned: 0 },
-    warnings: [],
-    error: null,
-  }
-
-  // The plan restricts the record to these keys: no history, timestamps,
-  // failure collection, or recovery state may appear.
-  it('carries exactly the fields of the MCP contract', () => {
-    expect(Object.keys(record).sort()).toEqual([
-      'completed',
-      'error',
-      'jobId',
-      'state',
-      'summary',
-      'total',
-      'warnings',
-    ])
-  })
-
-  it('carries exactly the four summary counters', () => {
-    expect(Object.keys(record.summary).sort()).toEqual(['empty', 'pruned', 'skipped', 'upserted'])
-  })
-
-  it('serializes total as JSON null before scanning has counted the disk files', () => {
-    expect(JSON.parse(JSON.stringify(record))).toEqual({
-      jobId: '8f2d1c34-1f9a-4f1e-9a3f-6d1b2c3e4f50',
-      state: 'running',
-      total: null,
-      completed: 0,
-      summary: { upserted: 0, skipped: 0, empty: 0, pruned: 0 },
-      warnings: [],
-      error: null,
-    })
   })
 })

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -44,20 +44,15 @@ describe('isAppError', () => {
 })
 
 describe('AppError discriminants', () => {
-  it('should expose layer and kind on every concrete instance', () => {
-    for (const err of oneOfEach()) {
-      expect(typeof err.layer).toBe('string')
-      expect(typeof err.kind).toBe('string')
-    }
-  })
-
-  it('should preserve the original name on each concrete class', () => {
-    expect(new EmbeddingError('x').name).toBe('EmbeddingError')
-    expect(new ValidationError('x').name).toBe('ValidationError')
-    expect(new FileOperationError('x').name).toBe('FileOperationError')
-    expect(new DatabaseError('x').name).toBe('DatabaseError')
-    expect(new BaseDirsConfigError('x').name).toBe('BaseDirsConfigError')
-    expect(new VlmError('x', { pageNum: 2 }).name).toBe('VlmError')
+  it('should map each concrete class to its own layer and kind', () => {
+    expect(oneOfEach().map((err) => [err.name, err.layer, err.kind])).toEqual([
+      ['EmbeddingError', 'embedder', 'internal'],
+      ['ValidationError', 'parser', 'validation'],
+      ['FileOperationError', 'parser', 'io'],
+      ['DatabaseError', 'vectordb', 'internal'],
+      ['BaseDirsConfigError', 'config', 'config'],
+      ['VlmError', 'pdf-visual', 'internal'],
+    ])
   })
 
   it('should preserve the cause as the original error object', () => {

--- a/src/utils/__tests__/scope-scan-pushdown.int.test.ts
+++ b/src/utils/__tests__/scope-scan-pushdown.int.test.ts
@@ -32,7 +32,7 @@
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, join, sep } from 'node:path'
+import { basename, join } from 'node:path'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ============================================================================
@@ -350,18 +350,9 @@ describe.each([0, 1])('walker[%i]', (walkerIndex) => {
     expect(scoped).toEqual(unscoped.filter((f) => survivors.has(f)))
   })
 
-  // AC: AC5 — trailing-separator equivalence: /a/b ≡ /a/b/ ≡ /a/b//.
-  // Behavior: three trailing-separator spellings of the same prefix yield one result set.
-  it('treats /a/b, /a/b/ and /a/b// as the same scope', async () => {
-    // Use the OS separator, not a hardcoded "/", so Windows doesn't get a mixed "\...\a\b/" prefix.
-    const plain = walker().files(await walker().run(base, [dirAB]))
-    visited.length = 0
-    const oneSlash = walker().files(await walker().run(base, [`${dirAB}${sep}`]))
-    visited.length = 0
-    const twoSlash = walker().files(await walker().run(base, [`${dirAB}${sep}${sep}`]))
-    expect(sorted(oneSlash)).toEqual(sorted(plain))
-    expect(sorted(twoSlash)).toEqual(sorted(plain))
-  })
+  // Trailing-separator equivalence is a property of the prefix predicate, proved
+  // on it directly in scope-match.test.ts. This file asserts pruning behavior,
+  // which that spelling does not change.
 
   // AC: AC4a — THE load-bearing pushdown proof. A readdir mock that returns
   // EACCES for a scope-outside path AND records visits shows that path is never


### PR DESCRIPTION
## Why

An audit of the test suite against behaviour-vs-implementation, tautology, duplication, and ROI criteria found assertions that carry no defect-detection power but full maintenance cost. The suite runs in ~18s, so runtime was never the problem — coupling was.

## What changed

**Assertions that cannot fail**

- `tool-definitions.test.ts` declared a `SyncStatusResult` literal and asserted that literal's own keys, including a `JSON.parse(JSON.stringify(...))` round-trip against itself. It never executed the module under test; `tsc` already enforces the shape.
- `errors.test.ts` asserted `typeof err.layer === 'string'`, restating the type system and leaving the actual `layer`/`kind` of all six error classes unverified. Now a table of the six real pairs, which absorbs the separate name test.

**Assertions on wiring rather than behaviour**

- `cli/common.test.ts` mocked an internal module to check the argument `createVectorStore` had just passed it. Its one fact, `tableName: 'chunks'`, is proved by every vectordb test that reads the real table.
- `handleIngestFile-visual-validation.test.ts` had four tests counting which parser function was called, with `parser`/`chunker`/`vectordb`/`pdf-visual` all mocked. `ingest-default-mode.test.ts` proves the same routing through a pdf-visual Proxy sentinel plus persisted chunk rows.
- Description-prose regexes in `tool-definitions.test.ts` broke on rewording without catching regressions. The one guard with provenance — that the `list_files` scope description must not claim `query_documents`' stored-`filePath` semantics — stays.

**Duplication**

- Three `visual` invalid-value tests repeated an identical seven-line assertion block; collapsed to one `it.each`. Per-value rejection is already covered on the parse function in `tool-input.test.ts`; what remains proves the handler validates ahead of its first I/O call.
- Five `postProcess` cases moved onto that function directly in the new `captioners-shared.test.ts`, which both captioner profiles share. One wiring test remains in `captioner.test.ts`.
- `lazy-initialization.test.ts` duplicated `embedder.test.ts`, which additionally asserts the underlying `Unsupported device` text.
- `captioner-quality.test.ts` re-proved a shared `postProcess` rule its own sibling test already covers.
- `scope-scan-pushdown.int.test.ts` re-proved trailing-separator equivalence, a predicate property owned by `scope-match.test.ts`. The pruning assertions this file exists for are untouched.

**Coverage added**

`captioners-shared.test.ts` pins three rules of `postProcess` that nothing previously exercised: tab and newline survive control-char stripping, `U+00A0` is content while `U+009F` is stripped, and the length cap measures after stripping. Control characters are built from code points — written literally they made `captioner.test.ts` byte-identical to a binary file, which is why its C1 coverage was unreadable in review and was nearly deleted as dead during this audit.

**Cleanups**

`rag-server.config.test.ts` swaps `as any` private access and a dead `eslint-disable` (this is a Biome project) for a typed accessor.

## CI documentation

`test:e2e` and `test:perf` are reachable from no workflow. That reads as an oversight and gets re-reported on every review, so the reasoning is now recorded where each path is discovered: in `ci.yml` beside the command carrying the exclusions, and in one line per test file pointing back to it. `test:e2e` needs a pre-cached VLM that `prepare-models` does not pin, so a job would fetch from HuggingFace inside a test job; `test:perf` asserts a wall-clock P95 that shared runners cannot hold.

## Flaky CI on merge (HTTP 429)

Merges to `main` failed intermittently, always in one `test` job while the other runner passed on the same commit:

```
Error (429) occurred while trying to load file:
"https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/config.json"
 at Embedder.initialize -> src/__tests__/server/ingest-data.test.ts:445
```

Not flaky test logic — a network dependency. `ingest-data`, `config-warnings`, and `html-workflow.e2e` set `cacheDir` to `./tmp/test-model-cache` instead of going through `testModelCacheDir()`. CI populates and restores only `tmp/models`, so every run downloaded the embedding model into that private directory, once per job, and the outcome depended on HuggingFace's rate limiter. It also contradicted the claim in `ci.yml` that the restore-only cache keeps tests off the network.

All three reach a real embedder (the first two ingest, `config-warnings` embeds a query through `handleQueryDocuments`) and none removes its `cacheDir`, so pointing them at the shared prewarmed cache is safe.

Verified by deleting `tmp/test-model-cache` (87 MB) and rerunning the three files: 52 tests pass and the directory is not recreated.

## Not addressed

`entry-routing.test.ts` is the slowest file at 4.1s over 6 spawned processes (~37% of test time), but it verifies the real binary's entry contract. Consolidating the spawns is an optimisation, not a defect fix, so it is left alone.

## Verification

`pnpm run check:all` passes with zero errors and zero warnings.

```
biome check / lint / format:check   Checked 135 files. No fixes applied.
knip --include exports             clean
dpdm                               53/53, no circular dependency
tsc / tsc -p tsconfig.test.json    clean
pnpm test                          78 files / 1311 tests passed
```

1311 tests, down from 1320, across 410 deleted and 75 added lines. No production source is modified. `ci.yml` was validated through a YAML parser: 6 jobs, the `test` job's 6 steps, and `Run tests` = `pnpm test` are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
