### PR TITLE
fix: defer embedding batch outliers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.17.1",
+  "version": "0.17.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/embedder/__tests__/batch-outlier-deferral.test.ts
+++ b/src/embedder/__tests__/batch-outlier-deferral.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { Embedder } from '../index.js'
+
+interface FakePipeline {
+  (texts: string[]): Promise<{ data: Float32Array; dims: number[] }>
+  tokenizer: (
+    texts: string[],
+    options: { padding: boolean; truncation: boolean; return_tensor: boolean }
+  ) => { input_ids: number[][] }
+}
+
+function createEmbedderWithFakePipeline(tokenLengths: Record<string, number>): {
+  embedder: Embedder
+  modelCalls: string[][]
+} {
+  const modelCalls: string[][] = []
+  const vectorValues = new Map(Object.keys(tokenLengths).map((text, index) => [text, index + 1]))
+  const pipeline = Object.assign(
+    async (texts: string[]) => {
+      modelCalls.push([...texts])
+      return {
+        data: Float32Array.from(texts.map((text) => vectorValues.get(text) ?? 0)),
+        dims: [texts.length, 1],
+      }
+    },
+    {
+      tokenizer: (texts: string[]) => ({
+        input_ids: texts.map((text) => Array.from({ length: tokenLengths[text] ?? 1 }, () => 1)),
+      }),
+    }
+  ) as FakePipeline
+
+  const embedder = new Embedder({
+    modelPath: 'unused-by-fake-pipeline',
+    batchSize: 16,
+    cacheDir: 'unused-by-fake-pipeline',
+  })
+  ;(embedder as unknown as { model: FakePipeline }).model = pipeline
+
+  return { embedder, modelCalls }
+}
+
+describe('Embedder batch outlier deferral', () => {
+  it('defers a token-length outlier to a singleton batch and restores input order', async () => {
+    const tokenLengths = {
+      'short-a': 10,
+      outlier: 100,
+      'short-b': 12,
+    }
+    const { embedder, modelCalls } = createEmbedderWithFakePipeline(tokenLengths)
+
+    const embeddings = await embedder.embedBatch(['short-a', 'outlier', 'short-b'])
+
+    expect(modelCalls).toEqual([['short-a', 'short-b'], ['outlier']])
+    expect(embeddings).toEqual([[1], [2], [3]])
+  })
+
+  it('keeps similarly sized inputs on the existing batch path', async () => {
+    const tokenLengths = {
+      'short-a': 10,
+      'short-b': 12,
+      'short-c': 14,
+    }
+    const { embedder, modelCalls } = createEmbedderWithFakePipeline(tokenLengths)
+
+    const embeddings = await embedder.embedBatch(['short-a', 'short-b', 'short-c'])
+
+    expect(modelCalls).toEqual([['short-a', 'short-b', 'short-c']])
+    expect(embeddings).toEqual([[1], [2], [3]])
+  })
+
+  it('defers when padding exceeds 1.5 times the estimated attention work', async () => {
+    const tokenLengths = {
+      'short-a': 10,
+      moderate: 15,
+      'short-b': 10,
+    }
+    const { embedder, modelCalls } = createEmbedderWithFakePipeline(tokenLengths)
+
+    const embeddings = await embedder.embedBatch(['short-a', 'moderate', 'short-b'])
+
+    expect(modelCalls).toEqual([['short-a', 'short-b'], ['moderate']])
+    expect(embeddings).toEqual([[1], [2], [3]])
+  })
+
+  it('defers multiple outliers individually after the normal batch', async () => {
+    const shortTexts = Array.from({ length: 14 }, (_, index) => `short-${index}`)
+    const texts = [
+      shortTexts[0]!,
+      'longest',
+      ...shortTexts.slice(1, 8),
+      'longer',
+      ...shortTexts.slice(8),
+    ]
+    const tokenLengths = Object.fromEntries([
+      ...shortTexts.map((text) => [text, 10]),
+      ['longest', 100],
+      ['longer', 90],
+    ])
+    const { embedder, modelCalls } = createEmbedderWithFakePipeline(tokenLengths)
+
+    const embeddings = await embedder.embedBatch(texts)
+
+    expect(modelCalls).toEqual([shortTexts, ['longest'], ['longer']])
+    expect(embeddings).toHaveLength(texts.length)
+    expect(embeddings.every((embedding) => embedding.length === 1)).toBe(true)
+  })
+})

