### PR TITLE
docs: streamline README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,42 @@
 [![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
 [![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
 
-Local RAG for developers via MCP or CLI.
-Semantic search with keyword boost for exact technical terms — fully private, zero setup.
+Search private documents from an MCP client or the terminal without sending them to an
+embedding API.
+
+mcp-local-rag indexes PDF, DOCX, Markdown, and text files on your machine. Search combines
+semantic similarity with keyword matching, so queries can match both intent and exact technical
+terms such as API names, class names, and error codes.
 
 ## Features
 
-- **Semantic search with keyword boost**
-  Vector search first, then keyword matching boosts exact matches. Terms like `useEffect`, error codes, and class names rank higher—not just semantically guessed.
+- **Runs locally** — document parsing, embeddings, storage, and search run on your machine.
+  After the initial model download, text ingestion and search work offline.
+- **Hybrid search** — semantic retrieval finds related concepts, while keyword matching boosts
+  exact technical terms.
+- **Semantic chunking** — documents are split at topic boundaries instead of fixed character
+  counts. Markdown code blocks stay intact.
+- **MCP and CLI** — use the same index from an AI coding tool or directly from the terminal.
 
-- **Smart semantic chunking**
-  Chunks documents by meaning, not character count. Uses embedding similarity to find natural topic boundaries—keeping related content together and splitting where topics change.
-
-- **Quality-first result filtering**
-  Groups results by relevance gaps instead of arbitrary top-K cutoffs. Get fewer but more trustworthy chunks.
-
-- **Runs entirely locally**
-  No API keys, no cloud, no data leaving your machine. Works fully offline after the first model download.
-
-- **Zero-friction setup**
-  One `npx` command. No Docker, no Python, no servers to manage.
-  Use via MCP, CLI, or both. Optional [Agent Skills](#agent-skills) help AI assistants form better queries and interpret results.
+No API key, Docker, Python, or external database is required.
 
 ## Quick Start
 
-Set `BASE_DIR` to the folder you want to search (or `BASE_DIRS` for multiple roots — see [Configuration](#configuration)). Documents must live under one of the configured roots.
+### Requirements
+
+- Node.js 22 or later
+- Internet access on first use to download the npm package and embedding model
+- A directory containing the documents you want to search
+
+Set `BASE_DIR` to that directory. It is also the security boundary for file operations. Replace
+`/absolute/path/to/your/documents` below with the directory's absolute path.
 
 Add the MCP server to your AI coding tool:
 
 **For Cursor** — Add to `~/.cursor/mcp.json`:
+
 ```json
 {
   "mcpServers": {
@@ -45,7 +50,7 @@ Add the MCP server to your AI coding tool:
       "command": "npx",
       "args": ["-y", "mcp-local-rag"],
       "env": {
-        "BASE_DIR": "/path/to/your/documents"
+        "BASE_DIR": "/absolute/path/to/your/documents"
       }
     }
   }
@@ -53,537 +58,317 @@ Add the MCP server to your AI coding tool:
 ```
 
 **For Codex** — Add to `~/.codex/config.toml`:
+
 ```toml
 [mcp_servers.local-rag]
 command = "npx"
 args = ["-y", "mcp-local-rag"]
 
 [mcp_servers.local-rag.env]
-BASE_DIR = "/path/to/your/documents"
+BASE_DIR = "/absolute/path/to/your/documents"
 ```
 
 **For Claude Code** — Run this command:
+
 ```bash
-claude mcp add local-rag --scope user --env BASE_DIR=/path/to/your/documents -- npx -y mcp-local-rag
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
 ```
 
-Restart your tool, then start using it:
+Restart the client, then ask it to build the index:
 
-```
-You: "Ingest api-spec.pdf"
-Assistant: Successfully ingested api-spec.pdf (47 chunks created)
-
-You: "What does the API documentation say about authentication?"
-Assistant: Based on the documentation, authentication uses OAuth 2.0 with JWT tokens.
-          The flow is described in section 3.2...
+```text
+Sync all documents in the configured root and wait until it finishes.
 ```
 
-**Or use directly as CLI** — no MCP server needed:
+The first sync downloads the default embedding model (about 90 MB) and may take 1–2 minutes
+before ingestion starts. Later runs use the local cache.
+
+Once the sync completes:
+
+```text
+What does the API documentation say about authentication?
+```
+
+### CLI Quick Start
+
+To use the CLI without an MCP client:
 
 ```bash
 npx mcp-local-rag ingest ./docs/
 npx mcp-local-rag query "authentication API"
 ```
 
-That's it. No Docker, no Python, no server setup.
+The CLI uses the current directory as its document root by default. Run both commands from the
+same directory so they use the same default index, or set `BASE_DIR` and `DB_PATH` explicitly.
 
 ## Why This Exists
 
-You want AI to search your documents—technical specs, research papers, internal docs. But most solutions send your files to external APIs.
+Some document sets cannot be sent to a hosted embedding service because of confidentiality or
+organizational policy. Keeping the index local makes them searchable without adding a per-query
+API cost.
 
-**Privacy.** Your documents might contain sensitive data. This runs entirely locally.
+Semantic search alone can miss exact identifiers that matter in technical documentation.
+Keyword reranking keeps those terms visible without giving up natural-language retrieval.
 
-**Cost.** External embedding APIs charge per use. This is free after the initial model download.
+## Supported Content
 
-**Offline.** Works without internet after setup.
-
-**Code search.** Pure semantic search misses exact terms like `useEffect` or `ERR_CONNECTION_REFUSED`. Keyword boost catches both meaning and exact matches.
-
-**Agent reality.** In practice, many AI environments mainly use tool calling. CLI support and Agent Skills make the same workflows available even without full MCP integration.
-
-## Usage
-
-mcp-local-rag provides two interfaces: an **MCP server** for AI coding tools and a **CLI** for direct use from the terminal.
-
-### Using with MCP
-
-The MCP server provides 9 tools: `ingest_file`, `ingest_data`, `query_documents`, `read_chunk_neighbors`, `list_files`, `delete_file`, `status`, `sync_start`, `sync_status`.
-
-#### Ingesting Documents
-
-```
-"Ingest the document at /Users/me/docs/api-spec.pdf"
-```
-
-Supports PDF, DOCX, TXT, and Markdown. The server extracts text, splits it into chunks, generates embeddings locally, and stores everything in a local vector database.
-
-Re-ingesting the same file replaces the old version automatically.
-
-##### Ingesting PDFs with figures (visual mode)
-
-PDFs with charts, tables, or diagrams can optionally add local VLM-generated captions to the document index, giving visual content some searchable representation in the same vector + FTS pipeline. Captions are auxiliary text — not image search, not OCR, and not a faithful transcription of the figure.
-
-**Via MCP**:
-```
-"Ingest /Users/me/docs/api-spec.pdf with visual: true"
-```
-
-**Via CLI**:
-```bash
-npx mcp-local-rag ingest ./docs/spec.pdf --visual
-```
-
-Each caption is emitted as its own chunk with the envelope `[Visual content on page N: …]`, alongside the page-body chunks. It flows through the existing embedder and FTS index — no schema differences, no separate index.
-
-Visual mode is opt-in; normal ingest does not load the VLM. Per-page VLM failures are tolerated — that page proceeds with text only.
-
-###### Choosing a visual-quality profile
-
-Visual mode offers two profiles, selected per ingest call:
-
-| Profile | Model | Disk (cache) | Per-page inference | Suited for |
-|---|---|---|---|---|
-| `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Light visual indexing, quick first-run setup. |
-| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than inference time. |
-
-The numbers above are measured on CPU during development on the project's probe PDFs; they may shift with model updates or differ on your hardware.
-
-**Via MCP** — `ingest_file` accepts an optional `visualQuality` parameter (enum: `'fast' | 'quality'`, default `'fast'`; ignored when `visual` is false):
-```
-"Ingest /Users/me/docs/research-paper.pdf with visual: true and visualQuality: 'quality'"
-```
-
-**Via CLI** — `--visual-quality fast|quality` (default `fast`; silently ignored when `--visual` is absent):
-```bash
-npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
-```
-
-Profile model identifiers and quantization variants are fixed per release. Both profiles share the same `CACHE_DIR` (default: `./models/`); the first run on each profile downloads its model.
-
-> **Behavior change from v0.14.0**: Captions are now emitted as dedicated chunks rather than appended to the page text before chunking. As a side effect, `metadata.fileSize` for visual ingests no longer includes the caption character count — it measures the post-extraction body length only. The underlying PDF is unchanged; only the reported `fileSize` for visual-ingested PDFs may shrink across the release boundary.
-
-> **Security note**: Visual captions are derived from PDF contents and may inherit attacker-controlled text. Downstream LLM consumers should treat retrieved chunks as untrusted data, not as instructions. The `[Visual content on page N: …]` envelope helps consumers distinguish caption text from prose.
-
-#### Ingesting HTML Content
-
-Use `ingest_data` to ingest HTML content retrieved by your AI assistant (via web fetch, curl, browser tools, etc.):
-
-```
-"Fetch https://example.com/docs and ingest the HTML"
-```
-
-The server extracts main content using Readability (removes navigation, ads, etc.), converts to Markdown, and indexes it. Perfect for:
-- Web documentation
-- HTML retrieved by the AI assistant
-- Clipboard content
-
-HTML is automatically cleaned—you get the article content, not the boilerplate.
-
-> **Note:** The RAG server itself doesn't fetch web content—your AI assistant retrieves it and passes the HTML to `ingest_data`. This keeps the server fully local while letting you index any content your assistant can access. Please respect website terms of service and copyright when ingesting external content.
-
-#### Searching Documents
-
-```
-"What does the API documentation say about authentication?"
-"Find information about rate limiting"
-"Search for error handling best practices"
-```
-
-Search uses semantic similarity with keyword boost. This means `useEffect` finds documents containing that exact term, not just semantically similar React concepts.
-
-Results include text content, source file, document title, and relevance score. The document title provides context for each chunk, helping identify which document a result belongs to. Adjust result count with `limit` (1-20, default 10).
-
-Narrow a search to part of your corpus with `scope` — one path prefix or a list of them. Results are restricted to chunks whose file path equals a prefix or sits under it (exact-or-descendant). For example, `"/docs/api"` matches `/docs/api` and `/docs/api/auth.md` but not `/docs/apiv2`; a file prefix like `"/docs/readme.md"` matches just that file. Pass prefixes in the server's OS path style.
-
-#### Expanding Context Around a Result
-
-When a search result needs more surrounding context, use `read_chunk_neighbors` to read the chunks before and after it:
-
-```
-"That result about authentication looks relevant — read the surrounding chunks for the full explanation"
-```
-
-Pass the `filePath` and `chunkIndex` from the search result. The response includes the target chunk (marked `isTarget: true`) plus its neighbors, sorted by chunk index. Defaults to 2 chunks before and 2 after (adjustable up to 50 each).
-
-#### Managing Files
-
-```
-"List all files in configured base directories and their ingested status"   # See what's indexed
-"Delete old-spec.pdf from RAG"     # Remove a file
-"Show RAG server status"           # Check system health
-```
-
-Narrow the listing with `scope` on `list_files` — one path prefix or a list of them. Results are restricted to files reachable at a path equal to or under a prefix (exact-or-descendant); for example, `"/docs/api"` matches `/docs/api` and `/docs/api/auth.md` but not `/docs/apiv2`. Raw-data sources (from `ingest_data`) stay listed regardless of scope. On large volumes, scope also speeds up the listing by skipping out-of-scope directories during the scan.
-
-#### Synchronizing the Index
-
-When files under a configured root change outside your assistant, `sync_start` brings the index back in line: new and changed files are re-ingested, byte-identical files are left untouched, and entries whose source file is gone are removed.
-
-```
-"Sync the index with /Users/me/docs"
-"Sync everything and tell me when it's finished"
-```
-
-`sync_start` takes an optional absolute `path` — a file or a directory inside a configured root; omit it to cover every root — and returns a `jobId` without waiting for the run to finish. Progress is read by polling `sync_status` with that `jobId` until `state` is no longer `running`:
-
-| Field | Meaning |
+| Input | How to ingest |
 |---|---|
-| `state` | `running`, `succeeded`, or `failed`. A job succeeds only when `error` is `null`. |
-| `total` | `null` until the scan has counted the supported files whose bytes it read, then a number. A file skipped for exceeding `MAX_FILE_SIZE` is never read, so it is not counted. |
-| `completed` | `upserted + skipped + empty`; never more than a non-null `total`. |
-| `summary` | `upserted` (new or changed, re-ingested), `skipped` (bytes identical, untouched), `empty` (produced no chunks; prior chunks kept and retried next run), `pruned` (indexed files whose source is gone). `pruned` is counted outside `completed`. |
-| `warnings` | Parts of the scope the scan could not observe — an unreadable directory, a subtree past the scan-depth limit, a symbolic link (the scan never descends into one), or a file larger than `MAX_FILE_SIZE` (never read). Indexed files under them are kept rather than pruned. Paths are shown with your home directory abbreviated to `~`. |
-| `error` | `null` unless the job failed; a failed job carries one message and, for a per-file failure, the file path. |
+| PDF, DOCX, TXT, Markdown | File ingestion or directory sync |
+| HTML already fetched by the client | `ingest_data`; cleaned with Readability and converted to Markdown |
+| Plain text or Markdown held in memory | `ingest_data` with a stable source identifier |
 
-Whether `path` is inside a configured root is decided from its real location, not from how it is spelled: a path that leaves every root through a symlinked parent directory is refused before anything reads it, with one message that reveals nothing about the target — not whether it exists, and not whether it is readable. A path that is inside a root keeps its own specific message (does not exist, is a symbolic link, is not a regular file or directory, is inside the database or cache directory, is not a supported document type).
+HTML fetching is not built into the server. An MCP client can fetch a page and pass its HTML to
+`ingest_data`.
 
-Every run hashes the full bytes of every file it scans, so cost scales with the size of the corpus rather than the number of changes. There is no visual mode on sync — a changed PDF is re-ingested as text.
+Excel, PowerPoint, standalone images, and source-code file extensions are not supported by file
+ingestion. PDFs can optionally use a local vision model to describe figures, but this is not OCR
+or image search.
 
-While a sync is running, that server refuses `sync_start`, `ingest_file`, `ingest_data`, and `delete_file` with an error naming the active `jobId`; poll `sync_status` instead of retrying. Search and inspection (`query_documents`, `read_chunk_neighbors`, `list_files`, `status`, `sync_status`) keep working throughout. After a failure, fix the cause and start a new sync — nothing is retried, resumed, or cancelled, and re-ingests that already completed are kept.
+## MCP Tools
 
-The server keeps only the current or latest job: starting a new one replaces a finished record, after which the older `jobId` is reported as unknown, and stopping the server discards the job entirely. Job state lasts only as long as the server process — there is no history and no recovery after a restart, so polling is how a client learns the outcome.
+| Tool | Purpose |
+|---|---|
+| `sync_start` | Reconcile the index with all configured roots or one path |
+| `sync_status` | Poll a running sync job |
+| `ingest_file` | Ingest or replace one file |
+| `ingest_data` | Ingest text, Markdown, or HTML already held by the client |
+| `query_documents` | Search with semantic matching and keyword boost |
+| `read_chunk_neighbors` | Read surrounding chunks from a search result |
+| `list_files` | Show supported files and their ingestion state |
+| `delete_file` | Delete an indexed file or an `ingest_data` item |
+| `status` | Show index and search status |
 
-The same reconciliation is available as the CLI [`sync` command](#using-as-cli), which runs in the foreground and prints the counters as JSON. Either way, only one writer may touch a database path at a time: keep MCP and CLI `ingest`, `delete`, and `sync` mutations against one `DB_PATH` to a single process — a sync inside the MCP server only excludes mutations in that same process. A background CLI `sync` may run alongside MCP read-only tools.
+### Syncing a Document Root
 
-### Using as CLI
+`sync_start` ingests new and changed files, skips byte-identical files, and removes index entries
+for files that no longer exist:
 
-Most MCP tools are also available as CLI commands — no MCP server needed. `sync_status` has no CLI counterpart, since the CLI `sync` blocks until the sync completes and leaves nothing to poll:
-
-```bash
-npx mcp-local-rag ingest ./docs/               # Bulk ingest files
-npx mcp-local-rag sync ./docs/                  # Reconcile the index with disk
-npx mcp-local-rag sync                          # Same, for every configured root
-npx mcp-local-rag query "authentication API"    # Search documents
-npx mcp-local-rag query "auth" --scope /docs/api --scope /docs/guide  # Restrict to path prefixes (repeatable)
-npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5  # Expand context
-npx mcp-local-rag list                          # Show ingestion status
-npx mcp-local-rag list --scope /docs/api --scope /docs/guide  # Restrict listing to path prefixes (repeatable)
-npx mcp-local-rag status                        # Database stats
-npx mcp-local-rag delete ./docs/old.pdf         # Remove content
-npx mcp-local-rag delete --source "https://..."  # Remove by source URL
+```text
+Sync everything under the configured document roots and wait for completion.
 ```
 
-`query`, `read-neighbors`, `list`, `status`, and `delete` output JSON to stdout for piping (e.g., `| jq`). `ingest` outputs progress to stderr; `sync` reports its counters (`upserted`, `skipped`, `empty`, `pruned`) as JSON on stdout, names each upserted and pruned path on stderr as it happens, runs in the foreground, and exits non-zero on the first error. Global options (`--db-path`, `--cache-dir`, `--model-name`) go before the subcommand. Run `npx mcp-local-rag --help` for details.
+The tool returns a `jobId` immediately. Clients should poll `sync_status` until its state becomes
+`succeeded` or `failed`. There is no visual mode during sync; changed PDFs are ingested as text.
 
-> ⚠️ The CLI does **not** read your MCP client config (`mcp.json`, `config.toml`, etc.). Configure the CLI via flags or environment variables as shown below.
+Only one sync job is retained by the server process. A newer job replaces a finished record, and
+restarting the server discards it.
 
-> ⚠️ **One writer at a time.** Keep CLI and MCP `ingest`, `delete`, and `sync` mutations against one database path to a single process. Nothing enforces this across processes — it is an operating constraint you keep. A background CLI `sync` may run alongside MCP read-only tools (`query_documents`, `list_files`, `status`, `read_chunk_neighbors`).
+### Ingesting One File
 
-#### Configuration
+`ingest_file` accepts PDF, DOCX, TXT, and Markdown. MCP file paths must be absolute and must stay
+inside a configured document root:
 
-**CLI flags** — global options go before the subcommand, subcommand options go after:
-
-```bash
-npx mcp-local-rag --db-path ./my-db query "auth" --base-dir ./docs
+```text
+Ingest the document at /Users/me/docs/api-spec.pdf.
 ```
 
-The `--base-dir` flag is repeatable on `ingest` and `list`; pass it once per root:
+Re-ingesting the same path replaces its existing chunks.
 
-```bash
-npx mcp-local-rag ingest --base-dir ./docs --base-dir ./specs ./docs/readme.md
-npx mcp-local-rag list --base-dir ./docs --base-dir ./specs
+### Searching and Reading More Context
+
+```text
+What does the API documentation say about authentication?
+Find the documented behavior of ERR_CONNECTION_REFUSED.
 ```
 
-The positional path to `ingest`, and to `sync` when given, must sit inside one of the configured roots. `sync` accepts no `--base-dir`; it reads its roots from `BASE_DIRS` / `BASE_DIR`. When at least one `--base-dir` is supplied, CLI roots replace any env-var roots (no merge).
+Results contain the text, source path, title, chunk index, and relevance score. Pass the
+`chunkIndex` and either `filePath` or `source` from a result to `read_chunk_neighbors` when the
+answer needs more context:
 
-**Environment variables** — set in your shell:
-
-```bash
-export DB_PATH=./my-db
-export BASE_DIR=./docs
-npx mcp-local-rag query "auth"
+```text
+Read the surrounding chunks for that authentication result.
 ```
 
-For multiple roots, use `BASE_DIRS` (JSON array of non-empty path strings):
+Both `query_documents` and `list_files` accept an optional absolute `scope` path prefix, or a
+list of prefixes. A prefix matches the exact path and its descendants.
+
+### Ingesting HTML
+
+Use `ingest_data` after the MCP client fetches a page:
+
+```text
+Fetch https://example.com/docs and ingest the HTML.
+```
+
+The server extracts the main article, converts it to Markdown, and stores it under the supplied
+source identifier. Reusing the same source updates the existing content.
+
+Respect the source site's terms and copyright when indexing external content.
+
+### PDF Figures
+
+Visual mode adds a generated caption for figure-heavy PDF pages. It is opt-in and does not load
+a vision model during normal ingestion.
+
+```text
+Ingest /Users/me/docs/research-paper.pdf with visual: true.
+```
 
 ```bash
-export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| Profile | Model cache | Use case |
+|---|---:|---|
+| `fast` (default) | about 250 MB | Lightweight visual indexing |
+| `quality` | about 2.9 GB | Figures containing labels, annotations, or other in-image text |
+
+Select the larger model with `visualQuality: "quality"` over MCP or
+`--visual-quality quality` over CLI. Measured CPU inference was about twice as slow as `fast`,
+though results depend on hardware and model updates.
+
+Captions are auxiliary text, not faithful transcriptions. Treat retrieved captions and document
+text as untrusted input rather than instructions.
+
+## CLI
+
+The CLI uses the same parser, embedder, and vector store without an MCP client:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "authentication API"
+npx mcp-local-rag query "auth" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
 npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
 ```
 
-**Sharing config between MCP and CLI** — if your MCP client inherits shell environment variables, you can set them in your shell profile (e.g., `~/.zshrc`) so both use the same values. Otherwise, set them explicitly in your MCP config as well.
+Global options such as `--db-path`, `--cache-dir`, and `--model-name` go before the subcommand.
+Subcommand options go after it:
 
 ```bash
-export BASE_DIR=/path/to/your/documents
-export DB_PATH=/path/to/lancedb
+npx mcp-local-rag --db-path ./my-db query "authentication"
 ```
 
-Configuration is resolved in this order:
+Run `npx mcp-local-rag --help` for the complete command reference.
 
-1. CLI flags (highest priority)
-2. Environment variables
-3. Defaults
-
-For the full list of CLI flags, environment variables, and defaults, see [Configuration](#configuration).
-
-For CLI-only setups (no MCP server), install [Agent Skills](#agent-skills) so your AI assistant can form better queries and interpret results consistently.
-
-> ⚠️ **CLI `--model-name` must match the MCP server's `MODEL_NAME` env var.** Using a different embedding model against an existing database produces incompatible vectors, silently degrading search quality.
+The CLI does not read MCP client configuration. Set the same environment variables or flags if
+both interfaces should share an index. In particular, `MODEL_NAME` and the CLI `--model-name`
+must match for a shared database.
 
 ## Search Tuning
 
-Adjust these for your use case:
+Keyword boost is enabled by default. Relevance-gap grouping and the distance and file filters are
+optional controls for corpora that need tighter result selection.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `RAG_HYBRID_WEIGHT` | `0.6` | Keyword boost factor. 0 = semantic only, higher = stronger keyword boost. |
-| `RAG_GROUPING` | (not set) | `similar` for top group only, `related` for top 2 groups. |
+| `RAG_HYBRID_WEIGHT` | `0.6` | Keyword boost factor (0.0–1.0). 0 disables keyword reranking; 1 applies the maximum boost. |
+| `RAG_GROUPING` | (not set) | `similar` keeps the first relevance group; `related` keeps up to two, using significant vector-distance gaps as boundaries. |
 | `RAG_MAX_DISTANCE` | (not set) | Filter out low-relevance results (e.g., `0.5`). |
 | `RAG_MAX_FILES` | (not set) | Limit results to top N files (e.g., `1` for single best file). |
 
-### Code-focused tuning
-
-For codebases and API specs, increase keyword boost so exact identifiers (`useEffect`, `ERR_*`, class names) dominate ranking:
+For API specifications and other documents containing many identifiers, a stronger keyword
+weight can improve exact-term ranking:
 
 ```json
 "env": {
-  "RAG_HYBRID_WEIGHT": "0.7",
-  "RAG_GROUPING": "similar"
+  "RAG_HYBRID_WEIGHT": "0.7"
 }
 ```
 
-- `0.7` — balanced semantic + keyword
-- `1.0` — aggressive; exact matches strongly rerank results
-
-Keyword boost is applied *after* semantic filtering, so it improves precision without surfacing unrelated matches.
+- `0.7` — slightly stronger exact-term reranking than the default
+- `1.0` — maximum keyword boost
 
 ## How It Works
 
-**TL;DR:**
-- Documents are chunked by semantic similarity, not fixed character counts
-- Each chunk is embedded locally using Transformers.js
-- Search uses semantic similarity with keyword boost for exact matches
-- Results are filtered based on relevance gaps, not raw scores
+During ingestion:
 
-### Details
+1. The parser extracts text for the input format.
+2. The semantic chunker finds topic boundaries and preserves Markdown code blocks.
+3. Transformers.js creates embeddings locally.
+4. LanceDB stores the chunks, metadata, vectors, and full-text index.
 
-When you ingest a document, the parser extracts text based on file type (PDF via `mupdf`, DOCX via `mammoth`, text files directly).
+During search:
 
-The semantic chunker splits text into sentences, then groups them using embedding similarity. It finds natural topic boundaries where the meaning shifts—keeping related content together instead of cutting at arbitrary character limits. This produces chunks that are coherent units of meaning, typically 500-1000 characters. Markdown code blocks are kept intact—never split mid-block—preserving copy-pastable code in search results.
-
-Each chunk goes through a Transformers.js embedding model (default: `all-MiniLM-L6-v2`, configurable via `MODEL_NAME`), converting text into vectors. Vectors are stored in LanceDB, a file-based vector database requiring no server process.
-
-When you search:
-1. Your query becomes a vector using the same model
-2. Semantic (vector) search finds the most relevant chunks
-3. Quality filters apply (distance threshold, grouping)
-4. Keyword matches boost rankings for exact term matching
-
-The keyword boost ensures exact terms like `useEffect` or error codes rank higher when they match.
+1. The query is embedded with the same model.
+2. Vector search retrieves semantically related chunks.
+3. Optional distance and relevance-group filters narrow the candidates when configured.
+4. Full-text matches boost exact query terms.
 
 ## Agent Skills
 
-[Agent Skills](https://agentskills.io/) provide optimized prompts that help AI assistants use RAG tools more effectively. Install skills for better query formulation, result interpretation, and ingestion workflows:
+[Agent Skills](https://agentskills.io/) provide query and ingestion guidance for AI assistants:
 
 ```bash
-# Claude Code (project-level)
 npx mcp-local-rag skills install --claude-code
-
-# Claude Code (user-level)
 npx mcp-local-rag skills install --claude-code --global
-
-# Codex
 npx mcp-local-rag skills install --codex
 ```
 
-Skills include:
-- **Query optimization**: Better search query formulation
-- **Result interpretation**: Score thresholds and filtering guidelines
-- **HTML ingestion**: Format selection and source naming
-
-### Ensuring Skill Activation
-
-Skills are loaded automatically in most cases—AI assistants scan skill metadata and load relevant instructions when needed. For consistent behavior:
-
-**Option 1: Explicit request (natural language)**
-Before RAG operations, request in natural language:
-- "Use the mcp-local-rag skill for this search"
-- "Apply RAG best practices from skills"
-
-**Option 2: Add to agent instruction file**
-Add to your `AGENTS.md`, `CLAUDE.md`, or other agent instruction file:
-```
-When using query_documents, ingest_file, or ingest_data tools,
-apply the mcp-local-rag skill for better query formulation and result interpretation.
-```
+Installed skills cover query formulation, result refinement, and HTML ingestion. Ask the
+assistant to use the mcp-local-rag skill explicitly if it does not activate automatically.
 
 ## Configuration
 
-### Environment Variables and CLI Flags
-
-The MCP server is configured by environment variables only — pass them through your MCP client's `env` block. The CLI accepts the same env vars plus equivalent flags (priority: CLI flag > env > default). CLI flags are not accepted on the bare `mcp-local-rag` (MCP server) launch.
+The MCP server reads environment variables. The CLI accepts the same variables plus the listed
+flags, with CLI flags taking precedence.
 
 | Environment Variable | CLI Flag | Default | Description |
 |---------------------|----------|---------|-------------|
-| `BASE_DIR` | `--base-dir` (repeatable) | Current directory | Single document root directory (security boundary). See [Document Roots](#document-roots-base_dir-and-base_dirs) for multi-root setup. |
-| `BASE_DIRS` | — | (unset) | JSON array of document roots (security boundary). Takes precedence over `BASE_DIR`. See [Document Roots](#document-roots-base_dir-and-base_dirs). |
+| `BASE_DIR` | `--base-dir` | Current directory | One document root; the CLI flag is repeatable on `ingest` and `list` |
+| `BASE_DIRS` | — | (unset) | JSON array of document roots; takes precedence over `BASE_DIR` |
 | `DB_PATH` | `--db-path` | `./lancedb/` | Vector database location |
 | `CACHE_DIR` | `--cache-dir` | `./models/` | Model cache directory |
-| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model ID ([available models](https://huggingface.co/models?library=transformers.js&pipeline_tag=feature-extraction)) |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Hugging Face embedding model |
 | `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100MB) | Maximum file size in bytes |
 | `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Minimum chunk length in characters (1–10000) |
-| `RAG_DEVICE` | — | `cpu` | Execution device. Passed straight to ONNX Runtime. See the [Transformers.js device source code](https://github.com/huggingface/transformers.js/blob/main/packages/transformers/src/utils/devices.js) for the live list of supported backend names. If initialization fails, the server throws an error. |
-| `RAG_DTYPE` | — | `fp32` | Embedding quantization dtype. Opt-in and passed straight through; accepts any dtype the chosen model provides (`fp32`, `fp16`, `q8`, `int8`, …). If the model lacks the requested variant, the server throws an error naming the dtypes it does provide. Changing `RAG_DEVICE`/`RAG_DTYPE` changes the embedding space — re-ingest existing data. |
-
-**Model choice tips:**
-- Multilingual docs → e.g., `onnx-community/embeddinggemma-300m-ONNX` (100+ languages)
-- Scientific papers → e.g., `sentence-transformers/allenai-specter` (citation-aware)
-- Code repositories → default often suffices; keyword boost matters more (or `jinaai/jina-embeddings-v2-base-code`)
-
-⚠️ Changing `MODEL_NAME` changes embedding dimensions. Delete `DB_PATH` and re-ingest after switching models.
+| `RAG_DEVICE` | — | `cpu` | ONNX Runtime execution device |
+| `RAG_DTYPE` | — | `fp32` | Embedding dtype supplied by the selected model |
 
 ### Document Roots (`BASE_DIR` and `BASE_DIRS`)
 
-mcp-local-rag enforces a security boundary: only files under a configured root are accessible to ingest, list, delete, or read-neighbor operations.
-
-**Single root** — use `BASE_DIR`:
-
-```bash
-export BASE_DIR=/Users/me/Documents/work
-```
-
-**Multiple roots** — use `BASE_DIRS` with a JSON array:
+mcp-local-rag only allows file operations inside configured roots. For multiple roots,
+`BASE_DIRS` must be a JSON array of non-empty paths:
 
 ```bash
 export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
 ```
 
-Only JSON-array syntax is supported. Delimiter syntax such as `BASE_DIRS=/a:/b` is intentionally **not** supported (avoids ambiguity with spaces, colons, commas, and Windows paths).
-
-**Resolution order** (highest precedence first):
+Root configuration is resolved in this order:
 
 1. CLI `--base-dir <path>` flags (repeatable on `ingest` and `list`)
-2. `BASE_DIRS` environment variable
-3. `BASE_DIR` environment variable
-4. `process.cwd()` (current working directory)
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. Current directory
 
-CLI roots **replace** env roots — they are never merged. `BASE_DIRS` and `BASE_DIR` are never merged either: `BASE_DIRS` wins when both are set.
-
-**Precedence warning** — when `BASE_DIRS` and `BASE_DIR` are both set (and no CLI `--base-dir` is supplied), `BASE_DIR` is ignored and a warning is surfaced. The warning is visible:
-
-- In MCP tool responses (as an additional content block, on every tool — including `status`, `query_documents`, `ingest_file`, `ingest_data`, `list_files`, `delete_file`, `read_chunk_neighbors`).
-- On CLI `stderr`.
-
-Unset `BASE_DIR` (or remove `BASE_DIRS`) to silence the warning.
-
-**Nested-root pruning** — if one configured root sits inside another after realpath resolution, the nested child is dropped to avoid duplicate scan results. A pruning warning is surfaced the same way as the precedence warning. The surviving parent root still defines the security boundary.
-
-**Invalid `BASE_DIRS`** — when `BASE_DIRS` is not a valid JSON array of non-empty strings (malformed JSON, empty array, non-string elements, ...), root-dependent MCP tools return a structured error and CLI subcommands exit non-zero. There is **no silent fallback** to `BASE_DIR` or `cwd`. The MCP `status` tool remains callable so you can diagnose the config error through your MCP client.
-
-**MCP client examples** — multi-root setup:
-
-Cursor (`~/.cursor/mcp.json`):
-```json
-{
-  "mcpServers": {
-    "local-rag": {
-      "command": "npx",
-      "args": ["-y", "mcp-local-rag"],
-      "env": {
-        "BASE_DIRS": "[\"/Users/me/Documents/work\",\"/Users/me/Projects/specs\"]"
-      }
-    }
-  }
-}
-```
-
-Codex (`~/.codex/config.toml`):
-```toml
-[mcp_servers.local-rag]
-command = "npx"
-args = ["-y", "mcp-local-rag"]
-
-[mcp_servers.local-rag.env]
-BASE_DIRS = "[\"/Users/me/Documents/work\",\"/Users/me/Projects/specs\"]"
-```
-
-Claude Code:
-```bash
-claude mcp add local-rag --scope user \
-  --env BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]' \
-  -- npx -y mcp-local-rag
-```
-
-**CLI examples** — multi-root invocations:
+Each source replaces the lower-priority source rather than merging with it. Invalid `BASE_DIRS`
+configuration fails instead of falling back to `BASE_DIR` or the current directory. `status`
+remains available in MCP so the client can report the configuration error.
 
 ```bash
-# Repeatable --base-dir
 npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
 npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
-
-# Or via BASE_DIRS env
 BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
 ```
 
-### Client-Specific Setup
+### Storage and Models
 
-**Cursor** — Global: `~/.cursor/mcp.json`, Project: `.cursor/mcp.json`
+`DB_PATH` and `CACHE_DIR` are relative to the process working directory by default. Set absolute
+paths when the MCP client may start the server from different project directories.
 
-```json
-{
-  "mcpServers": {
-    "local-rag": {
-      "command": "npx",
-      "args": ["-y", "mcp-local-rag"],
-      "env": {
-        "BASE_DIR": "/path/to/your/documents"
-      }
-    }
-  }
-}
-```
+Changing `MODEL_NAME`, `RAG_DEVICE`, or `RAG_DTYPE` can make existing vectors incompatible.
+Use a new `DB_PATH` or delete the existing index and re-ingest after changing the embedding
+configuration.
 
-**Codex** — `~/.codex/config.toml` (note: must use `mcp_servers` with underscore)
+Model examples:
 
-```toml
-[mcp_servers.local-rag]
-command = "npx"
-args = ["-y", "mcp-local-rag"]
+- Multilingual documents: `onnx-community/embeddinggemma-300m-ONNX`
+- Scientific papers: `sentence-transformers/allenai-specter`
 
-[mcp_servers.local-rag.env]
-BASE_DIR = "/path/to/your/documents"
-```
+## Security and Operation
 
-**Claude Code**:
-
-```bash
-claude mcp add local-rag --scope user \
-  --env BASE_DIR=/path/to/your/documents \
-  -- npx -y mcp-local-rag
-```
-
-### First Run
-
-The embedding model (~90MB) downloads on first use. Takes 1-2 minutes, then works offline.
-
-### Security
-
-- **Path restriction**: Only files within a configured root (`BASE_DIR` or any `BASE_DIRS` / `--base-dir` entry) are accessible. Symlinks resolving outside all configured roots, and sibling-prefix paths (e.g. `/foo/barista` for root `/foo/bar`), are rejected.
-- **Local only**: No network requests after model download
-- **Model sources** (all official HuggingFace repositories):
-  - Embedder: [`Xenova/all-MiniLM-L6-v2`](https://huggingface.co/Xenova/all-MiniLM-L6-v2)
-  - Visual `fast` profile: [`HuggingFaceTB/SmolVLM-256M-Instruct`](https://huggingface.co/HuggingFaceTB/SmolVLM-256M-Instruct)
-  - Visual `quality` profile: [`onnx-community/Qwen2.5-VL-3B-Instruct-ONNX`](https://huggingface.co/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX)
-- **Visual caption fidelity**: The `quality` profile reproduces in-image text more faithfully than `fast`. Both profiles output captions wrapped as `[Visual content on page N: …]`, but a faithful reproduction means attacker-controlled in-image text — including characters like `]` that visually close the envelope — can appear verbatim in retrieved chunks. Downstream LLM consumers should treat retrieved chunks as untrusted data, not as instructions, regardless of envelope shape.
-
-<details>
-<summary><strong>Performance</strong></summary>
-
-Tested on MacBook Pro M1 (16GB RAM), Node.js 22:
-
-**Query Speed**: ~1.2 seconds for 10,000 chunks (p90 < 3s)
-
-**Ingestion** (10MB PDF):
-- PDF parsing: ~8s
-- Chunking: ~2s
-- Embedding: ~30s
-- DB insertion: ~5s
-
-**Memory**: ~200MB idle, ~800MB peak (50MB file ingestion)
-
-**Concurrency**: Handles 5 parallel queries without degradation.
-
-</details>
+- File access is restricted to `BASE_DIR`, `BASE_DIRS`, or CLI `--base-dir` roots.
+- Symlinks that resolve outside every configured root are rejected.
+- Document processing and search make no network requests after the required models are cached.
+- The server is designed for one local user and does not provide authentication or access control.
+- Do not run multiple CLI or MCP writers against the same `DB_PATH`. Read-only queries can run
+  while a sync is active.
+- Back up an index by copying its `DB_PATH` directory while no writer is active.
 
 <details>
 <summary><strong>Troubleshooting</strong></summary>
@@ -610,95 +395,17 @@ Ensure file paths are within one of the configured roots (`BASE_DIR`, any `BASE_
 
 ### "BASE_DIRS must be a JSON array..."
 
-`BASE_DIRS` accepts only a JSON array of one or more non-empty path strings. Examples:
+`BASE_DIRS` accepts a JSON array of one or more non-empty path strings:
 
 - Valid: `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
 - Invalid: `BASE_DIRS=/a:/b` (delimiter syntax not supported)
 - Invalid: `BASE_DIRS='[]'` (empty array)
-- Invalid: `BASE_DIRS='["",""]'` (empty string element)
-
-When invalid, root-dependent operations fail with a clear error rather than silently falling back. The MCP `status` tool remains callable so you can inspect the diagnostic.
 
 ### MCP client doesn't see tools
 
 1. Verify config file syntax
 2. Restart client completely (Cmd+Q on Mac for Cursor)
 3. Test directly: `npx mcp-local-rag` should run without errors
-
-</details>
-
-<details>
-<summary><strong>FAQ</strong></summary>
-
-**Is this really private?**
-Yes. After model download, nothing leaves your machine. Verify with network monitoring.
-
-**Can I use this offline?**
-Yes, after the required models are cached locally. Text ingest/search needs the embedding model. PDF visual mode is opt-in and also needs the VLM model on first use; the download is ~250 MB for the default `fast` profile (SmolVLM-256M) or ~2.9 GB for the `quality` profile (Qwen2.5-VL-3B), cached under `CACHE_DIR` (default: `./models/`).
-
-**How does this compare to cloud RAG?**
-Cloud services offer better accuracy at scale but require sending data externally. This trades some accuracy for complete privacy and zero runtime cost.
-
-**What file formats are supported?**
-PDF, DOCX, TXT, Markdown, and HTML (via `ingest_data`). Not yet: Excel, PowerPoint, images.
-
-**Can I change the embedding model?**
-Yes, but you must delete your database and re-ingest all documents. Different models produce incompatible vector dimensions.
-
-**GPU acceleration?**
-Opt-in via `RAG_DEVICE`. Devices are passed straight to ONNX Runtime. GPU support is highly dependent on your system, Node.js version, and the underlying ONNX backend. See the [Transformers.js device source code](https://github.com/huggingface/transformers.js/blob/main/packages/transformers/src/utils/devices.js) for the live list of supported backend names. If the requested device fails to initialize, the server throws an error — set `RAG_DEVICE=cpu` to revert.
-
-**Can I change the embedding precision (dtype)?**
-Opt-in via `RAG_DTYPE` (default `fp32`); accepted values are in the env-var table above. A recognized dtype the model lacks errors and lists the available ones; an unrecognized value (a typo) silently falls back to `fp32`. Changing `RAG_DEVICE`/`RAG_DTYPE` changes the embedding space — delete `DB_PATH` and re-ingest.
-
-**Multi-user support?**
-No. Designed for single-user, local access. Multi-user would require authentication/access control.
-
-**How to backup?**
-Copy `DB_PATH` directory (default: `./lancedb/`).
-
-</details>
-
-<details>
-<summary><strong>Development</strong></summary>
-
-### Building from Source
-
-```bash
-git clone https://github.com/shinpr/mcp-local-rag.git
-cd mcp-local-rag
-pnpm install
-```
-
-### Testing
-
-```bash
-pnpm test              # Run all tests
-pnpm run test:watch    # Watch mode
-```
-
-### Code Quality
-
-```bash
-pnpm run type-check    # TypeScript check
-pnpm run check:fix     # Lint and format
-pnpm run check:deps    # Circular dependency check
-pnpm run check:all     # Full quality check
-```
-
-### Project Structure
-
-```
-src/
-  index.ts      # Entry point
-  server/       # MCP tool handlers
-  cli/          # CLI subcommands (ingest, query, list, delete, read-neighbors, etc.)
-  parser/       # PDF, DOCX, TXT, MD parsing
-  chunker/      # Text splitting
-  embedder/     # Transformers.js embeddings
-  vectordb/     # LanceDB operations
-  __tests__/    # Test suites
-```
 
 </details>
 


### PR DESCRIPTION
## Summary

- refocus the README on private local document search, hybrid retrieval, and semantic chunking
- provide a clearer first-run path for MCP clients and the CLI, including prerequisites and absolute-path requirements
- condense the reference sections while clarifying supported content, search tuning, storage, and operational constraints

## Validation

- `git diff --check`
- `biome check src` (pre-push hook)
- `tsc` (pre-push hook)
- test suite not run because this change only updates documentation