### PR TITLE
feat(pdf-visual): run the quality profile on Qwen3.5-2B

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -221,15 +221,15 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 
 Wähle das größere Modell über MCP mit `visualQuality: "quality"` oder über die CLI mit `--visual-quality quality`. In CPU-Messungen dauerte die Inferenz etwa dreimal so lange wie mit `fast`; die tatsächliche Geschwindigkeit hängt von Hardware und Modellversion ab.
 
-#### Umstieg von einem früheren `quality`-Modell
+#### Bestehende `quality`-Bildbeschreibungen aktualisieren
 
-`quality` nutzt jetzt Qwen3.5-2B, frühere Versionen nutzten Qwen2.5-VL-3B. Bereits indexierte Bildbeschreibungen behalten den Wortlaut des alten Modells, und `sync` erzeugt sie nicht neu — importiere also neu, was aktualisiert werden soll:
+Ab 0.18.4 nutzt `quality` Qwen3.5-2B, frühere Versionen nutzten Qwen2.5-VL-3B. Bereits indexierte Bildbeschreibungen behalten den Wortlaut des alten Modells, und `sync` erzeugt sie nicht neu. Importiere die betroffenen Dateien erneut, um ihre Bildbeschreibungen zu aktualisieren:
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-Das alte Modell bleibt auf der Festplatte. Sobald es nicht mehr gebraucht wird, lösche `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (standardmäßig `./models/`).
+Gib `--images` mit, wenn die Datei damit importiert wurde, denn ein Lauf ohne diese Option ersetzt die gespeicherten Bilder. Das alte Modell bleibt auf der Festplatte. Sobald es nicht mehr gebraucht wird, lösche `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` aus dem Modellcache-Verzeichnis — `<cache-dir>`, standardmäßig `./models/`.
 
 #### Visueller Modus über Synchronisierungen hinweg
 

--- a/README.de.md
+++ b/README.de.md
@@ -217,9 +217,19 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 | Profil | Modellcache | Geeignet für |
 |---|---:|---|
 | `fast` (Standard) | etwa 250 MB | Leichtgewichtige visuelle Indexierung |
-| `quality` | etwa 2,9 GB | Abbildungen mit Beschriftungen, Anmerkungen oder anderem Text im Bild |
+| `quality` | etwa 1,7 GB | Abbildungen mit Beschriftungen, Anmerkungen oder anderem Text im Bild |
 
-Wähle das größere Modell über MCP mit `visualQuality: "quality"` oder über die CLI mit `--visual-quality quality`. In CPU-Messungen dauerte die Inferenz etwa doppelt so lange wie mit `fast`; die tatsächliche Geschwindigkeit hängt von Hardware und Modellversion ab.
+Wähle das größere Modell über MCP mit `visualQuality: "quality"` oder über die CLI mit `--visual-quality quality`. In CPU-Messungen dauerte die Inferenz etwa dreimal so lange wie mit `fast`; die tatsächliche Geschwindigkeit hängt von Hardware und Modellversion ab.
+
+#### Umstieg von einem früheren `quality`-Modell
+
+`quality` nutzt jetzt Qwen3.5-2B, frühere Versionen nutzten Qwen2.5-VL-3B. Bereits indexierte Bildbeschreibungen behalten den Wortlaut des alten Modells, und `sync` erzeugt sie nicht neu — importiere also neu, was aktualisiert werden soll:
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+Das alte Modell bleibt auf der Festplatte. Sobald es nicht mehr gebraucht wird, lösche `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (standardmäßig `./models/`).
 
 #### Visueller Modus über Synchronisierungen hinweg
 

--- a/README.es.md
+++ b/README.es.md
@@ -217,9 +217,19 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 | Perfil | Caché del modelo | Uso |
 |---|---:|---|
 | `fast` (predeterminado) | unos 250 MB | Indexación visual ligera |
-| `quality` | unos 2,9 GB | Figuras con etiquetas, anotaciones u otro texto dentro de la imagen |
+| `quality` | unos 1,7 GB | Figuras con etiquetas, anotaciones u otro texto dentro de la imagen |
 
-Selecciona el modelo más grande con `visualQuality: "quality"` en MCP o con `--visual-quality quality` en la CLI. En pruebas con CPU, la inferencia tardó aproximadamente el doble que con `fast`, aunque el resultado depende del hardware y de las actualizaciones del modelo.
+Selecciona el modelo más grande con `visualQuality: "quality"` en MCP o con `--visual-quality quality` en la CLI. En pruebas con CPU, la inferencia tardó aproximadamente el triple que con `fast`, aunque el resultado depende del hardware y de las actualizaciones del modelo.
+
+#### Si vienes de un modelo `quality` anterior
+
+`quality` ahora usa Qwen3.5-2B; las versiones anteriores usaban Qwen2.5-VL-3B. Las descripciones ya indexadas conservan el texto del modelo anterior y `sync` no las regenera, así que vuelve a incorporar lo que quieras actualizar:
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+El modelo anterior permanece en el disco. Cuando ya nada lo use, elimina `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` por defecto).
 
 #### Modo visual entre sincronizaciones
 

--- a/README.es.md
+++ b/README.es.md
@@ -221,15 +221,15 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 
 Selecciona el modelo más grande con `visualQuality: "quality"` en MCP o con `--visual-quality quality` en la CLI. En pruebas con CPU, la inferencia tardó aproximadamente el triple que con `fast`, aunque el resultado depende del hardware y de las actualizaciones del modelo.
 
-#### Si vienes de un modelo `quality` anterior
+#### Actualizar las descripciones `quality` existentes
 
