### PR TITLE
docs: add multilingual READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,416 @@
+<p align="center">
+  <img src="assets/banner.jpg" alt="MCP Local RAG: Search below the surface." width="600" />
+</p>
+
+# MCP Local RAG
+
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
+[![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <strong>Deutsch</strong> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a>
+</p>
+
+Durchsuche vertrauliche Dokumente über einen MCP-Client oder das Terminal, ohne sie an eine Embedding-API zu senden.
+
+mcp-local-rag indexiert PDF-, DOCX-, Markdown- und Textdateien direkt auf deinem Rechner. Die Suche verbindet semantische Ähnlichkeit mit Stichwortsuche. Dadurch findet sie sowohl sinngleiche Inhalte als auch exakte technische Begriffe wie API-Namen, Klassennamen und Fehlercodes.
+
+## Funktionen
+
+- **Läuft lokal:** Dokument-Parsing, Embeddings, Speicherung und Suche finden auf deinem Rechner statt. Nach dem ersten Modelldownload funktionieren Textimport und Suche offline.
+- **Hybride Suche:** Die semantische Suche findet verwandte Konzepte, während die Stichwortsuche exakte Fachbegriffe höher gewichtet.
+- **Konfigurierbare Embeddings:** Wähle ein Hugging-Face-Embedding-Modell, das zur Sprache und zum Fachgebiet deiner Dokumente passt.
+- **Semantische Aufteilung:** Dokumente werden an Themenwechseln statt nach einer festen Zeichenzahl geteilt. Markdown-Codeblöcke bleiben erhalten.
+- **MCP und CLI:** KI-Programmierwerkzeuge und Terminal greifen auf denselben Index zu.
+
+Es werden weder API-Schlüssel noch Docker, Python oder eine externe Datenbank benötigt.
+
+## Schnellstart
+
+### Voraussetzungen
+
+- Node.js 22 oder neuer
+- Internetzugang beim ersten Start, um das npm-Paket und das Embedding-Modell herunterzuladen
+- Ein Verzeichnis mit den zu durchsuchenden Dokumenten
+
+Setze `BASE_DIR` auf dieses Verzeichnis. Es bildet zugleich die Sicherheitsgrenze für Dateizugriffe. Ersetze `/absolute/path/to/your/documents` in den folgenden Beispielen durch den absoluten Pfad zu deinen Dokumenten.
+
+mcp-local-rag verwendet das Standard-MCP-Protokoll über einen lokalen stdio-Server. Damit funktioniert es mit KI-Programmierwerkzeugen und anderen MCP-Hosts, die lokale MCP-Server unterstützen.
+
+Nutze eines der folgenden Beispiele oder registriere `npx -y mcp-local-rag` im Konfigurationsformat deines Clients und setze dort `BASE_DIR`.
+
+**Claude Code:** Führe diesen Befehl aus:
+
+```bash
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
+```
+
+**Codex:** Ergänze `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIR = "/absolute/path/to/your/documents"
+```
+
+**OpenCode:** Ergänze `~/.config/opencode/opencode.json` (oder `opencode.jsonc`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-rag": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-local-rag"],
+      "environment": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+**Cursor:** Ergänze `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+Starte den Client neu und lass ihn anschließend den Index aufbauen:
+
+```text
+Synchronisiere alle Dokumente im konfigurierten Stammverzeichnis und warte, bis der Vorgang abgeschlossen ist.
+```
+
+Bei der ersten Synchronisierung wird das Standard-Embedding-Modell heruntergeladen (etwa 90 MB). Bis der Import beginnt, können 1–2 Minuten vergehen. Spätere Durchläufe verwenden den lokalen Cache.
+
+Nach Abschluss der Synchronisierung kannst du zum Beispiel fragen:
+
+```text
+Was steht in der API-Dokumentation zur Authentifizierung?
+```
+
+### CLI-Schnellstart
+
+So verwendest du die CLI ohne MCP-Client:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag query "Authentifizierungs-API"
+```
+
+Die CLI verwendet standardmäßig das aktuelle Verzeichnis als Dokumentenstamm. Führe beide Befehle im selben Verzeichnis aus, damit sie denselben Standardindex verwenden, oder setze `BASE_DIR` und `DB_PATH` ausdrücklich.
+
+## Hintergrund
+
+Manche Dokumentensammlungen dürfen aus Vertraulichkeitsgründen oder aufgrund interner Richtlinien nicht an gehostete Embedding-Dienste gesendet werden. Mit einem lokalen Index bleiben sie durchsuchbar, ohne dass pro Anfrage API-Kosten entstehen.
+
+Eine rein semantische Suche kann exakte Bezeichner übersehen, die in technischer Dokumentation wichtig sind. Die Stichwortgewichtung hält diese Treffer sichtbar, ohne auf natürlichsprachliche Suche zu verzichten.
+
+## Unterstützte Inhalte
+
+| Eingabe | Import |
+|---|---|
+| PDF, DOCX, TXT, Markdown | Einzelne Datei importieren oder Verzeichnis synchronisieren |
+| Bereits vom Client abgerufenes HTML | Mit `ingest_data`; wird durch Readability bereinigt und in Markdown umgewandelt |
+| Im Speicher vorliegender Klartext oder Markdown | Mit `ingest_data` und einer stabilen Quellkennung |
+
+Der Server ruft HTML nicht selbst ab. Ein MCP-Client kann eine Seite laden und ihr HTML an `ingest_data` übergeben.
+
+Excel, PowerPoint, einzelne Bilddateien und Quellcodedateien werden beim Dateiimport nicht unterstützt. Für Abbildungen in PDFs kann optional ein lokales Vision-Modell verwendet werden. Das ist weder OCR noch Bildsuche.
+
+## MCP-Werkzeuge
+
+| Werkzeug | Zweck |
+|---|---|
+| `sync_start` | Alle konfigurierten Stammverzeichnisse oder einen Pfad mit dem Index abgleichen |
+| `sync_status` | Status einer laufenden Synchronisierung abrufen |
+| `ingest_file` | Eine Datei importieren oder ersetzen |
+| `ingest_data` | Bereits im Client vorliegenden Text, Markdown oder HTML importieren |
+| `query_documents` | Mit semantischem Abgleich und Stichwortgewichtung suchen |
+| `read_chunk_neighbors` | Benachbarte Abschnitte eines Suchtreffers lesen |
+| `list_files` | Unterstützte Dateien und ihren Importstatus anzeigen |
+| `delete_file` | Eine indexierte Datei oder einen `ingest_data`-Eintrag löschen |
+| `status` | Status von Index und Suche anzeigen |
+
+### Dokumentenstamm synchronisieren
+
+`sync_start` importiert neue und geänderte Dateien, überspringt bytegleiche Dateien und entfernt Indexeinträge für Dateien, die nicht mehr vorhanden sind:
+
+```text
+Synchronisiere alle Inhalte in den konfigurierten Dokumentenstämmen und warte auf den Abschluss.
+```
+
+Das Werkzeug gibt sofort eine `jobId` zurück. Clients sollten `sync_status` abfragen, bis der Status `succeeded` oder `failed` lautet. Während der Synchronisierung gibt es keinen visuellen Modus; geänderte PDFs werden als Text importiert.
+
+Der Serverprozess speichert nur einen Synchronisierungsauftrag. Ein neuer Auftrag ersetzt den Eintrag eines abgeschlossenen Auftrags. Beim Neustart des Servers geht der Eintrag verloren.
+
+### Einzelne Datei importieren
+
+`ingest_file` unterstützt PDF, DOCX, TXT und Markdown. MCP-Dateipfade müssen absolut sein und innerhalb eines konfigurierten Dokumentenstamms liegen:
+
+```text
+Importiere das Dokument /Users/me/docs/api-spec.pdf.
+```
+
+Ein erneuter Import desselben Pfads ersetzt die vorhandenen Abschnitte.
+
+### Suchen und weiteren Kontext lesen
+
+```text
+Was steht in der API-Dokumentation zur Authentifizierung?
+Finde das dokumentierte Verhalten von ERR_CONNECTION_REFUSED.
+```
+
+Ergebnisse enthalten Text, Quellpfad, Titel, Abschnittsnummer und Relevanzwert. Wenn mehr Kontext nötig ist, übergib `chunkIndex` und entweder `filePath` oder `source` aus dem Treffer an `read_chunk_neighbors`:
+
+```text
+Lies die benachbarten Abschnitte dieses Treffers zur Authentifizierung.
+```
+
+`query_documents` und `list_files` akzeptieren optional ein absolutes `scope`-Pfadpräfix oder eine Liste von Präfixen. Ein Präfix entspricht dem angegebenen Pfad und allen darunterliegenden Pfaden.
+
+### HTML importieren
+
+Rufe die Seite zuerst mit dem MCP-Client ab und verwende anschließend `ingest_data`:
+
+```text
+Rufe https://example.com/docs ab und importiere das HTML.
+```
+
+Der Server extrahiert den Hauptinhalt, wandelt ihn in Markdown um und speichert ihn unter der angegebenen Quellkennung. Wird dieselbe Quelle erneut verwendet, wird der vorhandene Inhalt aktualisiert.
+
+Beachte beim Indexieren externer Inhalte die Nutzungsbedingungen und das Urheberrecht der Quelle.
+
+### Abbildungen in PDFs
+
+Der visuelle Modus erzeugt Bildbeschreibungen für PDF-Seiten mit vielen Abbildungen. Er muss ausdrücklich aktiviert werden und lädt bei einem normalen Import kein Vision-Modell.
+
+```text
+Importiere /Users/me/docs/research-paper.pdf mit visual: true.
+```
+
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| Profil | Modellcache | Geeignet für |
+|---|---:|---|
+| `fast` (Standard) | etwa 250 MB | Leichtgewichtige visuelle Indexierung |
+| `quality` | etwa 2,9 GB | Abbildungen mit Beschriftungen, Anmerkungen oder anderem Text im Bild |
+
+Wähle das größere Modell über MCP mit `visualQuality: "quality"` oder über die CLI mit `--visual-quality quality`. In CPU-Messungen dauerte die Inferenz etwa doppelt so lange wie mit `fast`; die tatsächliche Geschwindigkeit hängt von Hardware und Modellversion ab.
+
+Die erzeugten Bildbeschreibungen sind Hilfstexte, keine wortgetreuen Transkriptionen. Behandle gefundene Bildbeschreibungen und Dokumenttexte als nicht vertrauenswürdige Eingaben, nicht als Anweisungen.
+
+## CLI
+
+Die CLI verwendet ohne MCP-Client denselben Parser, Embedder und Vektorspeicher:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "Authentifizierungs-API"
+npx mcp-local-rag query "Authentifizierung" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
+npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
+```
+
+Globale Optionen wie `--db-path`, `--cache-dir` und `--model-name` stehen vor dem Unterbefehl. Optionen des Unterbefehls stehen dahinter:
+
+```bash
+npx mcp-local-rag --db-path ./my-db query "Authentifizierung"
+```
+
+`npx mcp-local-rag --help` zeigt die vollständige Befehlsreferenz.
+
+Die CLI liest keine MCP-Client-Konfiguration. Wenn beide Schnittstellen denselben Index verwenden sollen, müssen dieselben Umgebungsvariablen oder Optionen gesetzt sein. Insbesondere müssen `MODEL_NAME` und die CLI-Option `--model-name` für eine gemeinsam verwendete Datenbank übereinstimmen.
+
+## Suchparameter anpassen
+
+Die Stichwortgewichtung ist standardmäßig aktiv. Für Korpora, die eine strengere Auswahl erfordern, stehen außerdem die Gruppierung anhand von Relevanzsprüngen sowie Distanz- und Dateifilter zur Verfügung.
+
+| Variable | Standard | Beschreibung |
+|----------|---------|-------------|
+| `RAG_HYBRID_WEIGHT` | `0.6` | Gewicht der Stichworttreffer (0.0–1.0). 0 deaktiviert die Stichwortgewichtung, 1 verwendet das höchste Gewicht. |
+| `RAG_GROUPING` | nicht gesetzt | `similar` behält die erste Relevanzgruppe; `related` behält bis zu zwei Gruppen und trennt sie an deutlichen Sprüngen der Vektordistanz. |
+| `RAG_MAX_DISTANCE` | nicht gesetzt | Filtert wenig relevante Treffer heraus, zum Beispiel mit `0.5`. |
+| `RAG_MAX_FILES` | nicht gesetzt | Beschränkt die Treffer auf die besten N Dateien, zum Beispiel mit `1` auf die beste Datei. |
+
+Bei API-Spezifikationen und anderen Dokumenten mit vielen Bezeichnern kann ein höheres Stichwortgewicht die Rangfolge exakter Treffer verbessern:
+
+```json
+"env": {
+  "RAG_HYBRID_WEIGHT": "0.7"
+}
+```
+
+- `0.7`: etwas stärkere Gewichtung exakter Begriffe als in der Standardeinstellung
+- `1.0`: höchste Stichwortgewichtung
+
+## Funktionsweise
+
+Beim Import:
+
+1. Der Parser extrahiert den Text aus dem Eingabeformat.
+2. Der semantische Chunker erkennt Themenwechsel und behält Markdown-Codeblöcke intakt.
+3. Transformers.js erzeugt die Embeddings lokal.
+4. LanceDB speichert Abschnitte, Metadaten, Vektoren und den Volltextindex.
+
+Bei der Suche:
+
+1. Die Abfrage wird mit demselben Modell eingebettet.
+2. Die Vektorsuche findet semantisch verwandte Abschnitte.
+3. Optionale Distanzfilter und Relevanzgruppen schränken die Kandidaten weiter ein.
+4. Volltexttreffer erhöhen das Gewicht exakter Suchbegriffe.
+
+## Agent Skills
+
+[Agent Skills](https://agentskills.io/) geben KI-Assistenten Hinweise für Abfragen und Importe:
+
+```bash
+npx mcp-local-rag skills install --claude-code
+npx mcp-local-rag skills install --claude-code --global
+npx mcp-local-rag skills install --codex
+```
+
+Die installierten Skills behandeln Abfrageformulierung, Trefferverfeinerung und HTML-Import. Falls ein Skill nicht automatisch aktiviert wird, bitte den Assistenten ausdrücklich darum, den mcp-local-rag-Skill zu verwenden.
+
+## Konfiguration
+
+Der MCP-Server liest Umgebungsvariablen. Die CLI unterstützt dieselben Variablen sowie die aufgeführten Optionen; CLI-Optionen haben Vorrang.
+
+| Umgebungsvariable | CLI-Option | Standard | Beschreibung |
+|---------------------|----------|---------|-------------|
+| `BASE_DIR` | `--base-dir` | Aktuelles Verzeichnis | Ein Dokumentenstamm; die CLI-Option kann bei `ingest`, `list` und `sync` mehrfach verwendet werden |
+| `BASE_DIRS` | – | nicht gesetzt | JSON-Array mit Dokumentenstämmen; hat Vorrang vor `BASE_DIR` |
+| `DB_PATH` | `--db-path` | `./lancedb/` | Pfad zur Vektordatenbank |
+| `CACHE_DIR` | `--cache-dir` | `./models/` | Verzeichnis für den Modellcache |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Hugging-Face-Embedding-Modell |
+| `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100 MB) | Maximale Dateigröße in Byte |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Mindestlänge eines Abschnitts in Zeichen (1–10000) |
+| `RAG_DEVICE` | – | `cpu` | ONNX-Runtime-Ausführungsgerät |
+| `RAG_DTYPE` | – | `fp32` | An das ausgewählte Modell übergebener Embedding-Datentyp |
+
+### Dokumentenstämme (`BASE_DIR` und `BASE_DIRS`)
+
+mcp-local-rag erlaubt Dateizugriffe nur innerhalb der konfigurierten Stammverzeichnisse. Für mehrere Stammverzeichnisse muss `BASE_DIRS` ein JSON-Array mit nicht leeren Pfaden sein:
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+Die Stammverzeichnisse werden in dieser Reihenfolge ermittelt:
+
+1. CLI-Optionen `--base-dir <path>` (mehrfach bei `ingest`, `list` und `sync` möglich)
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. Aktuelles Verzeichnis
+
+Jede Quelle ersetzt die nachrangige Quelle vollständig, statt mit ihr zusammengeführt zu werden. Eine ungültige `BASE_DIRS`-Konfiguration führt zu einem Fehler; es wird nicht auf `BASE_DIR` oder das aktuelle Verzeichnis zurückgegriffen. `status` bleibt in MCP verfügbar, damit der Client den Konfigurationsfehler melden kann.
+
+```bash
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+npx mcp-local-rag sync --base-dir /Users/me/work --base-dir /Users/me/specs
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
+
+### Speicher und Modelle
+
+`DB_PATH` und `CACHE_DIR` beziehen sich standardmäßig auf das Arbeitsverzeichnis des Prozesses. Verwende absolute Pfade, wenn der MCP-Client den Server aus unterschiedlichen Projektverzeichnissen starten kann.
+
+Setze `MODEL_NAME` oder übergib `--model-name`, um ein Hugging-Face-Embedding-Modell auszuwählen, das zur Sprache und zum Fachgebiet deiner Dokumente passt.
+
+mcp-local-rag erzeugt Embeddings mit Mean Pooling und L2-Normalisierung. Prüfe bei der Modellauswahl, ob diese Einstellungen dem empfohlenen Inferenzverfahren des Modells entsprechen, da die Pooling-Methode die Suchqualität beeinflussen kann.
+
+Eine Änderung von `MODEL_NAME`, `RAG_DEVICE` oder `RAG_DTYPE` kann vorhandene Vektoren inkompatibel machen. Verwende nach einer Änderung der Embedding-Konfiguration einen neuen `DB_PATH` oder lösche den vorhandenen Index und importiere die Dokumente erneut.
+
+Ein Beispiel für deutschsprachige Dokumente ist das Modell `jinaai/jina-embeddings-v2-base-de`.
+
+## Sicherheit und Betrieb
+
+- Dateizugriffe sind auf die mit `BASE_DIR`, `BASE_DIRS` oder der CLI-Option `--base-dir` festgelegten Stammverzeichnisse beschränkt.
+- Symbolische Links, deren Ziel außerhalb aller konfigurierten Stammverzeichnisse liegt, werden abgelehnt.
+- Sobald die benötigten Modelle im Cache liegen, greifen Dokumentverarbeitung und Suche nicht mehr auf das Netzwerk zu.
+- Der Server ist für einen einzelnen lokalen Benutzer ausgelegt und bietet keine Authentifizierung oder Zugriffskontrolle.
+- Mehrere CLI- oder MCP-Schreibprozesse dürfen nicht gleichzeitig denselben `DB_PATH` verwenden. Reine Leseabfragen sind während einer Synchronisierung möglich.
+- Sichere den Index, indem du das `DB_PATH`-Verzeichnis kopierst, während kein Schreibprozess läuft.
+
+<details>
+<summary><strong>Fehlerbehebung</strong></summary>
+
+### "No results found"
+
+Dokumente müssen zuerst importiert werden. Prüfe den Importstatus mit `"Liste alle importierten Dateien auf"`.
+
+### Modelldownload fehlgeschlagen
+
+Prüfe die Internetverbindung. Wenn du einen Proxy verwendest, kontrolliere die Netzwerkeinstellungen. Das Modell kann auch [manuell heruntergeladen](https://huggingface.co/Xenova/all-MiniLM-L6-v2) werden.
+
+### "File too large"
+
+Die Standardgrenze beträgt 100 MB. Teile die Datei auf oder erhöhe `MAX_FILE_SIZE`.
+
+### Langsame Abfragen
+
+Prüfe die Anzahl der Abschnitte mit `status`. Große Dokumente mit vielen Abschnitten können Abfragen verlangsamen. Sehr große Dateien sollten gegebenenfalls geteilt werden.
+
+### "Path outside BASE_DIR"
+
+Der Dateipfad muss innerhalb eines konfigurierten Stammverzeichnisses liegen: `BASE_DIR`, ein Eintrag aus `BASE_DIRS` oder ein über `--base-dir` gesetzter Pfad. Verwende einen absoluten Pfad.
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` akzeptiert ein JSON-Array mit einem oder mehreren nicht leeren Pfaden:
+
+- Gültig: `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- Ungültig: `BASE_DIRS=/a:/b` (Trennzeichensyntax wird nicht unterstützt)
+- Ungültig: `BASE_DIRS='[]'` (leeres Array)
+
+### MCP-Client zeigt keine Werkzeuge an
+
+1. Syntax der Konfigurationsdatei prüfen
+2. Client vollständig beenden und neu starten (bei Cursor auf dem Mac mit Cmd+Q)
+3. Direkt testen: `npx mcp-local-rag` sollte ohne Fehler starten
+
+</details>
+
+## Mitwirken
+
+Beiträge sind willkommen. Hinweise zur Einrichtung und zu den Richtlinien stehen in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Lizenz
+
+MIT-Lizenz. Kostenlose Nutzung für private und kommerzielle Zwecke.
+
+## Blogbeiträge
+
+- [Building a Local RAG for Agentic Coding](https://www.norsica.jp/blog/local-rag-agentic-coding): Technischer Einblick in semantische Aufteilung und hybride Suche.
+
+## Danksagung
+
+Erstellt mit dem [Model Context Protocol](https://modelcontextprotocol.io/) von Anthropic, [LanceDB](https://lancedb.com/) und [Transformers.js](https://huggingface.co/docs/transformers.js).

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,416 @@
+<p align="center">
+  <img src="assets/banner.jpg" alt="MCP Local RAG: Search below the surface." width="600" />
+</p>
+
+# MCP Local RAG
+
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
+[![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <strong>Español</strong> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a>
+</p>
+
+Busca en documentos privados desde un cliente MCP o desde la terminal sin enviarlos a una API de embeddings.
+
+mcp-local-rag indexa archivos PDF, DOCX y Markdown, además de archivos de texto, en tu equipo. La búsqueda combina similitud semántica y coincidencia de palabras clave. Así tiene en cuenta tanto el sentido de la consulta como los términos técnicos exactos, por ejemplo nombres de API, clases y códigos de error.
+
+## Funciones
+
+- **Ejecución local:** El análisis de documentos, los embeddings, el almacenamiento y la búsqueda se realizan en tu equipo. Después de descargar el modelo por primera vez, la incorporación de texto y las búsquedas funcionan sin conexión.
+- **Búsqueda híbrida:** La recuperación semántica encuentra conceptos relacionados y la coincidencia de palabras clave da más peso a los términos técnicos exactos.
+- **Embeddings configurables:** Puedes elegir un modelo de embeddings de Hugging Face adecuado para el idioma y el ámbito de tus documentos.
+- **Segmentación semántica:** Los documentos se dividen cuando cambia el tema, no cada cierto número de caracteres. Los bloques de código Markdown se mantienen intactos.
+- **MCP y CLI:** Usa el mismo índice desde una herramienta de programación con IA o directamente desde la terminal.
+
+No hace falta una clave de API, Docker, Python ni una base de datos externa.
+
+## Inicio rápido
+
+### Requisitos
+
+- Node.js 22 o posterior
+- Acceso a Internet durante el primer uso para descargar el paquete npm y el modelo de embeddings
+- Un directorio con los documentos que quieras consultar
+
+Asigna ese directorio a `BASE_DIR`. También será el límite de seguridad para las operaciones con archivos. Sustituye `/absolute/path/to/your/documents` en los ejemplos por la ruta absoluta del directorio.
+
+mcp-local-rag usa el protocolo MCP estándar mediante un servidor stdio local. Por eso funciona con herramientas de programación con IA y otros hosts MCP que admitan servidores MCP locales.
+
+Usa uno de los ejemplos siguientes o registra `npx -y mcp-local-rag` y configura `BASE_DIR` con el formato de configuración MCP de tu cliente.
+
+**Claude Code:** Ejecuta este comando:
+
+```bash
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
+```
+
+**Codex:** Añade lo siguiente a `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIR = "/absolute/path/to/your/documents"
+```
+
+**OpenCode:** Añade lo siguiente a `~/.config/opencode/opencode.json` (o `opencode.jsonc`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-rag": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-local-rag"],
+      "environment": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+**Cursor:** Añade lo siguiente a `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+Reinicia el cliente y pídele que construya el índice:
+
+```text
+Sincroniza todos los documentos del directorio raíz configurado y espera a que termine.
+```
+
+La primera sincronización descarga el modelo de embeddings predeterminado (unos 90 MB). Pueden pasar entre 1 y 2 minutos antes de que comience la incorporación. Las ejecuciones posteriores usan la caché local.
+
+Cuando termine la sincronización, prueba con una consulta:
+
+```text
+¿Qué dice la documentación de la API sobre la autenticación?
+```
+
+### Inicio rápido con la CLI
+
+Para usar la CLI sin un cliente MCP:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag query "API de autenticación"
+```
+
+La CLI usa el directorio actual como raíz de documentos de forma predeterminada. Ejecuta ambos comandos desde el mismo directorio para que compartan el índice predeterminado, o configura `BASE_DIR` y `DB_PATH` de forma explícita.
+
+## Por qué existe
+
+Algunos conjuntos de documentos no se pueden enviar a un servicio de embeddings alojado por motivos de confidencialidad o por las políticas de una organización. Un índice local permite consultarlos sin añadir un coste de API por búsqueda.
+
+Una búsqueda puramente semántica puede pasar por alto identificadores exactos que son importantes en la documentación técnica. El reajuste por palabras clave mantiene visibles esos términos sin renunciar a las consultas en lenguaje natural.
+
+## Contenido compatible
+
+| Entrada | Cómo incorporarla |
+|---|---|
+| PDF, DOCX, TXT, Markdown | Incorporación de archivos o sincronización de directorios |
+| HTML ya obtenido por el cliente | `ingest_data`; se limpia con Readability y se convierte a Markdown |
+| Texto sin formato o Markdown en memoria | `ingest_data` con un identificador de origen estable |
+
+El servidor no descarga páginas HTML. Un cliente MCP puede obtener una página y pasar su HTML a `ingest_data`.
+
+La incorporación de archivos no admite Excel, PowerPoint, imágenes independientes ni extensiones de código fuente. De forma opcional, los PDF pueden usar un modelo visual local para describir figuras, pero esta función no es OCR ni búsqueda de imágenes.
+
+## Herramientas MCP
+
+| Herramienta | Función |
+|---|---|
+| `sync_start` | Sincronizar el índice con todos los directorios raíz configurados o con una ruta |
+| `sync_status` | Consultar una sincronización en curso |
+| `ingest_file` | Incorporar o sustituir un archivo |
+| `ingest_data` | Incorporar texto, Markdown o HTML que ya esté disponible en el cliente |
+| `query_documents` | Buscar mediante coincidencia semántica y refuerzo de palabras clave |
+| `read_chunk_neighbors` | Leer los segmentos contiguos a un resultado de búsqueda |
+| `list_files` | Mostrar los archivos compatibles y su estado de incorporación |
+| `delete_file` | Eliminar un archivo indexado o un elemento de `ingest_data` |
+| `status` | Mostrar el estado del índice y de la búsqueda |
+
+### Sincronizar un directorio raíz
+
+`sync_start` incorpora archivos nuevos o modificados, omite los que son idénticos byte a byte y elimina del índice los archivos que ya no existen:
+
+```text
+Sincroniza todo el contenido de los directorios raíz configurados y espera a que termine.
+```
+
+La herramienta devuelve un `jobId` de inmediato. El cliente debe consultar `sync_status` hasta que el estado sea `succeeded` o `failed`. Durante la sincronización no hay modo visual; los PDF modificados se incorporan como texto.
+
+El proceso del servidor solo conserva un trabajo de sincronización. Un trabajo nuevo sustituye el registro de uno ya terminado y el registro se pierde al reiniciar el servidor.
+
+### Incorporar un archivo
+
+`ingest_file` admite PDF, DOCX, TXT y Markdown. Las rutas de archivo enviadas mediante MCP deben ser absolutas y estar dentro de un directorio raíz configurado:
+
+```text
+Incorpora el documento /Users/me/docs/api-spec.pdf.
+```
+
+Si se vuelve a incorporar la misma ruta, sus segmentos anteriores se sustituyen.
+
+### Buscar y leer más contexto
+
+```text
+¿Qué dice la documentación de la API sobre la autenticación?
+Busca el comportamiento documentado de ERR_CONNECTION_REFUSED.
+```
+
+Los resultados contienen el texto, la ruta de origen, el título, el índice del segmento y la puntuación de relevancia. Si necesitas más contexto, pasa a `read_chunk_neighbors` el `chunkIndex` y el `filePath` o `source` del resultado:
+
+```text
+Lee los segmentos contiguos a ese resultado sobre autenticación.
+```
+
+Tanto `query_documents` como `list_files` aceptan un prefijo de ruta absoluto opcional en `scope`, o una lista de prefijos. Cada prefijo coincide con la ruta exacta y con todo lo que contiene.
+
+### Incorporar HTML
+
+Usa `ingest_data` después de que el cliente MCP haya obtenido la página:
+
+```text
+Obtén https://example.com/docs e incorpora el HTML.
+```
+
+El servidor extrae el artículo principal, lo convierte a Markdown y lo guarda con el identificador de origen indicado. Si se reutiliza el mismo origen, se actualiza el contenido existente.
+
+Respeta las condiciones y los derechos de autor del sitio de origen al indexar contenido externo.
+
+### Figuras de PDF
+
+El modo visual añade una descripción generada a las páginas de un PDF que contienen muchas figuras. Es opcional y no carga ningún modelo visual durante una incorporación normal.
+
+```text
+Incorpora /Users/me/docs/research-paper.pdf con visual: true.
+```
+
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| Perfil | Caché del modelo | Uso |
+|---|---:|---|
+| `fast` (predeterminado) | unos 250 MB | Indexación visual ligera |
+| `quality` | unos 2,9 GB | Figuras con etiquetas, anotaciones u otro texto dentro de la imagen |
+
+Selecciona el modelo más grande con `visualQuality: "quality"` en MCP o con `--visual-quality quality` en la CLI. En pruebas con CPU, la inferencia tardó aproximadamente el doble que con `fast`, aunque el resultado depende del hardware y de las actualizaciones del modelo.
+
+Las descripciones son texto auxiliar, no transcripciones fieles. Trata las descripciones y el texto recuperado de los documentos como entradas no fiables, no como instrucciones.
+
+## CLI
+
+La CLI usa el mismo analizador, generador de embeddings y almacén vectorial sin necesidad de un cliente MCP:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "API de autenticación"
+npx mcp-local-rag query "autenticación" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
+npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
+```
+
+Las opciones globales, como `--db-path`, `--cache-dir` y `--model-name`, van antes del subcomando. Las opciones propias del subcomando van después:
+
+```bash
+npx mcp-local-rag --db-path ./my-db query "autenticación"
+```
+
+Ejecuta `npx mcp-local-rag --help` para ver la referencia completa de comandos.
+
+La CLI no lee la configuración del cliente MCP. Configura las mismas variables de entorno u opciones si ambas interfaces deben compartir un índice. En particular, `MODEL_NAME` y la opción `--model-name` de la CLI deben coincidir cuando usan la misma base de datos.
+
+## Ajuste de la búsqueda
+
+El refuerzo de palabras clave está activado de forma predeterminada. Para corpus que necesiten una selección más estricta, también se pueden configurar la agrupación por saltos de relevancia y los filtros de distancia y de archivos.
+
+| Variable | Valor predeterminado | Descripción |
+|----------|---------|-------------|
+| `RAG_HYBRID_WEIGHT` | `0.6` | Factor de refuerzo de palabras clave (0.0–1.0). 0 desactiva el reajuste por palabras clave y 1 aplica el refuerzo máximo. |
+| `RAG_GROUPING` | sin configurar | `similar` conserva el primer grupo de relevancia; `related` conserva hasta dos y usa saltos importantes de distancia vectorial como límites. |
+| `RAG_MAX_DISTANCE` | sin configurar | Descarta resultados poco relevantes (por ejemplo, `0.5`). |
+| `RAG_MAX_FILES` | sin configurar | Limita los resultados a los N archivos mejor clasificados (por ejemplo, `1` deja solo el mejor archivo). |
+
+En especificaciones de API y otros documentos con muchos identificadores, un peso mayor de palabras clave puede mejorar la clasificación de términos exactos:
+
+```json
+"env": {
+  "RAG_HYBRID_WEIGHT": "0.7"
+}
+```
+
+- `0.7`: reajuste de términos exactos algo más fuerte que el valor predeterminado
+- `1.0`: refuerzo máximo de palabras clave
+
+## Cómo funciona
+
+Durante la incorporación:
+
+1. El analizador extrae el texto del formato de entrada.
+2. El segmentador semántico localiza cambios de tema y conserva los bloques de código Markdown.
+3. Transformers.js crea los embeddings de forma local.
+4. LanceDB almacena los segmentos, los metadatos, los vectores y el índice de texto completo.
+
+Durante la búsqueda:
+
+1. La consulta se convierte en un embedding con el mismo modelo.
+2. La búsqueda vectorial recupera segmentos relacionados por su significado.
+3. Los filtros opcionales de distancia y los grupos de relevancia reducen los candidatos cuando están configurados.
+4. Las coincidencias de texto completo refuerzan los términos exactos de la consulta.
+
+## Agent Skills
+
+Las [Agent Skills](https://agentskills.io/) ofrecen a los asistentes de IA instrucciones para formular consultas e incorporar contenido:
+
+```bash
+npx mcp-local-rag skills install --claude-code
+npx mcp-local-rag skills install --claude-code --global
+npx mcp-local-rag skills install --codex
+```
+
+Las habilidades instaladas cubren la formulación de consultas, el refinamiento de resultados y la incorporación de HTML. Si alguna no se activa de forma automática, pide al asistente que use de manera explícita la habilidad mcp-local-rag.
+
+## Configuración
+
+El servidor MCP lee variables de entorno. La CLI acepta las mismas variables y las opciones de la tabla; las opciones de la CLI tienen prioridad.
+
+| Variable de entorno | Opción de la CLI | Valor predeterminado | Descripción |
+|---------------------|----------|---------|-------------|
+| `BASE_DIR` | `--base-dir` | Directorio actual | Un directorio raíz; la opción de la CLI puede repetirse en `ingest`, `list` y `sync` |
+| `BASE_DIRS` | No disponible | sin configurar | Matriz JSON de directorios raíz; tiene prioridad sobre `BASE_DIR` |
+| `DB_PATH` | `--db-path` | `./lancedb/` | Ubicación de la base de datos vectorial |
+| `CACHE_DIR` | `--cache-dir` | `./models/` | Directorio de caché de modelos |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Modelo de embeddings de Hugging Face |
+| `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100 MB) | Tamaño máximo del archivo en bytes |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Longitud mínima de un segmento en caracteres (1–10000) |
+| `RAG_DEVICE` | No disponible | `cpu` | Dispositivo de ejecución de ONNX Runtime |
+| `RAG_DTYPE` | No disponible | `fp32` | Tipo de datos de los embeddings que recibe el modelo seleccionado |
+
+### Directorios raíz (`BASE_DIR` y `BASE_DIRS`)
+
+mcp-local-rag solo permite operaciones con archivos dentro de los directorios raíz configurados. Para usar varios, `BASE_DIRS` debe ser una matriz JSON de rutas no vacías:
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+La configuración se resuelve en este orden:
+
+1. Opciones `--base-dir <path>` de la CLI (se pueden repetir en `ingest`, `list` y `sync`)
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. Directorio actual
+
+Cada origen sustituye al de menor prioridad, no se combina con él. Una configuración de `BASE_DIRS` no válida produce un error en lugar de recurrir a `BASE_DIR` o al directorio actual. `status` sigue disponible en MCP para que el cliente pueda informar del error de configuración.
+
+```bash
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+npx mcp-local-rag sync --base-dir /Users/me/work --base-dir /Users/me/specs
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
+
+### Almacenamiento y modelos
+
+`DB_PATH` y `CACHE_DIR` son relativos al directorio de trabajo del proceso de forma predeterminada. Usa rutas absolutas si el cliente MCP puede iniciar el servidor desde distintos directorios de proyecto.
+
+Configura `MODEL_NAME` o pasa `--model-name` para elegir un modelo de embeddings de Hugging Face que se ajuste al idioma y al ámbito de tus documentos.
+
+mcp-local-rag genera embeddings mediante mean pooling y normalización L2. Al elegir un modelo, comprueba si estos ajustes coinciden con su configuración de inferencia recomendada, ya que el método de pooling puede influir en la calidad de la búsqueda.
+
+Cambiar `MODEL_NAME`, `RAG_DEVICE` o `RAG_DTYPE` puede hacer que los vectores existentes sean incompatibles. Usa un `DB_PATH` nuevo o elimina el índice existente y vuelve a incorporar los documentos después de cambiar la configuración de embeddings.
+
+Un ejemplo de modelo disponible para documentos en español es `jinaai/jina-embeddings-v2-base-es`.
+
+## Seguridad y funcionamiento
+
+- El acceso a archivos está limitado a los directorios raíz configurados con `BASE_DIR`, `BASE_DIRS` o `--base-dir` en la CLI.
+- Se rechazan los enlaces simbólicos cuyo destino esté fuera de todos los directorios raíz configurados.
+- El procesamiento de documentos y las búsquedas no realizan solicitudes de red una vez que los modelos necesarios están en caché.
+- El servidor está diseñado para un único usuario local y no ofrece autenticación ni control de acceso.
+- No ejecutes varios procesos de escritura de la CLI o MCP sobre el mismo `DB_PATH`. Las consultas de solo lectura pueden ejecutarse mientras hay una sincronización en curso.
+- Para crear una copia de seguridad del índice, copia el directorio `DB_PATH` cuando no haya ningún proceso de escritura activo.
+
+<details>
+<summary><strong>Solución de problemas</strong></summary>
+
+### "No results found"
+
+Primero hay que incorporar los documentos. Ejecuta `"Enumera todos los archivos incorporados"` para comprobarlo.
+
+### Error al descargar el modelo
+
+Comprueba la conexión a Internet. Si usas un proxy, revisa la configuración de red. También puedes [descargar el modelo manualmente](https://huggingface.co/Xenova/all-MiniLM-L6-v2).
+
+### "File too large"
+
+El límite predeterminado es de 100 MB. Divide el archivo o aumenta `MAX_FILE_SIZE`.
+
+### Consultas lentas
+
+Comprueba el número de segmentos con `status`. Los documentos grandes con muchos segmentos pueden ralentizar las consultas. Considera dividir los archivos muy grandes.
+
+### "Path outside BASE_DIR"
+
+La ruta debe estar dentro de uno de los directorios raíz configurados: `BASE_DIR`, una entrada de `BASE_DIRS` o una ruta indicada mediante `--base-dir` en la CLI. Usa una ruta absoluta.
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` acepta una matriz JSON con una o más rutas no vacías:
+
+- Válido: `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- No válido: `BASE_DIRS=/a:/b` (no se admite la sintaxis con separadores)
+- No válido: `BASE_DIRS='[]'` (matriz vacía)
+
+### El cliente MCP no muestra las herramientas
+
+1. Comprueba la sintaxis del archivo de configuración
+2. Cierra el cliente por completo y vuelve a abrirlo (Cmd+Q en Mac para Cursor)
+3. Haz una prueba directa: `npx mcp-local-rag` debería iniciarse sin errores
+
+</details>
+
+## Colaboración
+
+Las contribuciones son bienvenidas. Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para preparar el entorno y revisar las pautas.
+
+## Licencia
+
+Licencia MIT. Uso gratuito para fines personales y comerciales.
+
+## Artículos del blog
+
+- [Building a Local RAG for Agentic Coding](https://www.norsica.jp/blog/local-rag-agentic-coding): análisis técnico del diseño de la segmentación semántica y la búsqueda híbrida.
+
+## Agradecimientos
+
+Creado con el [Model Context Protocol](https://modelcontextprotocol.io/) de Anthropic, [LanceDB](https://lancedb.com/) y [Transformers.js](https://huggingface.co/docs/transformers.js).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,416 @@
+<p align="center">
+  <img src="assets/banner.jpg" alt="MCP Local RAG: Search below the surface." width="600" />
+</p>
+
+# MCP Local RAG
+
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
+[![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <strong>Français</strong>
+</p>
+
+Recherchez dans des documents confidentiels depuis un client MCP ou un terminal, sans les envoyer à une API d'embeddings.
+
+mcp-local-rag indexe les fichiers PDF, DOCX et Markdown ainsi que les fichiers texte sur votre machine. La recherche associe similarité sémantique et correspondance par mots-clés. Elle tient ainsi compte du sens de la requête comme des termes techniques exacts, tels que les noms d'API, de classes et les codes d'erreur.
+
+## Fonctionnalités
+
+- **Exécution locale :** L'analyse des documents, les embeddings, le stockage et la recherche s'effectuent sur votre machine. Une fois le modèle téléchargé, l'import de texte et la recherche fonctionnent hors ligne.
+- **Recherche hybride :** La recherche sémantique trouve les concepts voisins, tandis que la correspondance par mots-clés améliore le classement des termes techniques exacts.
+- **Embeddings configurables :** Choisissez un modèle d'embeddings Hugging Face adapté à la langue et au domaine de vos documents.
+- **Découpage sémantique :** Les documents sont découpés aux changements de sujet plutôt qu'après un nombre fixe de caractères. Les blocs de code Markdown restent intacts.
+- **MCP et CLI :** Utilisez le même index depuis un outil de programmation assisté par IA ou directement dans le terminal.
+
+Aucune clé d'API, aucun conteneur Docker, aucune installation de Python ni aucune base de données externe ne sont nécessaires.
+
+## Démarrage rapide
+
+### Prérequis
+
+- Node.js 22 ou version ultérieure
+- Une connexion Internet lors de la première utilisation pour télécharger le paquet npm et le modèle d'embeddings
+- Un répertoire contenant les documents à rechercher
+
+Définissez `BASE_DIR` sur ce répertoire. Il sert également de limite de sécurité pour les opérations sur les fichiers. Remplacez `/absolute/path/to/your/documents` dans les exemples par le chemin absolu du répertoire.
+
+mcp-local-rag utilise le protocole MCP standard via un serveur stdio local. Il fonctionne donc avec les outils de programmation assistés par IA et les autres hôtes MCP qui prennent en charge les serveurs MCP locaux.
+
+Utilisez l'un des exemples ci-dessous, ou enregistrez `npx -y mcp-local-rag` et définissez `BASE_DIR` selon le format de configuration MCP de votre client.
+
+**Claude Code :** Exécutez cette commande :
+
+```bash
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
+```
+
+**Codex :** Ajoutez ceci à `~/.codex/config.toml` :
+
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIR = "/absolute/path/to/your/documents"
+```
+
+**OpenCode :** Ajoutez ceci à `~/.config/opencode/opencode.json` (ou `opencode.jsonc`) :
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-rag": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-local-rag"],
+      "environment": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+**Cursor :** Ajoutez ceci à `~/.cursor/mcp.json` :
+
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+Redémarrez le client, puis demandez-lui de construire l'index :
+
+```text
+Synchronise tous les documents du répertoire racine configuré et attends la fin de l'opération.
+```
+
+La première synchronisation télécharge le modèle d'embeddings par défaut (environ 90 Mo). Une à deux minutes peuvent s'écouler avant le début de l'import. Les exécutions suivantes utilisent le cache local.
+
+Une fois la synchronisation terminée, posez une question :
+
+```text
+Que dit la documentation de l'API au sujet de l'authentification ?
+```
+
+### Démarrage rapide avec la CLI
+
+Pour utiliser la CLI sans client MCP :
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag query "API d'authentification"
+```
+
+Par défaut, la CLI utilise le répertoire courant comme racine documentaire. Exécutez les deux commandes depuis le même répertoire pour qu'elles partagent l'index par défaut, ou définissez explicitement `BASE_DIR` et `DB_PATH`.
+
+## Pourquoi ce projet
+
+Certains documents ne peuvent pas être envoyés à un service d'embeddings hébergé pour des raisons de confidentialité ou de politique interne. Un index local permet de les rechercher sans ajouter de coût d'API à chaque requête.
+
+Une recherche uniquement sémantique peut ignorer des identifiants exacts qui comptent dans la documentation technique. Le reclassement par mots-clés garde ces termes visibles sans renoncer aux requêtes en langage naturel.
+
+## Contenu pris en charge
+
+| Entrée | Mode d'import |
+|---|---|
+| PDF, DOCX, TXT, Markdown | Import d'un fichier ou synchronisation d'un répertoire |
+| HTML déjà récupéré par le client | `ingest_data` ; nettoyé avec Readability puis converti en Markdown |
+| Texte brut ou Markdown en mémoire | `ingest_data` avec un identifiant de source stable |
+
+Le serveur ne récupère pas lui-même les pages HTML. Un client MCP peut charger une page et transmettre son HTML à `ingest_data`.
+
+L'import de fichiers ne prend pas en charge Excel, PowerPoint, les images seules ni les extensions de code source. Les PDF peuvent éventuellement utiliser un modèle visuel local pour décrire les figures, mais cette fonction n'est ni un OCR ni un moteur de recherche d'images.
+
+## Outils MCP
+
+| Outil | Rôle |
+|---|---|
+| `sync_start` | Synchroniser l'index avec toutes les racines configurées ou avec un chemin précis |
+| `sync_status` | Consulter l'état d'une synchronisation en cours |
+| `ingest_file` | Importer ou remplacer un fichier |
+| `ingest_data` | Importer du texte, du Markdown ou du HTML déjà présent dans le client |
+| `query_documents` | Rechercher avec correspondance sémantique et renforcement des mots-clés |
+| `read_chunk_neighbors` | Lire les segments voisins d'un résultat de recherche |
+| `list_files` | Afficher les fichiers pris en charge et leur état d'import |
+| `delete_file` | Supprimer un fichier indexé ou un élément `ingest_data` |
+| `status` | Afficher l'état de l'index et de la recherche |
+
+### Synchroniser une racine documentaire
+
+`sync_start` importe les fichiers nouveaux ou modifiés, ignore ceux qui sont identiques octet par octet et retire de l'index les fichiers qui n'existent plus :
+
+```text
+Synchronise tout le contenu des racines documentaires configurées et attends la fin de l'opération.
+```
+
+L'outil renvoie immédiatement un `jobId`. Le client doit interroger `sync_status` jusqu'à ce que son état passe à `succeeded` ou `failed`. Le mode visuel n'est pas disponible pendant une synchronisation ; les PDF modifiés sont importés comme texte.
+
+Le processus serveur ne conserve qu'une tâche de synchronisation. Une nouvelle tâche remplace l'enregistrement d'une tâche terminée, et le redémarrage du serveur efface cet enregistrement.
+
+### Importer un fichier
+
+`ingest_file` accepte les fichiers PDF, DOCX, TXT et Markdown. Les chemins transmis par MCP doivent être absolus et rester dans une racine documentaire configurée :
+
+```text
+Importe le document /Users/me/docs/api-spec.pdf.
+```
+
+Réimporter le même chemin remplace les segments existants.
+
+### Rechercher et lire davantage de contexte
+
+```text
+Que dit la documentation de l'API au sujet de l'authentification ?
+Trouve le comportement documenté de ERR_CONNECTION_REFUSED.
+```
+
+Les résultats contiennent le texte, le chemin source, le titre, l'indice du segment et le score de pertinence. Pour obtenir plus de contexte, transmettez à `read_chunk_neighbors` le `chunkIndex` et le `filePath` ou la `source` du résultat :
+
+```text
+Lis les segments voisins de ce résultat sur l'authentification.
+```
+
+`query_documents` et `list_files` acceptent un préfixe de chemin absolu facultatif dans `scope`, ou une liste de préfixes. Un préfixe correspond au chemin exact et à tous ses descendants.
+
+### Importer du HTML
+
+Utilisez `ingest_data` après que le client MCP a récupéré la page :
+
+```text
+Récupère https://example.com/docs et importe le HTML.
+```
+
+Le serveur extrait l'article principal, le convertit en Markdown et l'enregistre sous l'identifiant de source fourni. Réutiliser la même source met à jour le contenu existant.
+
+Respectez les conditions du site source et les droits d'auteur lors de l'indexation de contenu externe.
+
+### Figures dans les PDF
+
+Le mode visuel ajoute une description générée aux pages PDF riches en figures. Il est facultatif et ne charge aucun modèle visuel pendant un import normal.
+
+```text
+Importe /Users/me/docs/research-paper.pdf avec visual: true.
+```
+
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| Profil | Cache du modèle | Usage |
+|---|---:|---|
+| `fast` (par défaut) | environ 250 Mo | Indexation visuelle légère |
+| `quality` | environ 2,9 Go | Figures contenant des libellés, des annotations ou d'autres textes intégrés à l'image |
+
+Sélectionnez le modèle le plus volumineux avec `visualQuality: "quality"` via MCP ou `--visual-quality quality` via la CLI. Lors des mesures sur CPU, l'inférence a pris environ deux fois plus de temps qu'avec `fast`, mais le résultat dépend du matériel et des mises à jour du modèle.
+
+Les descriptions sont des textes auxiliaires, pas des transcriptions fidèles. Considérez les descriptions et le texte extrait des documents comme des entrées non fiables, et non comme des instructions.
+
+## CLI
+
+La CLI utilise le même analyseur, le même générateur d'embeddings et le même stockage vectoriel sans client MCP :
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "API d'authentification"
+npx mcp-local-rag query "authentification" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
+npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
+```
+
+Les options globales comme `--db-path`, `--cache-dir` et `--model-name` précèdent la sous-commande. Les options propres à la sous-commande viennent ensuite :
+
+```bash
+npx mcp-local-rag --db-path ./my-db query "authentification"
+```
+
+Exécutez `npx mcp-local-rag --help` pour afficher la référence complète des commandes.
+
+La CLI ne lit pas la configuration du client MCP. Définissez les mêmes variables d'environnement ou options si les deux interfaces doivent partager un index. En particulier, `MODEL_NAME` et l'option CLI `--model-name` doivent correspondre pour une base de données partagée.
+
+## Réglage de la recherche
+
+Le renforcement par mots-clés est activé par défaut. Pour les corpus qui nécessitent une sélection plus stricte, vous pouvez aussi configurer le regroupement par écarts de pertinence ainsi que les filtres de distance et de fichiers.
+
+| Variable | Valeur par défaut | Description |
+|----------|---------|-------------|
+| `RAG_HYBRID_WEIGHT` | `0.6` | Facteur de renforcement des mots-clés (0.0–1.0). 0 désactive le reclassement par mots-clés et 1 applique le renforcement maximal. |
+| `RAG_GROUPING` | non définie | `similar` conserve le premier groupe de pertinence ; `related` en conserve jusqu'à deux et utilise les écarts importants de distance vectorielle comme limites. |
+| `RAG_MAX_DISTANCE` | non définie | Écarte les résultats peu pertinents, par exemple avec `0.5`. |
+| `RAG_MAX_FILES` | non définie | Limite les résultats aux N fichiers les mieux classés, par exemple `1` pour le meilleur fichier uniquement. |
+
+Pour les spécifications d'API et les autres documents comportant de nombreux identifiants, un poids plus élevé des mots-clés peut améliorer le classement des termes exacts :
+
+```json
+"env": {
+  "RAG_HYBRID_WEIGHT": "0.7"
+}
+```
+
+- `0.7` : reclassement des termes exacts légèrement plus fort que la valeur par défaut
+- `1.0` : renforcement maximal des mots-clés
+
+## Fonctionnement
+
+Pendant l'import :
+
+1. L'analyseur extrait le texte du format d'entrée.
+2. Le découpage sémantique repère les changements de sujet et conserve les blocs de code Markdown.
+3. Transformers.js crée les embeddings localement.
+4. LanceDB stocke les segments, les métadonnées, les vecteurs et l'index de texte intégral.
+
+Pendant la recherche :
+
+1. La requête est convertie en embedding avec le même modèle.
+2. La recherche vectorielle récupère les segments sémantiquement proches.
+3. Les filtres de distance et les groupes de pertinence facultatifs réduisent la liste des candidats lorsqu'ils sont configurés.
+4. Les correspondances en texte intégral renforcent les termes exacts de la requête.
+
+## Agent Skills
+
+Les [Agent Skills](https://agentskills.io/) donnent aux assistants IA des consignes pour les requêtes et les imports :
+
+```bash
+npx mcp-local-rag skills install --claude-code
+npx mcp-local-rag skills install --claude-code --global
+npx mcp-local-rag skills install --codex
+```
+
+Les skills installées couvrent la formulation des requêtes, l'affinage des résultats et l'import de HTML. Si une skill ne s'active pas automatiquement, demandez explicitement à l'assistant d'utiliser la skill mcp-local-rag.
+
+## Configuration
+
+Le serveur MCP lit les variables d'environnement. La CLI accepte les mêmes variables ainsi que les options du tableau ; les options de la CLI sont prioritaires.
+
+| Variable d'environnement | Option CLI | Valeur par défaut | Description |
+|---------------------|----------|---------|-------------|
+| `BASE_DIR` | `--base-dir` | Répertoire courant | Une racine documentaire ; l'option CLI peut être répétée avec `ingest`, `list` et `sync` |
+| `BASE_DIRS` | Non disponible | non définie | Tableau JSON de racines documentaires ; prioritaire sur `BASE_DIR` |
+| `DB_PATH` | `--db-path` | `./lancedb/` | Emplacement de la base de données vectorielle |
+| `CACHE_DIR` | `--cache-dir` | `./models/` | Répertoire du cache des modèles |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Modèle d'embeddings Hugging Face |
+| `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100 Mo) | Taille maximale d'un fichier en octets |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Longueur minimale d'un segment en caractères (1–10000) |
+| `RAG_DEVICE` | Non disponible | `cpu` | Périphérique utilisé par ONNX Runtime |
+| `RAG_DTYPE` | Non disponible | `fp32` | Type de données des embeddings transmis au modèle choisi |
+
+### Racines documentaires (`BASE_DIR` et `BASE_DIRS`)
+
+mcp-local-rag n'autorise les opérations sur les fichiers qu'à l'intérieur des racines configurées. Pour en utiliser plusieurs, `BASE_DIRS` doit être un tableau JSON de chemins non vides :
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+La configuration est résolue dans cet ordre :
+
+1. Options CLI `--base-dir <path>` (répétables avec `ingest`, `list` et `sync`)
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. Répertoire courant
+
+Chaque source remplace entièrement celle de priorité inférieure, au lieu de s'y ajouter. Une configuration `BASE_DIRS` incorrecte provoque une erreur sans revenir à `BASE_DIR` ni au répertoire courant. `status` reste disponible dans MCP afin que le client puisse signaler l'erreur de configuration.
+
+```bash
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+npx mcp-local-rag sync --base-dir /Users/me/work --base-dir /Users/me/specs
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
+
+### Stockage et modèles
+
+`DB_PATH` et `CACHE_DIR` sont relatifs au répertoire de travail du processus par défaut. Utilisez des chemins absolus si le client MCP peut démarrer le serveur depuis différents répertoires de projet.
+
+Définissez `MODEL_NAME` ou passez `--model-name` pour choisir un modèle d'embeddings Hugging Face adapté à la langue et au domaine de vos documents.
+
+mcp-local-rag génère les embeddings avec un pooling moyen et une normalisation L2. Lorsque vous choisissez un modèle, vérifiez que ces réglages correspondent à sa méthode d'inférence recommandée, car le type de pooling peut influer sur la qualité de la recherche.
+
+Modifier `MODEL_NAME`, `RAG_DEVICE` ou `RAG_DTYPE` peut rendre les vecteurs existants incompatibles. Après une modification de la configuration des embeddings, utilisez un nouveau `DB_PATH` ou supprimez l'index existant et réimportez les documents.
+
+Un exemple de modèle disponible pour les documents en français est `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`.
+
+## Sécurité et exploitation
+
+- L'accès aux fichiers est limité aux racines définies par `BASE_DIR`, `BASE_DIRS` ou l'option CLI `--base-dir`.
+- Les liens symboliques qui pointent hors de toutes les racines configurées sont refusés.
+- Le traitement des documents et la recherche n'effectuent plus de requêtes réseau une fois les modèles nécessaires en cache.
+- Le serveur est conçu pour un seul utilisateur local et ne fournit ni authentification ni contrôle d'accès.
+- Ne lancez pas plusieurs processus d'écriture CLI ou MCP sur le même `DB_PATH`. Les requêtes en lecture seule restent possibles pendant une synchronisation.
+- Pour sauvegarder un index, copiez le répertoire `DB_PATH` lorsqu'aucun processus d'écriture n'est actif.
+
+<details>
+<summary><strong>Dépannage</strong></summary>
+
+### "No results found"
+
+Les documents doivent d'abord être importés. Exécutez `"Répertoriez tous les fichiers importés"` pour vérifier leur état.
+
+### Échec du téléchargement du modèle
+
+Vérifiez la connexion Internet. Si vous utilisez un proxy, contrôlez les paramètres réseau. Le modèle peut aussi être [téléchargé manuellement](https://huggingface.co/Xenova/all-MiniLM-L6-v2).
+
+### "File too large"
+
+La limite par défaut est de 100 Mo. Découpez le fichier ou augmentez `MAX_FILE_SIZE`.
+
+### Requêtes lentes
+
+Consultez le nombre de segments avec `status`. Les gros documents comportant de nombreux segments peuvent ralentir les requêtes. Envisagez de diviser les fichiers très volumineux.
+
+### "Path outside BASE_DIR"
+
+Le chemin doit se trouver dans l'une des racines configurées : `BASE_DIR`, une entrée de `BASE_DIRS` ou un chemin fourni avec `--base-dir` dans la CLI. Utilisez un chemin absolu.
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` accepte un tableau JSON comportant un ou plusieurs chemins non vides :
+
+- Valide : `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- Invalide : `BASE_DIRS=/a:/b` (la syntaxe à séparateurs n'est pas prise en charge)
+- Invalide : `BASE_DIRS='[]'` (tableau vide)
+
+### Le client MCP n'affiche pas les outils
+
+1. Vérifiez la syntaxe du fichier de configuration
+2. Quittez complètement le client, puis relancez-le (Cmd+Q sur Mac pour Cursor)
+3. Testez directement : `npx mcp-local-rag` doit démarrer sans erreur
+
+</details>
+
+## Contribuer
+
+Les contributions sont les bienvenues. Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour préparer l'environnement et connaître les règles du projet.
+
+## Licence
+
+Licence MIT. Utilisation gratuite à des fins personnelles et commerciales.
+
+## Articles de blog
+
+- [Building a Local RAG for Agentic Coding](https://www.norsica.jp/blog/local-rag-agentic-coding) : présentation technique du découpage sémantique et de la recherche hybride.
+
+## Remerciements
+
+Développé avec le [Model Context Protocol](https://modelcontextprotocol.io/) d'Anthropic, [LanceDB](https://lancedb.com/) et [Transformers.js](https://huggingface.co/docs/transformers.js).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
 
+<p align="center">
+  <strong>English</strong> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a>
+</p>
+
 Search private documents from an MCP client or the terminal without sending them to an
 embedding API.
 
@@ -341,7 +350,7 @@ flags, with CLI flags taking precedence.
 | `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100MB) | Maximum file size in bytes |
 | `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Minimum chunk length in characters (1–10000) |
 | `RAG_DEVICE` | N/A | `cpu` | ONNX Runtime execution device |
-| `RAG_DTYPE` | N/A | `fp32` | Embedding dtype supplied by the selected model |
+| `RAG_DTYPE` | N/A | `fp32` | Embedding dtype passed to the selected model |
 
 ### Document Roots (`BASE_DIR` and `BASE_DIRS`)
 
@@ -378,14 +387,15 @@ paths when the MCP client may start the server from different project directorie
 Set `MODEL_NAME` or pass `--model-name` to choose a Hugging Face embedding model that fits the
 language and domain of your documents.
 
+mcp-local-rag generates embeddings with mean pooling and L2 normalization. When choosing a
+model, check whether these settings match its recommended inference setup, since the pooling
+method can affect retrieval quality.
+
 Changing `MODEL_NAME`, `RAG_DEVICE`, or `RAG_DTYPE` can make existing vectors incompatible.
 Use a new `DB_PATH` or delete the existing index and re-ingest after changing the embedding
 configuration.
 
-Model examples:
-
-- Multilingual documents: `onnx-community/embeddinggemma-300m-ONNX`
-- Scientific papers: `sentence-transformers/allenai-specter`
+An example model for English documents is `Xenova/bge-small-en-v1.5`.
 
 ## Security and Operation
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ terms such as API names, class names, and error codes.
   After the initial model download, text ingestion and search work offline.
 - **Hybrid search:** Semantic retrieval finds related concepts, while keyword matching boosts
   exact technical terms.
+- **Configurable embeddings:** Choose a Hugging Face embedding model that fits the language and
+  domain of your documents.
 - **Semantic chunking:** Documents are split at topic boundaries instead of fixed character
   counts. Markdown code blocks stay intact.
 - **MCP and CLI:** Use the same index from an AI coding tool or directly from the terminal.
@@ -372,6 +374,9 @@ BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
 
 `DB_PATH` and `CACHE_DIR` are relative to the process working directory by default. Set absolute
 paths when the MCP client may start the server from different project directories.
+
+Set `MODEL_NAME` or pass `--model-name` to choose a Hugging Face embedding model that fits the
+language and domain of your documents.
 
 Changing `MODEL_NAME`, `RAG_DEVICE`, or `RAG_DTYPE` can make existing vectors incompatible.
 Use a new `DB_PATH` or delete the existing index and re-ingest after changing the embedding

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,416 @@
+<p align="center">
+  <img src="assets/banner.jpg" alt="MCP Local RAG: Search below the surface." width="600" />
+</p>
+
+# MCP Local RAG
+
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
+[![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <strong>Português (Brasil)</strong> |
+  <a href="README.fr.md">Français</a>
+</p>
+
+Pesquise documentos privados usando um cliente MCP ou o terminal sem enviá-los a uma API de embeddings.
+
+O mcp-local-rag indexa arquivos PDF, DOCX, Markdown e texto no seu computador. A busca combina similaridade semântica e correspondência por palavras-chave. Assim, leva em conta tanto o sentido da consulta quanto termos técnicos exatos, como nomes de APIs, classes e códigos de erro.
+
+## Recursos
+
+- **Execução local:** O processamento dos documentos, os embeddings, o armazenamento e a busca acontecem no seu computador. Depois do primeiro download do modelo, a importação de texto e as buscas funcionam offline.
+- **Busca híbrida:** A recuperação semântica encontra conceitos relacionados, enquanto a correspondência por palavras-chave dá mais peso a termos técnicos exatos.
+- **Embeddings configuráveis:** Escolha um modelo de embeddings do Hugging Face adequado ao idioma e à área dos seus documentos.
+- **Divisão semântica:** Os documentos são divididos nas mudanças de assunto, não por uma quantidade fixa de caracteres. Blocos de código Markdown permanecem intactos.
+- **MCP e CLI:** Use o mesmo índice em uma ferramenta de programação com IA ou diretamente no terminal.
+
+Não é necessário ter chave de API, Docker, Python nem banco de dados externo.
+
+## Início rápido
+
+### Requisitos
+
+- Node.js 22 ou mais recente
+- Acesso à internet no primeiro uso para baixar o pacote npm e o modelo de embeddings
+- Um diretório com os documentos que você quer pesquisar
+
+Defina `BASE_DIR` com o caminho desse diretório. Ele também funciona como limite de segurança para as operações com arquivos. Substitua `/absolute/path/to/your/documents` nos exemplos pelo caminho absoluto do diretório.
+
+O mcp-local-rag usa o protocolo MCP padrão por meio de um servidor stdio local. Assim, ele funciona com ferramentas de programação com IA e outros hosts MCP compatíveis com servidores MCP locais.
+
+Use um dos exemplos abaixo ou registre `npx -y mcp-local-rag` e defina `BASE_DIR` no formato de configuração MCP do seu cliente.
+
+**Claude Code:** Execute este comando:
+
+```bash
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
+```
+
+**Codex:** Adicione a `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIR = "/absolute/path/to/your/documents"
+```
+
+**OpenCode:** Adicione a `~/.config/opencode/opencode.json` (ou `opencode.jsonc`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-rag": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-local-rag"],
+      "environment": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+**Cursor:** Adicione a `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+Reinicie o cliente e peça para ele criar o índice:
+
+```text
+Sincronize todos os documentos do diretório raiz configurado e aguarde a conclusão.
+```
+
+A primeira sincronização baixa o modelo de embeddings padrão (cerca de 90 MB). O início da importação pode levar de 1 a 2 minutos. Nas próximas execuções, o cache local será usado.
+
+Quando a sincronização terminar, faça uma pergunta:
+
+```text
+O que a documentação da API diz sobre autenticação?
+```
+
+### Início rápido pela CLI
+
+Para usar a CLI sem um cliente MCP:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag query "API de autenticação"
+```
+
+Por padrão, a CLI usa o diretório atual como raiz dos documentos. Execute os dois comandos no mesmo diretório para que usem o mesmo índice padrão ou defina `BASE_DIR` e `DB_PATH` explicitamente.
+
+## Por que este projeto existe
+
+Alguns conjuntos de documentos não podem ser enviados a um serviço de embeddings hospedado devido a requisitos de confidencialidade ou políticas da organização. Mantendo o índice local, esses documentos continuam pesquisáveis sem gerar custo de API por consulta.
+
+Uma busca puramente semântica pode ignorar identificadores exatos que são importantes na documentação técnica. O reordenamento por palavras-chave mantém esses termos visíveis sem abrir mão das consultas em linguagem natural.
+
+## Conteúdo compatível
+
+| Entrada | Como importar |
+|---|---|
+| PDF, DOCX, TXT, Markdown | Importação de arquivo ou sincronização de diretório |
+| HTML já obtido pelo cliente | `ingest_data`; limpo com Readability e convertido para Markdown |
+| Texto simples ou Markdown em memória | `ingest_data` com um identificador de origem estável |
+
+O servidor não busca HTML por conta própria. Um cliente MCP pode obter uma página e enviar o HTML para `ingest_data`.
+
+A importação de arquivos não aceita Excel, PowerPoint, imagens avulsas nem extensões de código-fonte. Opcionalmente, arquivos PDF podem usar um modelo visual local para descrever figuras, mas esse recurso não é OCR nem busca de imagens.
+
+## Ferramentas MCP
+
+| Ferramenta | Finalidade |
+|---|---|
+| `sync_start` | Sincronizar o índice com todos os diretórios raiz configurados ou com um caminho |
+| `sync_status` | Consultar uma sincronização em andamento |
+| `ingest_file` | Importar ou substituir um arquivo |
+| `ingest_data` | Importar texto, Markdown ou HTML que já esteja disponível no cliente |
+| `query_documents` | Pesquisar com correspondência semântica e reforço por palavras-chave |
+| `read_chunk_neighbors` | Ler os fragmentos próximos a um resultado de busca |
+| `list_files` | Mostrar os arquivos compatíveis e o estado de importação |
+| `delete_file` | Excluir um arquivo indexado ou um item de `ingest_data` |
+| `status` | Mostrar o estado do índice e da busca |
+
+### Sincronizar um diretório raiz
+
+`sync_start` importa arquivos novos e alterados, ignora os que são idênticos byte a byte e remove do índice os arquivos que deixaram de existir:
+
+```text
+Sincronize todo o conteúdo dos diretórios raiz configurados e aguarde a conclusão.
+```
+
+A ferramenta retorna um `jobId` imediatamente. O cliente deve consultar `sync_status` até o estado mudar para `succeeded` ou `failed`. Não há modo visual durante a sincronização; arquivos PDF alterados são importados como texto.
+
+O processo do servidor mantém apenas o registro de um job de sincronização. Um novo job substitui o registro de outro já concluído, e o registro é descartado quando o servidor reinicia.
+
+### Importar um arquivo
+
+`ingest_file` aceita PDF, DOCX, TXT e Markdown. Os caminhos enviados via MCP devem ser absolutos e permanecer dentro de um diretório raiz configurado:
+
+```text
+Importe o documento /Users/me/docs/api-spec.pdf.
+```
+
+Importar novamente o mesmo caminho substitui os fragmentos existentes.
+
+### Pesquisar e ler mais contexto
+
+```text
+O que a documentação da API diz sobre autenticação?
+Encontre o comportamento documentado de ERR_CONNECTION_REFUSED.
+```
+
+Os resultados contêm o texto, o caminho de origem, o título, o índice do fragmento e a pontuação de relevância. Se precisar de mais contexto, envie a `read_chunk_neighbors` o `chunkIndex` e o `filePath` ou `source` do resultado:
+
+```text
+Leia os fragmentos próximos a esse resultado sobre autenticação.
+```
+
+Tanto `query_documents` quanto `list_files` aceitam um prefixo de caminho absoluto opcional em `scope`, ou uma lista de prefixos. Cada prefixo corresponde ao caminho exato e a todos os caminhos abaixo dele.
+
+### Importar HTML
+
+Use `ingest_data` depois que o cliente MCP buscar a página:
+
+```text
+Busque https://example.com/docs e importe o HTML.
+```
+
+O servidor extrai o artigo principal, converte o conteúdo para Markdown e o armazena com o identificador de origem fornecido. Reutilizar a mesma origem atualiza o conteúdo existente.
+
+Respeite os termos e os direitos autorais do site de origem ao indexar conteúdo externo.
+
+### Figuras em PDF
+
+O modo visual adiciona uma descrição gerada às páginas de PDF com muitas figuras. Ele é opcional e não carrega um modelo visual durante a importação normal.
+
+```text
+Importe /Users/me/docs/research-paper.pdf com visual: true.
+```
+
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| Perfil | Cache do modelo | Indicação |
+|---|---:|---|
+| `fast` (padrão) | cerca de 250 MB | Indexação visual leve |
+| `quality` | cerca de 2,9 GB | Figuras com rótulos, anotações ou outros textos dentro da imagem |
+
+Selecione o modelo maior com `visualQuality: "quality"` via MCP ou com `--visual-quality quality` pela CLI. Em testes com CPU, a inferência levou cerca do dobro do tempo de `fast`, mas o resultado depende do hardware e das atualizações do modelo.
+
+As descrições são textos auxiliares, não transcrições fiéis. Trate as descrições e o texto recuperado dos documentos como entradas não confiáveis, não como instruções.
+
+## CLI
+
+A CLI usa o mesmo analisador, gerador de embeddings e banco vetorial sem precisar de um cliente MCP:
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "API de autenticação"
+npx mcp-local-rag query "autenticação" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
+npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
+```
+
+Opções globais, como `--db-path`, `--cache-dir` e `--model-name`, vêm antes do subcomando. As opções próprias do subcomando vêm depois:
+
+```bash
+npx mcp-local-rag --db-path ./my-db query "autenticação"
+```
+
+Execute `npx mcp-local-rag --help` para consultar a referência completa dos comandos.
+
+A CLI não lê a configuração do cliente MCP. Defina as mesmas variáveis de ambiente ou opções se as duas interfaces precisarem compartilhar um índice. Em particular, `MODEL_NAME` e a opção `--model-name` da CLI devem ser iguais quando usam o mesmo banco de dados.
+
+## Ajuste da busca
+
+O reforço por palavras-chave é ativado por padrão. Para acervos que exigem uma seleção mais restrita, também é possível configurar o agrupamento por saltos de relevância e os filtros de distância e de arquivos.
+
+| Variável | Padrão | Descrição |
+|----------|---------|-------------|
+| `RAG_HYBRID_WEIGHT` | `0.6` | Fator de reforço por palavras-chave (0.0–1.0). 0 desativa o reordenamento por palavras-chave e 1 aplica o reforço máximo. |
+| `RAG_GROUPING` | não definido | `similar` mantém o primeiro grupo de relevância; `related` mantém até dois e usa saltos relevantes na distância vetorial como limites. |
+| `RAG_MAX_DISTANCE` | não definido | Descarta resultados pouco relevantes, por exemplo, com `0.5`. |
+| `RAG_MAX_FILES` | não definido | Limita os resultados aos N arquivos mais bem classificados, por exemplo, `1` para apenas o melhor arquivo. |
+
+Em especificações de API e outros documentos com muitos identificadores, um peso maior para palavras-chave pode melhorar a classificação de termos exatos:
+
+```json
+"env": {
+  "RAG_HYBRID_WEIGHT": "0.7"
+}
+```
+
+- `0.7`: reordenamento de termos exatos um pouco mais forte que o padrão
+- `1.0`: reforço máximo por palavras-chave
+
+## Como funciona
+
+Durante a importação:
+
+1. O analisador extrai o texto do formato de entrada.
+2. O divisor semântico encontra as mudanças de assunto e preserva os blocos de código Markdown.
+3. O Transformers.js cria os embeddings localmente.
+4. O LanceDB armazena os fragmentos, metadados, vetores e o índice de texto completo.
+
+Durante a busca:
+
+1. A consulta é convertida em embedding pelo mesmo modelo.
+2. A busca vetorial recupera fragmentos relacionados pelo significado.
+3. Quando configurados, os filtros opcionais de distância e os grupos de relevância reduzem os candidatos.
+4. As correspondências de texto completo reforçam os termos exatos da consulta.
+
+## Agent Skills
+
+As [Agent Skills](https://agentskills.io/) orientam assistentes de IA na formulação de consultas e na importação de conteúdo:
+
+```bash
+npx mcp-local-rag skills install --claude-code
+npx mcp-local-rag skills install --claude-code --global
+npx mcp-local-rag skills install --codex
+```
+
+As skills instaladas cobrem formulação de consultas, refinamento de resultados e importação de HTML. Se uma skill não for ativada automaticamente, peça ao assistente para usar a skill mcp-local-rag de forma explícita.
+
+## Configuração
+
+O servidor MCP lê variáveis de ambiente. A CLI aceita as mesmas variáveis e as opções listadas na tabela; as opções da CLI têm prioridade.
+
+| Variável de ambiente | Opção da CLI | Padrão | Descrição |
+|---------------------|----------|---------|-------------|
+| `BASE_DIR` | `--base-dir` | Diretório atual | Um diretório raiz; a opção da CLI pode ser repetida em `ingest`, `list` e `sync` |
+| `BASE_DIRS` | N/D | não definido | Array JSON de diretórios raiz; tem prioridade sobre `BASE_DIR` |
+| `DB_PATH` | `--db-path` | `./lancedb/` | Local do banco de dados vetorial |
+| `CACHE_DIR` | `--cache-dir` | `./models/` | Diretório de cache dos modelos |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Modelo de embeddings do Hugging Face |
+| `MAX_FILE_SIZE` | `--max-file-size` | `104857600` (100 MB) | Tamanho máximo do arquivo em bytes |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | Tamanho mínimo de um fragmento em caracteres (1–10000) |
+| `RAG_DEVICE` | N/D | `cpu` | Dispositivo de execução do ONNX Runtime |
+| `RAG_DTYPE` | N/D | `fp32` | Tipo de dados dos embeddings enviado ao modelo selecionado |
+
+### Diretórios raiz (`BASE_DIR` e `BASE_DIRS`)
+
+O mcp-local-rag só permite operações com arquivos dentro dos diretórios raiz configurados. Para usar vários diretórios, `BASE_DIRS` deve ser um array JSON de caminhos não vazios:
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+A configuração é resolvida nesta ordem:
+
+1. Opções `--base-dir <path>` da CLI (podem ser repetidas em `ingest`, `list` e `sync`)
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. Diretório atual
+
+Cada origem substitui a de menor prioridade, em vez de ser combinada com ela. Uma configuração inválida de `BASE_DIRS` produz um erro, sem recorrer a `BASE_DIR` ou ao diretório atual. `status` continua disponível no MCP para que o cliente possa informar o erro de configuração.
+
+```bash
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+npx mcp-local-rag sync --base-dir /Users/me/work --base-dir /Users/me/specs
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
+
+### Armazenamento e modelos
+
+Por padrão, `DB_PATH` e `CACHE_DIR` são relativos ao diretório de trabalho do processo. Use caminhos absolutos se o cliente MCP puder iniciar o servidor a partir de diretórios de projeto diferentes.
+
+Defina `MODEL_NAME` ou passe `--model-name` para escolher um modelo de embeddings do Hugging Face adequado ao idioma e à área dos seus documentos.
+
+O mcp-local-rag gera embeddings com mean pooling e normalização L2. Ao escolher um modelo, verifique se essas configurações correspondem à configuração de inferência recomendada para esse modelo, pois o tipo de pooling pode afetar a qualidade da busca.
+
+Alterar `MODEL_NAME`, `RAG_DEVICE` ou `RAG_DTYPE` pode deixar os vetores existentes incompatíveis. Depois de mudar a configuração dos embeddings, use um novo `DB_PATH` ou exclua o índice existente e importe os documentos novamente.
+
+Um exemplo de modelo disponível para documentos em português é `Xenova/paraphrase-multilingual-MiniLM-L12-v2`.
+
+## Segurança e operação
+
+- O acesso a arquivos fica restrito aos diretórios raiz definidos em `BASE_DIR`, `BASE_DIRS` ou pela opção `--base-dir` da CLI.
+- Links simbólicos que apontam para fora de todos os diretórios raiz configurados são rejeitados.
+- O processamento dos documentos e as buscas não fazem solicitações de rede depois que os modelos necessários estão no cache.
+- O servidor foi projetado para um único usuário local e não oferece autenticação nem controle de acesso.
+- Não execute vários processos de escrita da CLI ou do MCP no mesmo `DB_PATH`. Consultas somente leitura podem ser executadas durante uma sincronização.
+- Para fazer backup do índice, copie o diretório `DB_PATH` enquanto não houver nenhum processo de escrita ativo.
+
+<details>
+<summary><strong>Solução de problemas</strong></summary>
+
+### "No results found"
+
+Os documentos precisam ser importados primeiro. Execute `"Liste todos os arquivos importados"` para verificar.
+
+### Falha no download do modelo
+
+Verifique a conexão com a internet. Se estiver usando um proxy, revise as configurações de rede. O modelo também pode ser [baixado manualmente](https://huggingface.co/Xenova/all-MiniLM-L6-v2).
+
+### "File too large"
+
+O limite padrão é 100 MB. Divida o arquivo ou aumente `MAX_FILE_SIZE`.
+
+### Consultas lentas
+
+Verifique a quantidade de fragmentos com `status`. Documentos grandes, com muitos fragmentos, podem deixar as consultas mais lentas. Considere dividir arquivos muito grandes.
+
+### "Path outside BASE_DIR"
+
+O caminho precisa estar dentro de um dos diretórios raiz configurados: `BASE_DIR`, uma entrada de `BASE_DIRS` ou um caminho definido por `--base-dir` na CLI. Use um caminho absoluto.
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` aceita um array JSON com um ou mais caminhos não vazios:
+
+- Válido: `BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- Inválido: `BASE_DIRS=/a:/b` (a sintaxe com separadores não é aceita)
+- Inválido: `BASE_DIRS='[]'` (array vazio)
+
+### O cliente MCP não mostra as ferramentas
+
+1. Verifique a sintaxe do arquivo de configuração
+2. Feche o cliente por completo e abra novamente (Cmd+Q no Mac para o Cursor)
+3. Teste diretamente: `npx mcp-local-rag` deve iniciar sem erros
+
+</details>
+
+## Como contribuir
+
+Contribuições são bem-vindas. Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para preparar o ambiente e conferir as orientações.
+
+## Licença
+
+Licença MIT. Uso gratuito para fins pessoais e comerciais.
+
+## Artigos do blog
+
+- [Building a Local RAG for Agentic Coding](https://www.norsica.jp/blog/local-rag-agentic-coding): análise técnica do design da divisão semântica e da busca híbrida.
+
+## Agradecimentos
+
+Desenvolvido com o [Model Context Protocol](https://modelcontextprotocol.io/) da Anthropic, o [LanceDB](https://lancedb.com/) e o [Transformers.js](https://huggingface.co/docs/transformers.js).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,416 @@
+<p align="center">
+  <img src="assets/banner.jpg" alt="MCP Local RAG: Search below the surface." width="600" />
+</p>
+
+# MCP Local RAG
+
+[![GitHub stars](https://img.shields.io/github/stars/shinpr/mcp-local-rag?style=social)](https://github.com/shinpr/mcp-local-rag)
+[![npm version](https://img.shields.io/npm/v/mcp-local-rag.svg)](https://www.npmjs.com/package/mcp-local-rag)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-green.svg)](https://registry.modelcontextprotocol.io/)
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <strong>简体中文</strong> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a>
+</p>
+
+通过 MCP 客户端或终端搜索私有文档，无需将内容发送给嵌入 API。
+
+mcp-local-rag 在本机为 PDF、DOCX、Markdown 和文本文件建立索引。搜索结合语义相似度与关键词匹配，既能理解查询意图，也能准确匹配 API 名称、类名和错误代码等技术术语。
+
+## 功能
+
+- **本地运行：** 文档解析、嵌入、存储和搜索全部在本机完成。首次下载模型后，文本导入和搜索均可离线使用。
+- **混合搜索：** 语义检索负责查找相关概念，关键词匹配则提高精确技术术语的排名。
+- **可配置嵌入模型：** 可根据文档的语言和领域选择合适的 Hugging Face 嵌入模型。
+- **语义分块：** 按主题边界而非固定字符数拆分文档，并保持 Markdown 代码块完整。
+- **MCP 和 CLI：** AI 编程工具与终端可使用同一份索引。
+
+无需 API 密钥、Docker、Python 或外部数据库。
+
+## 快速开始
+
+### 使用要求
+
+- Node.js 22 或更高版本
+- 首次使用时需要联网下载 npm 包和嵌入模型
+- 一个包含待搜索文档的目录
+
+将 `BASE_DIR` 设置为该目录。它同时也是文件操作的安全边界。请将下方的 `/absolute/path/to/your/documents` 替换为该目录的绝对路径。
+
+mcp-local-rag 通过本地 stdio 服务器使用标准 MCP 协议，因此可与支持本地 MCP 服务器的 AI 编程工具及其他 MCP 宿主配合使用。
+
+可直接使用以下示例，也可以按照客户端的 MCP 配置格式注册 `npx -y mcp-local-rag` 并设置 `BASE_DIR`。
+
+**Claude Code：** 运行以下命令：
+
+```bash
+claude mcp add local-rag --scope user --env BASE_DIR=/absolute/path/to/your/documents -- npx -y mcp-local-rag
+```
+
+**Codex：** 在 `~/.codex/config.toml` 中添加：
+
+```toml
+[mcp_servers.local-rag]
+command = "npx"
+args = ["-y", "mcp-local-rag"]
+
+[mcp_servers.local-rag.env]
+BASE_DIR = "/absolute/path/to/your/documents"
+```
+
+**OpenCode：** 在 `~/.config/opencode/opencode.json`（或 `opencode.jsonc`）中添加：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-rag": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-local-rag"],
+      "environment": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+**Cursor：** 在 `~/.cursor/mcp.json` 中添加：
+
+```json
+{
+  "mcpServers": {
+    "local-rag": {
+      "command": "npx",
+      "args": ["-y", "mcp-local-rag"],
+      "env": {
+        "BASE_DIR": "/absolute/path/to/your/documents"
+      }
+    }
+  }
+}
+```
+
+重启客户端，然后让它创建索引：
+
+```text
+同步已配置根目录中的所有文档，并等待同步完成。
+```
+
+首次同步会下载默认嵌入模型（约 90 MB）。开始导入前可能需要等待 1–2 分钟，之后会直接使用本地缓存。
+
+同步完成后即可提问：
+
+```text
+API 文档如何说明身份验证？
+```
+
+### CLI 快速开始
+
+不使用 MCP 客户端时，可直接通过 CLI 操作：
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag query "身份验证 API"
+```
+
+CLI 默认将当前目录作为文档根目录。请在同一目录中运行这两条命令，以便共用默认索引；也可以显式设置 `BASE_DIR` 和 `DB_PATH`。
+
+## 为什么开发它
+
+出于保密要求或组织政策，有些文档不能发送给托管式嵌入服务。将索引保留在本机，既能搜索这些文档，也不会产生按查询计费的 API 成本。
+
+单纯依赖语义搜索，可能会漏掉技术文档中重要的精确标识符。关键词重排可以保留这些精确匹配，同时继续利用自然语言检索。
+
+## 支持的内容
+
+| 输入 | 导入方式 |
+|---|---|
+| PDF、DOCX、TXT、Markdown | 导入文件或同步目录 |
+| 客户端已获取的 HTML | 使用 `ingest_data`；通过 Readability 清理后转换为 Markdown |
+| 内存中的纯文本或 Markdown | 使用 `ingest_data`，并提供稳定的来源标识符 |
+
+服务器本身不负责获取 HTML。MCP 客户端可以先获取网页，再将 HTML 传给 `ingest_data`。
+
+文件导入不支持 Excel、PowerPoint、独立图片和源代码文件扩展名。PDF 可以选择使用本地视觉模型描述图像内容，但该功能不属于 OCR 或图片搜索。
+
+## MCP 工具
+
+| 工具 | 用途 |
+|---|---|
+| `sync_start` | 将全部已配置根目录或指定路径与索引同步 |
+| `sync_status` | 查询正在运行的同步任务 |
+| `ingest_file` | 导入或替换单个文件 |
+| `ingest_data` | 导入客户端已有的文本、Markdown 或 HTML |
+| `query_documents` | 使用语义匹配和关键词加权进行搜索 |
+| `read_chunk_neighbors` | 读取搜索结果相邻的文本块 |
+| `list_files` | 显示支持的文件及其导入状态 |
+| `delete_file` | 删除已建立索引的文件或 `ingest_data` 条目 |
+| `status` | 显示索引和搜索状态 |
+
+### 同步文档根目录
+
+`sync_start` 会导入新增和已修改的文件，跳过字节完全相同的文件，并删除已不存在文件的索引记录：
+
+```text
+同步已配置文档根目录中的所有内容，并等待完成。
+```
+
+该工具会立即返回 `jobId`。客户端应持续查询 `sync_status`，直到状态变为 `succeeded` 或 `failed`。同步期间不使用视觉模式；发生变化的 PDF 会按文本导入。
+
+服务器进程只保留一个同步任务记录。新任务会替换已经结束的记录，服务器重启后该记录也会丢失。
+
+### 导入单个文件
+
+`ingest_file` 支持 PDF、DOCX、TXT 和 Markdown。通过 MCP 传入的文件路径必须是绝对路径，并且必须位于已配置的文档根目录内：
+
+```text
+导入 /Users/me/docs/api-spec.pdf。
+```
+
+再次导入同一路径会替换原有文本块。
+
+### 搜索并读取更多上下文
+
+```text
+API 文档如何说明身份验证？
+查找 ERR_CONNECTION_REFUSED 的文档说明。
+```
+
+搜索结果包含文本、来源路径、标题、文本块编号和相关度分数。需要更多上下文时，将结果中的 `chunkIndex` 以及 `filePath` 或 `source` 传给 `read_chunk_neighbors`：
+
+```text
+读取该身份验证结果前后的文本块。
+```
+
+`query_documents` 和 `list_files` 都接受可选的绝对 `scope` 路径前缀或前缀列表。前缀会匹配指定路径及其全部子路径。
+
+### 导入 HTML
+
+由 MCP 客户端获取网页后，再使用 `ingest_data`：
+
+```text
+获取 https://example.com/docs 并导入其中的 HTML。
+```
+
+服务器会提取正文、转换为 Markdown，并使用提供的来源标识符保存。再次使用同一来源会更新已有内容。
+
+为外部内容建立索引时，请遵守来源网站的条款和版权规定。
+
+### PDF 图像
+
+视觉模式会为图像内容较多的 PDF 页面生成说明文字。该功能需要主动开启，常规导入不会加载视觉模型。
+
+```text
+使用 visual: true 导入 /Users/me/docs/research-paper.pdf。
+```
+
+```bash
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
+```
+
+| 模式 | 模型缓存 | 适用场景 |
+|---|---:|---|
+| `fast`（默认） | 约 250 MB | 轻量视觉索引 |
+| `quality` | 约 2.9 GB | 包含标签、标注或其他图中文字的图像 |
+
+通过 MCP 使用 `visualQuality: "quality"`，或通过 CLI 使用 `--visual-quality quality`，即可选择较大的模型。实测 CPU 推理耗时约为 `fast` 的两倍，但实际结果取决于硬件和模型更新。
+
+生成的说明文字只是辅助文本，并非忠实的逐字转录。检索到的说明文字和文档文本都应视为不可信输入，而不是操作指令。
+
+## CLI
+
+CLI 无需 MCP 客户端，使用与服务器相同的解析器、嵌入器和向量存储：
+
+```bash
+npx mcp-local-rag ingest ./docs/
+npx mcp-local-rag sync ./docs/
+npx mcp-local-rag query "身份验证 API"
+npx mcp-local-rag query "身份验证" --scope /docs/api --scope /docs/guide
+npx mcp-local-rag read-neighbors --file-path /abs/path.md --chunk-index 5
+npx mcp-local-rag list
+npx mcp-local-rag status
+npx mcp-local-rag delete ./docs/old.pdf
+npx mcp-local-rag delete --source "https://example.com/docs"
+```
+
+`--db-path`、`--cache-dir` 和 `--model-name` 等全局选项应放在子命令之前，子命令选项则放在子命令之后：
+
+```bash
+npx mcp-local-rag --db-path ./my-db query "身份验证"
+```
+
+运行 `npx mcp-local-rag --help` 可查看完整命令说明。
+
+CLI 不读取 MCP 客户端配置。如果两个接口需要共用索引，请设置相同的环境变量或命令行参数。特别是共享同一数据库时，`MODEL_NAME` 必须与 CLI 的 `--model-name` 一致。
+
+## 搜索调优
+
+关键词加权默认开启。对于需要更严格筛选结果的语料库，还可以使用相关度间隔分组、距离过滤和文件数量限制。
+
+| 变量 | 默认值 | 说明 |
+|----------|---------|-------------|
+| `RAG_HYBRID_WEIGHT` | `0.6` | 关键词加权系数（0.0–1.0）。0 表示禁用关键词重排，1 表示使用最大加权。 |
+| `RAG_GROUPING` | 未设置 | `similar` 保留第一个相关度分组；`related` 最多保留两个分组，并以明显的向量距离间隔为边界。 |
+| `RAG_MAX_DISTANCE` | 未设置 | 过滤相关度较低的结果（例如 `0.5`）。 |
+| `RAG_MAX_FILES` | 未设置 | 将结果限制在排名最靠前的 N 个文件中（例如 `1` 表示只保留最佳文件）。 |
+
+对于包含大量标识符的 API 规范及类似文档，提高关键词权重可以改善精确术语的排名：
+
+```json
+"env": {
+  "RAG_HYBRID_WEIGHT": "0.7"
+}
+```
+
+- `0.7`：比默认值稍强的精确术语重排
+- `1.0`：最大关键词加权
+
+## 工作原理
+
+导入时：
+
+1. 解析器从输入格式中提取文本。
+2. 语义分块器识别主题边界，并保持 Markdown 代码块完整。
+3. Transformers.js 在本地生成嵌入向量。
+4. LanceDB 保存文本块、元数据、向量和全文索引。
+
+搜索时：
+
+1. 使用同一模型为查询生成嵌入向量。
+2. 向量搜索检索语义相关的文本块。
+3. 配置后，可使用距离过滤和相关度分组进一步缩小候选范围。
+4. 全文匹配会提高精确查询词的排名。
+
+## Agent Skills
+
+[Agent Skills](https://agentskills.io/) 为 AI 助手提供查询和导入指导：
+
+```bash
+npx mcp-local-rag skills install --claude-code
+npx mcp-local-rag skills install --claude-code --global
+npx mcp-local-rag skills install --codex
+```
+
+安装的技能涵盖查询写法、结果优化和 HTML 导入。如果技能没有自动启用，请明确要求助手使用 mcp-local-rag 技能。
+
+## 配置
+
+MCP 服务器读取环境变量。CLI 支持相同的变量和下表所列的命令行参数；命令行参数优先级更高。
+
+| 环境变量 | CLI 参数 | 默认值 | 说明 |
+|---------------------|----------|---------|-------------|
+| `BASE_DIR` | `--base-dir` | 当前目录 | 一个文档根目录；`ingest`、`list` 和 `sync` 可重复使用该 CLI 参数 |
+| `BASE_DIRS` | 不适用 | 未设置 | 文档根目录的 JSON 数组；优先于 `BASE_DIR` |
+| `DB_PATH` | `--db-path` | `./lancedb/` | 向量数据库位置 |
+| `CACHE_DIR` | `--cache-dir` | `./models/` | 模型缓存目录 |
+| `MODEL_NAME` | `--model-name` | `Xenova/all-MiniLM-L6-v2` | Hugging Face 嵌入模型 |
+| `MAX_FILE_SIZE` | `--max-file-size` | `104857600`（100 MB） | 最大文件大小（字节） |
+| `CHUNK_MIN_LENGTH` | `--chunk-min-length` | `50` | 文本块最小字符数（1–10000） |
+| `RAG_DEVICE` | 不适用 | `cpu` | ONNX Runtime 执行设备 |
+| `RAG_DTYPE` | 不适用 | `fp32` | 传给所选模型的嵌入数据类型 |
+
+### 文档根目录（`BASE_DIR` 和 `BASE_DIRS`）
+
+mcp-local-rag 只允许在已配置的根目录中执行文件操作。需要使用多个根目录时，`BASE_DIRS` 必须是由非空路径组成的 JSON 数组：
+
+```bash
+export BASE_DIRS='["/Users/me/Documents/work","/Users/me/Projects/specs"]'
+```
+
+根目录配置按以下优先顺序解析：
+
+1. CLI 的 `--base-dir <path>` 参数（可在 `ingest`、`list` 和 `sync` 中重复使用）
+2. `BASE_DIRS`
+3. `BASE_DIR`
+4. 当前目录
+
+每一级配置都会完全取代优先级更低的配置，而不是与其合并。无效的 `BASE_DIRS` 会直接报错，不会回退到 `BASE_DIR` 或当前目录。即使配置有误，MCP 中的 `status` 仍然可用，因此客户端可以报告具体问题。
+
+```bash
+npx mcp-local-rag ingest --base-dir /Users/me/work --base-dir /Users/me/specs /Users/me/work/readme.md
+npx mcp-local-rag list --base-dir /Users/me/work --base-dir /Users/me/specs
+npx mcp-local-rag sync --base-dir /Users/me/work --base-dir /Users/me/specs
+BASE_DIRS='["/Users/me/work","/Users/me/specs"]' npx mcp-local-rag list
+```
+
+### 存储和模型
+
+`DB_PATH` 和 `CACHE_DIR` 默认相对于进程的工作目录。如果 MCP 客户端可能从不同的项目目录启动服务器，请使用绝对路径。
+
+设置 `MODEL_NAME` 或传入 `--model-name`，即可选择适合文档语言和领域的 Hugging Face 嵌入模型。
+
+mcp-local-rag 使用平均池化和 L2 归一化生成嵌入。选择模型时，请确认这些设置是否符合该模型建议的推理方式，因为池化方式可能影响检索质量。
+
+更改 `MODEL_NAME`、`RAG_DEVICE` 或 `RAG_DTYPE` 可能导致现有向量不兼容。更改嵌入配置后，请使用新的 `DB_PATH`，或者删除现有索引并重新导入。
+
+适用于中文文档的模型示例：`Xenova/bge-small-zh-v1.5`。
+
+## 安全与运行
+
+- 文件访问仅限 `BASE_DIR`、`BASE_DIRS` 或 CLI 的 `--base-dir` 所指定的根目录。
+- 指向所有已配置根目录之外的符号链接会被拒绝。
+- 所需模型缓存完成后，文档处理和搜索不会再发起网络请求。
+- 服务器面向单个本地用户设计，不提供身份验证或访问控制。
+- 不要让多个 CLI 或 MCP 写入进程同时操作同一个 `DB_PATH`。同步进行时仍可执行只读查询。
+- 没有写入进程运行时，可以复制 `DB_PATH` 目录来备份索引。
+
+<details>
+<summary><strong>故障排除</strong></summary>
+
+### "No results found"
+
+必须先导入文档。运行 `"列出所有已导入的文件"` 检查导入状态。
+
+### 模型下载失败
+
+请检查网络连接。如果使用代理，请确认网络设置。也可以[手动下载模型](https://huggingface.co/Xenova/all-MiniLM-L6-v2)。
+
+### "File too large"
+
+默认上限为 100 MB。请拆分大文件，或提高 `MAX_FILE_SIZE`。
+
+### 查询缓慢
+
+使用 `status` 查看文本块数量。包含大量文本块的大型文档可能降低查询速度，可以考虑拆分特别大的文件。
+
+### "Path outside BASE_DIR"
+
+请确保文件路径位于某个已配置根目录内，即 `BASE_DIR`、`BASE_DIRS` 中的任一路径或 CLI 的任一 `--base-dir`。请使用绝对路径。
+
+### "BASE_DIRS must be a JSON array..."
+
+`BASE_DIRS` 接受由一个或多个非空路径组成的 JSON 数组：
+
+- 有效：`BASE_DIRS='["/Users/me/work","/Users/me/specs"]'`
+- 无效：`BASE_DIRS=/a:/b`（不支持分隔符语法）
+- 无效：`BASE_DIRS='[]'`（空数组）
+
+### MCP 客户端未显示工具
+
+1. 检查配置文件语法
+2. 完全退出并重启客户端（Cursor 在 Mac 上使用 Cmd+Q）
+3. 直接测试：`npx mcp-local-rag` 应能正常运行且不报错
+
+</details>
+
+## 参与贡献
+
+欢迎贡献！环境设置和贡献规范请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 许可证
+
+MIT 许可证，可免费用于个人和商业用途。
+
+## 博客文章
+
+- [为 Agentic Coding 构建本地 RAG](https://www.norsica.jp/blog/local-rag-agentic-coding)：深入介绍语义分块与混合搜索的技术设计。
+
+## 致谢
+
+本项目基于 Anthropic 的 [Model Context Protocol](https://modelcontextprotocol.io/)、[LanceDB](https://lancedb.com/) 和 [Transformers.js](https://huggingface.co/docs/transformers.js) 构建。


### PR DESCRIPTION
## Summary

- Add localized READMEs for Simplified Chinese, German, Spanish, Brazilian Portuguese, and French.
- Add a language switcher to every README.
- Clarify that embedding models are configurable and document the mean-pooling and L2-normalization behavior.
- Include a language-relevant example model in each README without presenting it as a recommendation.

## Verification

- Loaded every documented example model with the public mcp-local-rag 0.17.4 CLI on CPU with fp32 and completed a query.
- Confirmed the branch diff passes git diff --check.
- The pre-push hook passed Biome and TypeScript checks.