--- a/src/embedder/index.ts
+++ b/src/embedder/index.ts
@@ -34,6 +34,64 @@ export interface EmbedderConfig {
   dtype?: string
 }
 
+interface IndexedEmbeddingInput {
+  text: string
+  originalIndex: number
+  tokenLength: number
+}
+
+interface BatchEmbeddingPipeline {
+  (input: string[], options: unknown): Promise<{ data: Float32Array; dims: number[] }>
+  tokenizer: (
+    input: string[],
+    options: {
+      padding: boolean
+      truncation: boolean
+      return_tensor: boolean
+    }
+  ) => { input_ids: { length: number }[] }
+}
+
+// Keep estimated padding waste below one-third of dense self-attention work.
+const MAX_PADDING_AMPLIFICATION = 1.5
+
+function estimatePaddingAmplification(inputs: IndexedEmbeddingInput[]): number {
+  let maxTokenLength = 0
+  let individualWork = 0
+  for (const input of inputs) {
+    maxTokenLength = Math.max(maxTokenLength, input.tokenLength)
+    individualWork += input.tokenLength ** 2
+  }
+  return (inputs.length * maxTokenLength ** 2) / individualWork
+}
+
+function deferBatchOutliers(inputs: IndexedEmbeddingInput[]): {
+  batch: IndexedEmbeddingInput[]
+  deferred: IndexedEmbeddingInput[]
+} {
+  const batch = [...inputs]
+  const deferred: IndexedEmbeddingInput[] = []
+
+  while (batch.length > 1) {
+    if (estimatePaddingAmplification(batch) <= MAX_PADDING_AMPLIFICATION) {
+      break
+    }
+
+    let longestIndex = 0
+    for (let index = 1; index < batch.length; index++) {
+      if (batch[index]!.tokenLength > batch[longestIndex]!.tokenLength) {
+        longestIndex = index
+      }
+    }
+
+    const longest = batch[longestIndex]!
+    deferred.push(longest)
+    batch.splice(longestIndex, 1)
+  }
+
+  return { batch, deferred }
+}
+
 // ============================================
 // Error Classes
 // ============================================
