### PR TITLE
fix: align sync base directory guidance

### DIFF
--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -279,7 +279,7 @@ All ingest/list/delete/read-neighbor/sync operations are confined to one or more
 |---------|-----|------|
 | `BASE_DIR` | Single path string env var | Single-root setups (legacy, still supported) |
 | `BASE_DIRS` | JSON array env var: `'["/a","/b"]'` | Multi-root setups via env (MCP and CLI) |
-| `--base-dir <path>` | Repeatable CLI flag on `ingest` and `list` | Multi-root setups via CLI; CLI roots replace env roots |
+| `--base-dir <path>` | Repeatable CLI flag on `ingest`, `list`, and `sync` | Multi-root setups via CLI; CLI roots replace env roots |
 
 **Resolution order**: CLI `--base-dir` > `BASE_DIRS` > `BASE_DIR` > `process.cwd()`.
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -60,12 +60,12 @@ The CLI accepts only `fast` or `quality` for `--visual-quality`. The MCP `ingest
 ### sync
 
 ```bash
-npx mcp-local-rag [global-options] sync [path]
+npx mcp-local-rag [global-options] sync [options] [path]
 ```
 
-Reconcile the index with the files on disk: ingest new and changed files, leave unchanged files alone, and remove index entries for files that are gone. `-h, --help` is the only option — there is no `--visual` on `sync`, so a changed PDF is re-ingested as text.
+Reconcile the index with the files on disk: ingest new and changed files, leave unchanged files alone, and remove index entries for files that are gone. `--base-dir <path>` is repeatable. There is no `--visual` on `sync`, so a changed PDF is re-ingested as text.
 
-The positional `path` is optional and must sit inside a configured base directory; omit it to synchronize every configured root. A directory is scanned, while a single file is synchronized on its own and its siblings are left untouched. `sync` takes no `--base-dir`: roots come from `BASE_DIRS` / `BASE_DIR` (default: cwd).
+The positional `path` is optional and must sit inside a configured base directory; omit it to synchronize every configured root. A directory is scanned, while a single file is synchronized on its own and its siblings are left untouched. Without `--base-dir`, roots come from `BASE_DIRS` / `BASE_DIR` (default: cwd).
 
 Output: one JSON object to stdout on success. Each upserted and pruned path is named on stderr as it happens, alongside warnings and errors; unchanged files stay silent, so the output is proportional to what changed.
 

--- a/src/__tests__/cli/options.test.ts
+++ b/src/__tests__/cli/options.test.ts
@@ -436,7 +436,7 @@ describe('ROOT_HELP_TEXT command list', () => {
 
     expect(ingestIndex).toBeGreaterThan(-1)
     expect(lines[ingestIndex + 1]).toBe(
-      '  sync [options] [path]  Incrementally synchronize indexed files with disk'
+      '  sync [path]            Incrementally synchronize indexed files with disk'
     )
   })
 

--- a/src/__tests__/cli/sync.test.ts
+++ b/src/__tests__/cli/sync.test.ts
@@ -376,10 +376,12 @@ describe('CLI sync', () => {
             )
         )
     )
+    const envOnlyContent = `environment-only root ${'e'.repeat(200)}`
     const envOnlyPath = await writeFixtureFile(
       join(fixture.roots[2]!, 'environment-only.md'),
-      `environment-only root ${'e'.repeat(200)}`
+      envOnlyContent
     )
+    await seedRows(fixture, envOnlyPath, sha256(envOnlyContent), 1)
 
     const outcome = await runCli(fixture, [
       '--base-dir',
@@ -394,11 +396,12 @@ describe('CLI sync', () => {
     expect(calls.scanArgs.map(([root]) => root)).toEqual(
       fixture.roots.slice(0, 2).map((root) => `${root}${sep}`)
     )
-    const storedPaths = [
-      ...new Set((await storedManifest(fixture)).map((row) => row.filePath)),
-    ].sort()
-    expect(storedPaths).toEqual(selectedPaths.sort())
-    expect(storedPaths).not.toContain(envOnlyPath)
+    const manifest = await storedManifest(fixture)
+    const storedPaths = [...new Set(manifest.map((row) => row.filePath))].sort()
+    expect(storedPaths).toEqual([...selectedPaths, envOnlyPath].sort())
+    expect(manifest.filter((row) => row.filePath === envOnlyPath)).toEqual([
+      { filePath: envOnlyPath, contentHash: sha256(envOnlyContent) },
+    ])
   })
 
   it.each(['before', 'after'] as const)(

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -150,7 +150,7 @@ Options:
 
 Commands:
   ingest <path>          Ingest files into the vector database
-  sync [options] [path]  Incrementally synchronize indexed files with disk
+  sync [path]            Incrementally synchronize indexed files with disk
   query <text>           Search ingested documents
   read-neighbors         Read N chunks before and after a target chunk within the same document
   list                   List files and ingestion status


### PR DESCRIPTION
## Summary

- update the bundled skill documentation to reflect `sync --base-dir` support
- verify that CLI-selected roots do not prune indexed rows under environment-only roots
- keep the root command summary consistent while retaining full option syntax in `sync --help`

## Verification

- `pnpm test src/__tests__/cli/sync.test.ts src/__tests__/cli/options.test.ts` (82 tests)
- `pnpm run check:all` (80 test files, 1,354 tests)
- built root and sync help output
- `pnpm pack --dry-run`
- `git diff --check`