-`quality` ahora usa Qwen3.5-2B; las versiones anteriores usaban Qwen2.5-VL-3B. Las descripciones ya indexadas conservan el texto del modelo anterior y `sync` no las regenera, así que vuelve a incorporar lo que quieras actualizar:
+Desde 0.18.4, `quality` usa Qwen3.5-2B; las versiones anteriores usaban Qwen2.5-VL-3B. Las descripciones ya indexadas conservan el texto del modelo anterior y `sync` no las regenera, así que vuelve a importar los archivos que quieras actualizar:
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-El modelo anterior permanece en el disco. Cuando ya nada lo use, elimina `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` por defecto).
+Añade `--images` si el archivo se incorporó con esa opción, porque una ejecución sin ella reemplaza las imágenes almacenadas. El modelo anterior permanece en el disco. Cuando ya nada lo use, elimina `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` del directorio de caché de modelos: `<cache-dir>`, que por defecto es `./models/`.
 
 #### Modo visual entre sincronizaciones
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -217,9 +217,19 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 | Profil | Cache du modèle | Usage |
 |---|---:|---|
 | `fast` (par défaut) | environ 250 Mo | Indexation visuelle légère |
-| `quality` | environ 2,9 Go | Figures contenant des libellés, des annotations ou d'autres textes intégrés à l'image |
+| `quality` | environ 1,7 Go | Figures contenant des libellés, des annotations ou d'autres textes intégrés à l'image |
 
-Sélectionnez le modèle le plus volumineux avec `visualQuality: "quality"` via MCP ou `--visual-quality quality` via la CLI. Lors des mesures sur CPU, l'inférence a pris environ deux fois plus de temps qu'avec `fast`, mais le résultat dépend du matériel et des mises à jour du modèle.
+Sélectionnez le modèle le plus volumineux avec `visualQuality: "quality"` via MCP ou `--visual-quality quality` via la CLI. Lors des mesures sur CPU, l'inférence a pris environ trois fois plus de temps qu'avec `fast`, mais le résultat dépend du matériel et des mises à jour du modèle.
+
+#### Migration depuis un modèle `quality` précédent
+
+`quality` utilise désormais Qwen3.5-2B ; les versions précédentes utilisaient Qwen2.5-VL-3B. Les descriptions déjà indexées conservent le texte produit par l'ancien modèle et `sync` ne les régénère pas : réimportez ce que vous voulez mettre à jour.
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+L'ancien modèle reste sur le disque. Lorsque plus rien ne l'utilise, supprimez `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` par défaut).
 
 #### Mode visuel au fil des synchronisations
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -221,15 +221,15 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 
 Sélectionnez le modèle le plus volumineux avec `visualQuality: "quality"` via MCP ou `--visual-quality quality` via la CLI. Lors des mesures sur CPU, l'inférence a pris environ trois fois plus de temps qu'avec `fast`, mais le résultat dépend du matériel et des mises à jour du modèle.
 
-#### Migration depuis un modèle `quality` précédent
+#### Mettre à jour les descriptions `quality` existantes
 
-`quality` utilise désormais Qwen3.5-2B ; les versions précédentes utilisaient Qwen2.5-VL-3B. Les descriptions déjà indexées conservent le texte produit par l'ancien modèle et `sync` ne les régénère pas : réimportez ce que vous voulez mettre à jour.
+À partir de 0.18.4, `quality` utilise Qwen3.5-2B ; les versions précédentes utilisaient Qwen2.5-VL-3B. Les descriptions déjà indexées conservent le texte produit par l'ancien modèle et `sync` ne les régénère pas : réimportez les fichiers dont vous souhaitez actualiser les descriptions.
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-L'ancien modèle reste sur le disque. Lorsque plus rien ne l'utilise, supprimez `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` par défaut).
+Ajoutez `--images` si le fichier a été importé avec cette option, car une exécution sans elle remplace les images stockées. L'ancien modèle reste sur le disque. Lorsque plus rien ne l'utilise, supprimez `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` du répertoire de cache des modèles : `<cache-dir>`, dont la valeur par défaut est `./models/`.
 
 #### Mode visuel au fil des synchronisations
 

--- a/README.md
+++ b/README.md
@@ -274,17 +274,20 @@ Select the larger model with `visualQuality: "quality"` over MCP or
 `--visual-quality quality` over CLI. Measured CPU inference was about three times as slow as
 `fast`, though results depend on hardware and model updates.
 
-#### Coming From an Earlier `quality` Model
+#### Updating Existing `quality` Captions
 
-`quality` now runs Qwen3.5-2B; earlier versions ran Qwen2.5-VL-3B. Captions already indexed keep the
-wording the old model produced, and `sync` will not redo them, so re-ingest what you want refreshed:
+From 0.18.4 `quality` runs Qwen3.5-2B; earlier versions ran Qwen2.5-VL-3B. Captions already indexed
+keep the wording the old model produced, and `sync` will not redo them, so re-ingest the files you
+want refreshed:
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-The old model stays on disk. Once nothing else uses it, delete
-`<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` by default).
+Add `--images` if the file was ingested with it, because a run without it replaces the stored
+images. The old model stays on disk. Once nothing else uses it, delete
+`onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` from the model cache directory — `<cache-dir>`, which
+defaults to `./models/`.
 
 #### Visual Mode Across Syncs
 

--- a/README.md
+++ b/README.md
@@ -268,11 +268,23 @@ alter ranking, scores, or result count.
 | Profile | Model cache | Use case |
 |---|---:|---|
 | `fast` (default) | about 250 MB | Lightweight visual indexing |