@@ -257,15 +315,15 @@ export class Embedder {
       // inference is not parallelized by Promise.all). Passing the whole batch
       // lets the runtime batch the matmuls. Mean-pooling honors the attention
       // mask, so per-row vectors match the single-text result.
-      const modelCall = this.model as (
-        input: string[],
-        options: unknown
-      ) => Promise<{ data: Float32Array; dims: number[] }>
+      const modelCall = this.model as BatchEmbeddingPipeline
+      const embeddings: (number[] | undefined)[] = Array.from({ length: texts.length })
+      const deferred: IndexedEmbeddingInput[] = []
 
-      const embeddings: number[][] = []
-      for (let i = 0; i < texts.length; i += this.config.batchSize) {
-        const batch = texts.slice(i, i + this.config.batchSize)
-        const output = await modelCall(batch, options)
+      const embedInputs = async (inputs: IndexedEmbeddingInput[]): Promise<void> => {
+        const output = await modelCall(
+          inputs.map((input) => input.text),
+          options
+        )
 
         // Validate the output shape before slicing so a runtime/model contract
         // change surfaces as a clear error rather than silently wrong vectors.
@@ -275,17 +333,53 @@ export class Embedder {
           !(output.data instanceof Float32Array) ||
           typeof dim !== 'number' ||
           dim <= 0 ||
-          output.data.length !== batch.length * dim
+          output.data.length !== inputs.length * dim
         ) {
           throw new EmbeddingError('Unexpected embedder batch output shape')
         }
 
-        for (let row = 0; row < batch.length; row++) {
-          embeddings.push(Array.from(output.data.subarray(row * dim, (row + 1) * dim)))
+        for (let row = 0; row < inputs.length; row++) {
+          const input = inputs[row]!
+          embeddings[input.originalIndex] = Array.from(
+            output.data.subarray(row * dim, (row + 1) * dim)
+          )
         }
       }
 
-      return embeddings
+      for (let i = 0; i < texts.length; i += this.config.batchSize) {
+        const batchTexts = texts.slice(i, i + this.config.batchSize)
+        const tokenized = modelCall.tokenizer(batchTexts, {
+          padding: false,
+          truncation: true,
+          return_tensor: false,
+        })
+        if (
+          !tokenized ||
+          !Array.isArray(tokenized.input_ids) ||
+          tokenized.input_ids.length !== batchTexts.length
+        ) {
+          throw new EmbeddingError('Unexpected embedder tokenizer output shape')
+        }
+
+        const indexedInputs = batchTexts.map((text, batchIndex) => ({
+          text,
+          originalIndex: i + batchIndex,
+          tokenLength: tokenized.input_ids[batchIndex]!.length,
+        }))
+        const selected = deferBatchOutliers(indexedInputs)
+        deferred.push(...selected.deferred)
+        await embedInputs(selected.batch)
+      }
+
+      for (const input of deferred) {
+        await embedInputs([input])
+      }
+
+      if (embeddings.some((embedding) => embedding === undefined)) {
+        throw new EmbeddingError('Missing embedder batch output row')
+      }
+
+      return embeddings as number[][]
     } catch (error) {
       if (error instanceof EmbeddingError) {
         throw error


### PR DESCRIPTION
## Summary

- measure each input with the active model tokenizer before batched inference
- defer the longest inputs to singleton inference while estimated padding amplification exceeds 1.5
- process normal batches first and restore embeddings to their original input order
- preserve the existing chunking, truncation, public API, and stored content
- bump the package and MCP registry metadata version to `0.17.2`

## Rationale

Transformer batches are padded to their longest sequence, while dense self-attention cost grows quadratically with sequence length. The implementation estimates padding amplification as:

```text
batch size × max token length² / sum(individual token length²)
```

The 1.5 threshold limits estimated padding waste to about one-third of padded attention work. Tests with `Xenova/all-MiniLM-L6-v2` and `Xenova/nomic-embed-text-v1` showed that 1.25 fragmented regular batches, while 2.0 and 4.0 missed moderately imbalanced batches.

## CLI verification

All measurements used the same inputs, model, CPU/fp32 settings, and latest `main` baseline.

| Model and input | Latest `main` | This PR | Peak RSS |
|---|---:|---:|---:|
| MiniLM, one long input | 1.086 s | 0.569 s | 575 MB → 436 MB |
| MiniLM, four long inputs among normal text | 2.473 s | 0.855 s | 1,581 MB → 399 MB |
| nomic, one long input | 31.387 s | 5.418 s | 5.86 GB → 3.77 GB |
| nomic, two long inputs among normal text | 81.347 s | 5.213 s | 8.24 GB → 1.95 GB |
| nomic, four issue-length inputs among normal text | timed out at 180 s | 19.210 s | 9.63 GB → 4.50 GB |

The baseline and updated databases had identical chunk counts, text, metadata, ordering, and vector dimensions. The maximum absolute vector difference was `1.42e-7`, with minimum cosine similarity above `0.9999999999996`.

## Tests

- `pnpm run check:all`
- 80 test files and 1,348 tests passed
- focused batch-outlier and real-model equivalence tests passed

Closes #178