-| `quality` | about 2.9 GB | Figures containing labels, annotations, or other in-image text |
+| `quality` | about 1.7 GB | Figures containing labels, annotations, or other in-image text |
 
 Select the larger model with `visualQuality: "quality"` over MCP or
-`--visual-quality quality` over CLI. Measured CPU inference was about twice as slow as `fast`,
-though results depend on hardware and model updates.
+`--visual-quality quality` over CLI. Measured CPU inference was about three times as slow as
+`fast`, though results depend on hardware and model updates.
+
+#### Coming From an Earlier `quality` Model
+
+`quality` now runs Qwen3.5-2B; earlier versions ran Qwen2.5-VL-3B. Captions already indexed keep the
+wording the old model produced, and `sync` will not redo them, so re-ingest what you want refreshed:
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+The old model stays on disk. Once nothing else uses it, delete
+`<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` by default).
 
 #### Visual Mode Across Syncs
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -221,15 +221,15 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 
 Selecione o modelo maior com `visualQuality: "quality"` via MCP ou com `--visual-quality quality` pela CLI. Em testes com CPU, a inferência levou cerca do triplo do tempo de `fast`, mas o resultado depende do hardware e das atualizações do modelo.
 
-#### Vindo de um modelo `quality` anterior
+#### Atualizar as descrições `quality` existentes
 
-O `quality` agora usa o Qwen3.5-2B; versões anteriores usavam o Qwen2.5-VL-3B. As descrições já indexadas mantêm o texto do modelo antigo e o `sync` não as refaz, então reimporte o que você quiser atualizar:
+A partir da 0.18.4, o `quality` usa o Qwen3.5-2B; versões anteriores usavam o Qwen2.5-VL-3B. As descrições já indexadas mantêm o texto do modelo antigo e o `sync` não as refaz, então reimporte os arquivos que você quiser atualizar:
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-O modelo antigo continua no disco. Quando nada mais o usar, apague `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` por padrão).
+Inclua `--images` se o arquivo foi importado com essa opção, porque uma execução sem ela substitui as imagens armazenadas. O modelo antigo continua no disco. Quando nada mais o usar, apague `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` do diretório de cache dos modelos: `<cache-dir>`, cujo padrão é `./models/`.
 
 #### Modo visual entre sincronizações
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -217,9 +217,19 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 | Perfil | Cache do modelo | Indicação |
 |---|---:|---|
 | `fast` (padrão) | cerca de 250 MB | Indexação visual leve |
-| `quality` | cerca de 2,9 GB | Figuras com rótulos, anotações ou outros textos dentro da imagem |
+| `quality` | cerca de 1,7 GB | Figuras com rótulos, anotações ou outros textos dentro da imagem |
 
-Selecione o modelo maior com `visualQuality: "quality"` via MCP ou com `--visual-quality quality` pela CLI. Em testes com CPU, a inferência levou cerca do dobro do tempo de `fast`, mas o resultado depende do hardware e das atualizações do modelo.
+Selecione o modelo maior com `visualQuality: "quality"` via MCP ou com `--visual-quality quality` pela CLI. Em testes com CPU, a inferência levou cerca do triplo do tempo de `fast`, mas o resultado depende do hardware e das atualizações do modelo.
+
+#### Vindo de um modelo `quality` anterior
+
+O `quality` agora usa o Qwen3.5-2B; versões anteriores usavam o Qwen2.5-VL-3B. As descrições já indexadas mantêm o texto do modelo antigo e o `sync` não as refaz, então reimporte o que você quiser atualizar:
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+O modelo antigo continua no disco. Quando nada mais o usar, apague `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/` (`./models/` por padrão).
 
 #### Modo visual entre sincronizações
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,15 +221,15 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 
 通过 MCP 使用 `visualQuality: "quality"`，或通过 CLI 使用 `--visual-quality quality`，即可选择较大的模型。实测 CPU 推理耗时约为 `fast` 的三倍，但实际结果取决于硬件和模型更新。
 
-#### 从旧版 `quality` 模型迁移
+#### 更新已索引的 `quality` 说明文字
 
-`quality` 现在使用 Qwen3.5-2B，旧版本使用 Qwen2.5-VL-3B。已索引的说明文字仍是旧模型生成的内容，`sync` 不会重新生成，需要更新的文件请重新导入：
+从 0.18.4 起，`quality` 使用 Qwen3.5-2B，旧版本使用 Qwen2.5-VL-3B。已索引的说明文字仍是旧模型生成的内容，`sync` 不会重新生成，需要更新的文件请重新导入：
 
 ```bash
-npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+npx mcp-local-rag ingest ./docs/research-paper.pdf --visual --visual-quality quality
 ```
 
-旧模型仍留在磁盘上。确认不再使用后，可删除 `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/`（默认为 `./models/`）。
+如果该文件当初是带 `--images` 导入的，请一并加上该选项，否则本次导入会替换已保存的图像。旧模型仍留在磁盘上。确认不再使用后，可删除模型缓存目录（`<cache-dir>`，默认为 `./models/`）下的 `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/`。
 
 #### 跨同步的视觉模式
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,9 +217,19 @@ npx mcp-local-rag ingest ./docs/research-paper.pdf --visual
 | 模式 | 模型缓存 | 适用场景 |
 |---|---:|---|
 | `fast`（默认） | 约 250 MB | 轻量视觉索引 |
-| `quality` | 约 2.9 GB | 包含标签、标注或其他图中文字的图像 |
+| `quality` | 约 1.7 GB | 包含标签、标注或其他图中文字的图像 |
 
-通过 MCP 使用 `visualQuality: "quality"`，或通过 CLI 使用 `--visual-quality quality`，即可选择较大的模型。实测 CPU 推理耗时约为 `fast` 的两倍，但实际结果取决于硬件和模型更新。
+通过 MCP 使用 `visualQuality: "quality"`，或通过 CLI 使用 `--visual-quality quality`，即可选择较大的模型。实测 CPU 推理耗时约为 `fast` 的三倍，但实际结果取决于硬件和模型更新。
+
+#### 从旧版 `quality` 模型迁移
+
+`quality` 现在使用 Qwen3.5-2B，旧版本使用 Qwen2.5-VL-3B。已索引的说明文字仍是旧模型生成的内容，`sync` 不会重新生成，需要更新的文件请重新导入：
+
+```bash
+npx mcp-local-rag ingest ./docs/ --visual --visual-quality quality
+```
+
+旧模型仍留在磁盘上。确认不再使用后，可删除 `<cache-dir>/onnx-community/Qwen2.5-VL-3B-Instruct-ONNX/`（默认为 `./models/`）。
 
 #### 跨同步的视觉模式
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-local-rag",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Local RAG MCP Server - Easy-to-setup document search with minimal configuration",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-local-rag",
     "source": "github"
   },
-  "version": "0.18.3",
+  "version": "0.18.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-local-rag",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "transport": {
         "type": "stdio"
       },

--- a/skills/mcp-local-rag/SKILL.md
+++ b/skills/mcp-local-rag/SKILL.md
@@ -111,7 +111,7 @@ ingest_file({ filePath: "/absolute/path/to/document.pdf" })
 
 - text-only — no VLM download or visual-page inference.
 - `fast` — figure titles and broad types; in-image text is less reliable. Downloads ~250 MB **the first time this profile is used**, then inference per visual page.
-- `quality` — reads in-image text (axis labels, panel sub-labels, flowchart nodes) far more reliably. ~2.9 GB on first use, ~2x per-page inference.
+- `quality` — reads in-image text (axis labels, panel sub-labels, flowchart nodes) far more reliably. ~1.7 GB on first use, ~3x per-page inference.
 
 A profile the request names wins. Otherwise reach for `quality` when in-image text fidelity is the point — research figures, technical diagrams with embedded labels, dense dashboards — and `fast` for everything else.
 

--- a/skills/mcp-local-rag/references/cli-reference.md
+++ b/skills/mcp-local-rag/references/cli-reference.md
@@ -50,7 +50,7 @@ VLM failures degrade to text-only ingest. A failed page produces no caption reco
 | Profile | Model | Cache (approx) | Per-page inference (approx) | Suited for |
 |---------|-------|----------------|------------------------------|------------|
 | `fast` (default) | `HuggingFaceTB/SmolVLM-256M-Instruct` | ~250 MB | baseline | Chart titles, figure types, broad layout. Lightweight first-run. |
-| `quality` | `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX` | ~2.9 GB | ~2× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than inference throughput. |
+| `quality` | `onnx-community/Qwen3.5-2B-ONNX` | ~1.7 GB | ~3× `fast` | Figures with in-image text (axis labels, panel sub-labels, annotations) where caption fidelity matters more than inference throughput. |
 
 Numbers are approximate at the time of writing and may shift with model updates or differ by hardware. Switching profiles does not invalidate the other's cache.
 

--- a/src/pdf-visual/__tests__/captioner-quality.test.ts
+++ b/src/pdf-visual/__tests__/captioner-quality.test.ts
@@ -1,21 +1,7 @@
-// `createCaptioner` (`quality` profile dispatch) unit test.
-//
-// Asserts the Qwen2.5-VL-3B-Instruct-ONNX surface contract owned by
-// `src/pdf-visual/captioners/quality.ts`:
-//
-//   - Model loaded via the explicit `Qwen2_5_VLForConditionalGeneration`
-//     class (not the architecture-agnostic `AutoModelForImageTextToText`).
-//   - Processor invoked with a SINGLE image argument (not the array form
-//     used by the IDEFICS3-based `fast` profile).
-//   - Image is resized to 448x448 client-side before being handed to the
-//     processor.
-//   - `model.generate` is called with `max_new_tokens` ONLY — the
-//     `repetition_penalty` / `no_repeat_ngram_size` options used by `fast`
-//     MUST NOT be present (they produce forced variant generation on Qwen).
-//   - `inputs.input_ids.dims.at(-1)` is the value used to slice prompt
-//     tokens from the generated output.
-//   - Load failure surfaces the resolved Qwen model identifier in the
-//     wrapper message.
+// `createCaptioner` (`quality` profile dispatch) unit test. Pins the
+// Qwen3.5-2B surface contract owned by `src/pdf-visual/captioners/quality.ts`:
+// model id and class, single-image processor call, long-edge input cap,
+// generation options, prompt-token slicing, and load-failure wrapping.
 //
 // Cross-file mock isolation
 // -------------------------
@@ -40,12 +26,16 @@ import {
 
 const mocks = vi.hoisted(() => {
   const state: {
+    decodedWidth: number
+    decodedHeight: number
     decodedText: string
     fromPretrainedThrows: Error | null
     generateThrows: Error | null
     fromBlobThrows: Error | null
     resizeThrows: Error | null
   } = {
+    decodedWidth: 2000,
+    decodedHeight: 1000,
     decodedText: 'a valid quality caption',
     fromPretrainedThrows: null,
     generateThrows: null,
@@ -67,10 +57,7 @@ const mocks = vi.hoisted(() => {
     return mockModelInstance
   })
 
-  // The Qwen2.5-VL processor takes the image directly (not as an array). The
-  // input_ids tensor's last dimension is the input length read via
-  // `dims.at(-1)`. We model the dim list with a leading batch dim so the
-  // selector hits the intended index.
+  // A leading batch dim so `dims.at(-1)` hits the intended index.
   const mockProcessorInstance = Object.assign(
     vi.fn(async (_chatPrompt: string, _image: unknown) => ({
       input_ids: { dims: [1, 7] },
@@ -95,20 +82,18 @@ const mocks = vi.hoisted(() => {
   const mockDispose = vi.fn(async () => {})
   const mockModelInstance = { dispose: mockDispose, generate: mockGenerate }
 
-  // RawImage.fromBlob resolves to an object with a `.resize()` method; the
-  // production code chains `.resize(448, 448)` and we assert on the args.
-  const mockResize = vi.fn((_w: number, _h: number) => {
+  const mockResize = vi.fn((w: number, h: number) => {
     if (state.resizeThrows) {
       throw state.resizeThrows
     }
-    return { width: 448, height: 448, channels: 3, data: new Uint8ClampedArray(0) }
+    return { width: w, height: h, channels: 3, data: new Uint8ClampedArray(0) }
   })
 
   const mockFromBlob = vi.fn(async (_blob: Blob) => {
     if (state.fromBlobThrows) {
       throw state.fromBlobThrows
     }
-    return { resize: mockResize }
+    return { width: state.decodedWidth, height: state.decodedHeight, resize: mockResize }
   })
 
   const env: { cacheDir: string } = { cacheDir: '' }
@@ -123,7 +108,7 @@ const mocks = vi.hoisted(() => {
     // module resolution do not crash — the `quality`-profile tests in this
     // file never construct a fast captioner.
     AutoModelForImageTextToText: { from_pretrained: vi.fn() },
-    Qwen2_5_VLForConditionalGeneration: { from_pretrained: mockModelFromPretrained },
+    Qwen3_5ForConditionalGeneration: { from_pretrained: mockModelFromPretrained },
     RawImage: { fromBlob: mockFromBlob },
     mockGenerate,
     mockProcessorFromPretrained,
@@ -137,7 +122,7 @@ const mocks = vi.hoisted(() => {
 const transformersFactory = () => ({
   AutoProcessor: mocks.AutoProcessor,
   AutoModelForImageTextToText: mocks.AutoModelForImageTextToText,
-  Qwen2_5_VLForConditionalGeneration: mocks.Qwen2_5_VLForConditionalGeneration,
+  Qwen3_5ForConditionalGeneration: mocks.Qwen3_5ForConditionalGeneration,
   RawImage: mocks.RawImage,
   env: mocks.env,
 })
@@ -152,14 +137,14 @@ let createCaptioner: typeof import('../captioner.js').createCaptioner
 let VlmError: typeof import('../types.js').VlmError
 
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
-const QUALITY_MODEL_ID = 'onnx-community/Qwen2.5-VL-3B-Instruct-ONNX'
+const QUALITY_MODEL_ID = 'onnx-community/Qwen3.5-2B-ONNX'
 
 const BASE_CONFIG = {
   profile: 'quality' as const,
   cacheDir: '/tmp/cache-quality',
 }
 
-describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-ONNX)', () => {
+describe('createCaptioner — quality profile dispatch (Qwen3.5-2B-ONNX)', () => {
   beforeAll(async () => {
     vi.resetModules()
     vi.doMock('@huggingface/transformers', transformersFactory)
@@ -177,6 +162,8 @@ describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-O
   beforeEach(() => {
     mocks.mockDispose.mockClear()
     mocks.state.decodedText = 'a valid quality caption'
+    mocks.state.decodedWidth = 2000
+    mocks.state.decodedHeight = 1000
     mocks.state.fromPretrainedThrows = null
     mocks.state.generateThrows = null
     mocks.state.fromBlobThrows = null
@@ -232,7 +219,7 @@ describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-O
     expect(mocks.mockModelFromPretrained.mock.calls[0]?.[0]).toBe(QUALITY_MODEL_ID)
   })
 
-  it('loads via Qwen2_5_VLForConditionalGeneration (not the auto entry point)', async () => {
+  it('loads via Qwen3_5ForConditionalGeneration (not the auto entry point)', async () => {
     const captioner = createCaptioner(BASE_CONFIG)
     await captioner.caption(PNG_BYTES, 1)
 
@@ -243,22 +230,28 @@ describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-O
     expect(mocks.mockModelFromPretrained).toHaveBeenCalledTimes(1)
   })
 
-  it('resizes the decoded image to 448x448 before invoking the processor', async () => {
+  it('caps the decoded image long edge at 1024', async () => {
     const captioner = createCaptioner(BASE_CONFIG)
     await captioner.caption(PNG_BYTES, 1)
 
     expect(mocks.mockFromBlob).toHaveBeenCalledTimes(1)
     expect(mocks.mockResize).toHaveBeenCalledTimes(1)
-    expect(mocks.mockResize.mock.calls[0]).toEqual([448, 448])
+    expect(mocks.mockResize.mock.calls[0]).toEqual([1024, 512])
   })
 
-  it('invokes the processor with a SINGLE image (Qwen) — not an array (IDEFICS3)', async () => {
+  it('leaves an image already within the cap unresized', async () => {
+    mocks.state.decodedWidth = 800
+    mocks.state.decodedHeight = 600
     const captioner = createCaptioner(BASE_CONFIG)
     await captioner.caption(PNG_BYTES, 1)
 
-    // The processor instance itself is the callable that consumes
-    // (prompt, image). It must have been invoked once with the image as the
-    // second argument — and that second argument MUST NOT be an array.
+    expect(mocks.mockResize).not.toHaveBeenCalled()
+  })
+
+  it('invokes the processor with a SINGLE image — not an array (IDEFICS3)', async () => {
+    const captioner = createCaptioner(BASE_CONFIG)
+    await captioner.caption(PNG_BYTES, 1)
+
     expect(mocks.mockProcessorInstance).toHaveBeenCalledTimes(1)
     const call = expectDefined(mocks.mockProcessorInstance.mock.calls[0])
     const promptArg = call[0]
@@ -267,17 +260,17 @@ describe('createCaptioner — quality profile dispatch (Qwen2.5-VL-3B-Instruct-O
     expect(Array.isArray(imageArg)).toBe(false)
   })
 
-  it('calls model.generate with max_new_tokens only — no repetition_penalty / no_repeat_ngram_size', async () => {
+  it('calls model.generate with the measured decoding options', async () => {
     const captioner = createCaptioner(BASE_CONFIG)
     await captioner.caption(PNG_BYTES, 1)
 
     expect(mocks.mockGenerate).toHaveBeenCalledTimes(1)
     const arg = expectRecord(mocks.mockGenerate.mock.calls[0]?.[0])
-    expect(arg['max_new_tokens']).toBe(128)
-    // These two options exist on `fast` but are explicitly absent on `quality`
-    // because they cause forced variant generation on Qwen2.5-VL.
-    expect(arg['repetition_penalty']).toBeUndefined()
-    expect(arg['no_repeat_ngram_size']).toBeUndefined()
+    expect(arg['max_new_tokens']).toBe(160)
+    expect(arg['no_repeat_ngram_size']).toBe(6)
+    expect(arg['repetition_penalty']).toBe(1.05)
+    // The model's own generation_config would sample.
+    expect(arg['do_sample']).toBe(false)
   })
 
   it('returns the decoded caption verbatim when post-processing leaves it unchanged', async () => {

--- a/src/pdf-visual/__tests__/captioners-shared.test.ts
+++ b/src/pdf-visual/__tests__/captioners-shared.test.ts
@@ -1,8 +1,10 @@
-// Both captioner profiles route decoded output through `postProcess`, so its
-// rules are pinned here once instead of through each profile's mock stack.
+// Profile-agnostic helpers, pinned once instead of through each profile's
+// mock stack.
 
+import { RawImage } from '@huggingface/transformers'
 import { describe, expect, it } from 'vitest'
-import { postProcess } from '../captioners/shared.js'
+
+import { capLongEdge, postProcess } from '../captioners/shared.js'
 
 // Built from code points rather than written as escapes: a literal control
 // character in a fixture is invisible in review, which is how an earlier version
@@ -76,5 +78,31 @@ describe('postProcess — length cap', () => {
     const text = `${'c'.repeat(1000)}${chars(0x00).repeat(500)}`
 
     expect(postProcess(text)).toBe('c'.repeat(1000))
+  })
+})
+
+describe('capLongEdge', () => {
+  const image = (width: number, height: number) =>
+    new RawImage(new Uint8ClampedArray(width * height * 3), width, height, 3)
+
+  it('returns the image untouched when it already fits', async () => {
+    const source = image(80, 60)
+    expect(await capLongEdge(source, 1024)).toBe(source)
+  })
+
+  it('scales the long edge down to the cap, keeping the aspect ratio', async () => {
+    const resized = await capLongEdge(image(2000, 1000), 1024)
+    expect([resized.width, resized.height]).toEqual([1024, 512])
+  })
+
+  it('widens a hairline crop to the ratio the processor accepts', async () => {
+    const resized = await capLongEdge(image(4000, 2), 1024)
+    expect([resized.width, resized.height]).toEqual([1024, 6])
+    expect(resized.width / resized.height).toBeLessThan(200)
+  })
+
+  it('widens a hairline crop that needs no downscaling', async () => {
+    const resized = await capLongEdge(image(600, 1), 1024)
+    expect([resized.width, resized.height]).toEqual([600, 3])
   })
 })

--- a/src/pdf-visual/captioners/quality.ts
+++ b/src/pdf-visual/captioners/quality.ts
@@ -1,71 +1,68 @@
-// `quality` visual-quality profile — Qwen2.5-VL-3B-Instruct-ONNX.
+// `quality` visual-quality profile — Qwen3.5-2B.
 //
-// Higher fidelity than `fast` on figures with in-image text (axis labels,
-// panel sub-labels), at ~10x the model cache and ~2x per-page inference on
-// CPU. Shares the load/decode mechanics with `fast` via `shared.ts`, and keeps
-// its own model class, prompt, resize, processor call shape and generation
-// options.
-//
-// Three details are not inferable from the code:
-//   - The image is resized to a fixed 448x448 matching the onnx-community
-//     reference example, though Qwen2.5-VL supports dynamic resolution.
-//   - `repetition_penalty` / `no_repeat_ngram_size`, which `fast` uses, are
-//     deliberately absent: on Qwen2.5-VL they force variant generation
-//     whenever a figure repeats a phrase ("Cycles per cycle" becomes "Cpu
-//     cycles/cycle", then "Cnt cyles/clk").
-//   - The conversation shape is hard-coded against the Qwen2.5-VL family, so a
-//     non-Qwen-VL model needs a new profile.
+// Non-obvious constraints:
+//   - The `-ONNX-OPT` export of this model needs an ORT contrib op
+//     (`com.microsoft:CausalConvWithState`) that onnxruntime-node does not
+//     register, so the plain `-ONNX` repo is the only loadable one here.
+//   - Generation options were picked by measurement over a figure fixture set:
+//     a stronger `repetition_penalty` (1.15, as `fast` uses) makes this family
+//     invent label variants, and `no_repeat_ngram_size: 3` costs recall,
+//     because a figure legitimately repeats short phrases.
+//   - Keywords precede the summary because `postProcess` truncates the tail,
+//     and the tail is where an exhausted run degenerates.
 
-import { AutoProcessor, Qwen2_5_VLForConditionalGeneration } from '@huggingface/transformers'
+import { AutoProcessor, Qwen3_5ForConditionalGeneration } from '@huggingface/transformers'
 
 import type { Captioner } from '../types.js'
 import { VlmError } from '../types.js'
 import {
   asVlmModel,
   asVlmProcessor,
+  capLongEdge,
   createModelLoader,
   decodePngToRawImage,
   postProcess,
 } from './shared.js'
 
-const MODEL_NAME = 'onnx-community/Qwen2.5-VL-3B-Instruct-ONNX'
+const MODEL_NAME = 'onnx-community/Qwen3.5-2B-ONNX'
 
 /**
- * Fixed input resolution (px) for the Qwen2.5-VL reference resize. Matches the
- * onnx-community Qwen2-VL example's stable-behavior fixed resize.
+ * Input long-edge cap (px). The image processor does not downscale on its own,
+ * so this is what bounds per-page CPU time. Measured: 768 loses small in-figure
+ * text, 1280 costs ~20% more time for no recall gain.
  */
-const QWEN_INPUT_SIZE = 448
+const INPUT_LONG_EDGE = 1024
 
-/**
- * Static prompt, tuned for retrieval indexing: scan the whole image before
- * composing, then answer as Summary + Keywords. No length specifier — length
- * is `max_new_tokens`'s job, because a spec in the prompt narrows coverage.
- */
-const PROMPT = `Describe this PDF page image for retrieval search indexing.
+const PROMPT = `This image is a figure region cropped from a PDF page. Write search text for it.
 
-Procedure:
-1. Scan the whole image and identify every distinct region.
-2. Compose the output from across all regions identified.
+Output two lines, in this order:
 
-Output exactly two parts:
+Line 1 starts with "Keywords:" and then lists the phrases, separated by semicolons.
+Line 2 starts with "Summary:" and then holds one sentence.
 
-Summary: Describe the page's content, including its type and subject when identifiable.
+Keywords rules:
+- Copy the text that is legible in the image: titles, axis names, legend entries, row and column names, panel labels, annotations, diagram node and step names, and numbers shown as labels.
+- Use the exact wording from the image.
+- Keep a number with the label it belongs to, printed as shown, including decimal points and units.
+- Every part of the image that carries legible text contributes at least one phrase.
+- List each phrase once.
+- For partly legible text, keep the part you can read.
+- For a table, keep its title, row names and column names; leave the cell-by-cell values out.
+- Once the legible labels are listed, write the Summary line and stop.
 
-Keywords: Phrases separated by semicolons. Capture readable text and visible labels from across the page — including section titles, sub-labels inside figures, tables, panels, or annotations. Use exact wording from the image when readable. Cover the visible regions of the page. List each phrase once.
+Summary rule:
+- One sentence naming the figure type and its subject.
 
-Use only details visible in the image. If a region is unreadable, skip it.`
+Ground every phrase and the summary in what is visible. Where a region carries no legible text, describe it in the summary instead of supplying words for it.`
 
 /**
  * Create a `quality` profile captioner. The dispatcher has already configured
  * `env.cacheDir`; this profile only owns lazy model loading and inference.
  */
 export function createQualityCaptioner(resolvedDevice: string): Captioner {
-  // The explicit `Qwen2_5_VLForConditionalGeneration` class matches the
-  // onnx-community reference example (rather than the architecture-agnostic
-  // AutoModelForImageTextToText entry point used by `fast`).
   const loader = createModelLoader(MODEL_NAME, resolvedDevice, async ({ dtypeOpt, modelOpt }) => {
     const processor = await AutoProcessor.from_pretrained(MODEL_NAME, dtypeOpt)
-    const model = await Qwen2_5_VLForConditionalGeneration.from_pretrained(MODEL_NAME, modelOpt)
+    const model = await Qwen3_5ForConditionalGeneration.from_pretrained(MODEL_NAME, modelOpt)
     return { processor, model }
   })
 
@@ -75,26 +72,15 @@ export function createQualityCaptioner(resolvedDevice: string): Captioner {
       try {
         const { processor, model } = await loader.ensureLoaded()
 
-        // Decode PNG → RawImage, then resize to 448x448 to match the
-        // onnx-community Qwen2-VL reference example. Qwen2.5-VL supports dynamic
-        // resolution natively, but the reference example uses a fixed resize for
-        // stable behavior; revisit if small in-figure text is lost.
-        const rawImage = await (await decodePngToRawImage(pngBytes)).resize(
-          QWEN_INPUT_SIZE,
-          QWEN_INPUT_SIZE
-        )
+        const rawImage = await capLongEdge(await decodePngToRawImage(pngBytes), INPUT_LONG_EDGE)
 
-        // Build chat-style input. The Qwen2.5-VL conversation shape mirrors
-        // the onnx-community Qwen2-VL reference: a single user turn with an
-        // image placeholder followed by the text prompt.
         const messages = [
           {
             role: 'user',
             content: [{ type: 'image' }, { type: 'text', text: PROMPT }],
           },
         ]
-        // Qwen2.5-VL takes a single image (not an array), per the
-        // onnx-community reference `processor(text, image)`.
+        // Qwen3.5 takes a single image, not an array.
         const proc = asVlmProcessor(processor)
         const mdl = asVlmModel(model)
 
@@ -103,12 +89,14 @@ export function createQualityCaptioner(resolvedDevice: string): Captioner {
 
         const outputs = await mdl.generate({
           ...inputs,
-          max_new_tokens: 128,
+          max_new_tokens: 160,
+          no_repeat_ngram_size: 6,
+          repetition_penalty: 1.05,
+          // The model ships `do_sample: true`, which would make captions for
+          // the same page differ between ingests.
+          do_sample: false,
         })
 
-        // `outputs.slice(null, [inputLen, null])` strips the prompt tokens.
-        // `dims.at(-1)` reads the last dimension defensively — matches the
-        // onnx-community reference example.
         const inputLen = inputs.input_ids.dims.at(-1)
         if (typeof inputLen !== 'number') {
           throw new VlmError('Captioner returned an input tensor without a token dimension', {

--- a/src/pdf-visual/captioners/shared.ts
+++ b/src/pdf-visual/captioners/shared.ts
@@ -137,6 +137,29 @@ export async function decodePngToRawImage(pngBytes: Uint8Array): Promise<RawImag
   return RawImage.fromBlob(blob)
 }
 
+/** Aspect ratio the Qwen image processors reject above. */
+const MAX_ASPECT_RATIO = 200
+
+/**
+ * Downscale so the long edge is at most `longEdge`, preserving the aspect
+ * ratio, and widen a hairline crop until the processor accepts it. Alignment to
+ * the model's patch grid is left to the image processor. Returns the image
+ * untouched when it already satisfies both.
+ */
+export async function capLongEdge(image: RawImage, longEdge: number): Promise<RawImage> {
+  const scale = Math.min(1, longEdge / Math.max(image.width, image.height))
+  const scaled = (size: number): number => Math.max(1, Math.floor(size * scale))
+  // Stretching the thin side rather than padding it: at this ratio the crop
+  // holds no legible text either way, and a caption beats a thrown page.
+  const shortest = Math.ceil(Math.max(scaled(image.width), scaled(image.height)) / MAX_ASPECT_RATIO)
+  const width = Math.max(scaled(image.width), shortest)
+  const height = Math.max(scaled(image.height), shortest)
+  if (width === image.width && height === image.height) {
+    return image
+  }
+  return image.resize(width, height)
+}
+
 /** Maximum caption length in characters; longer captions are truncated with an ellipsis. */
 const MAX_CAPTION_LENGTH = 1000
 


### PR DESCRIPTION
## Why

The `quality` profile ran `onnx-community/Qwen2.5-VL-3B-Instruct-ONNX`, which ships under the Qwen
RESEARCH license (non-commercial). Its ONNX export also only accepts a 448x448 input in this build,
and at that resolution it read in-image text poorly.

`onnx-community/Qwen3.5-2B-ONNX` is Apache-2.0, half the cache size, and reads figure labels far
more reliably.

## What changed

- `quality` loads Qwen3.5-2B via `Qwen3_5ForConditionalGeneration`.
- Input is capped to a 1024px long edge with the aspect ratio preserved, instead of a fixed 448x448
  square. `capLongEdge` also widens a hairline crop, because the image processor rejects an aspect
  ratio above 200.
- Prompt asks for keywords first (post-processing truncates the tail), pairs numbers with their
  label, keeps table row/column names over cell values, and ends with a one-sentence summary.
- Decoding: `max_new_tokens: 160`, `no_repeat_ngram_size: 6`, `repetition_penalty: 1.05`,
  `do_sample: false`. The model ships `do_sample: true`, which made captions for the same page
  differ between ingests.
- `fast` is unchanged.
- Docs: profile tables in all six READMEs, the skill, and the CLI reference; a short migration
  section in the READMEs.

## Measurements

Six figure crops (five English, one Chinese) captioned through the production captioner on CPU with
q4 weights. Label recall is the share of the figure's real in-image strings present in the caption
after post-processing.

| | before (Qwen2.5-VL-3B) | after (Qwen3.5-2B) |
|---|---|---|
| label recall | 0.13 | 0.81 |
| summary completed | – | 4/6 |
| model cache | 2.9 GB | 1.7 GB |
| per region | 29.5s | 37.9s |
| license | Qwen RESEARCH | Apache-2.0 |

Each knob was measured one at a time; the alternatives that lost are recorded in the commit trail of
this branch's work: a 768px cap drops recall to 0.45, a 1280px cap costs ~20% more time for no gain,
`no_repeat_ngram_size: 0` drops recall to 0.74 and doubles fabricated numbers, and 128 output tokens
drops summary completion to 2/6.

On five held-out figures never used for tuning, label recall was 0.66 on the two with ground truth.

Known limits: a dense eight-panel figure still scores 0.39 because its axis labels are a few pixels
tall at this cap, and label/value adjacency stays low (0.04) even with a prompt rule for it.

## Test plan

- `pnpm run check:all` — 87 files, 1497 tests, lint, format, unused exports, circular deps, build,
  test type-check.
- Unit tests pin the new model id and class, the single-image processor call, the long-edge cap, the
  hairline-crop widening, and the decoding options.
- The gated `visual-ingest-e2e` suite still exercises `fast` only, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)