### PR TITLE
chore(deps): bump transitive hono to 4.13.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,8 +1773,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -2873,9 +2873,9 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@hono/node-server@2.1.0(hono@4.13.1)':
+  '@hono/node-server@2.1.0(hono@4.13.7)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@huggingface/jinja@0.3.4':
     optional: true
@@ -3122,7 +3122,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -3132,7 +3132,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@7.2.0)
       express-rate-limit: 8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4032,7 +4032,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.13.1: {}
+  hono@4.13.7: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Refreshes the lockfile entry for `hono` from 4.13.1 to 4.13.7, resolving three open Dependabot alerts. `hono` is a transitive dependency pulled in through `@modelcontextprotocol/sdk`, which declares `hono: ^4.11.4` — the patched 4.13.5+ is already inside that range, so this needed no manifest change and no `pnpm.overrides`.

Alerts resolved:

| # | Severity | Issue |
|---|----------|-------|
| 123 | medium | Unbounded dot-notation nesting in `parseBody()` can cause memory exhaustion |
| 122 | medium | `toSSG()` still writes files outside the output directory (incomplete fix for CVE-2026-39408) |
| 121 | medium | Query parser reads parameters after the URL fragment, causing cache-key and proxy interpretation differentials |

## Changes

`pnpm-lock.yaml` only (7 insertions, 7 deletions) — the `hono` resolution and the `@hono/node-server` / `@modelcontextprotocol/sdk` peer references that point at it.

## Verification

`pnpm run check:all` passes: biome check/lint/format, knip, circular-dependency check, build, test type-check, and the full suite (87 files, 1497 tests).

## Not addressed here

Four alerts remain open and are not fixable without an override or an upstream release:

- **sharp #124 / #105 (high)** — the patched 0.35.4 falls outside both `@huggingface/transformers@4.2.0` (`^0.34.5`) and `@lancedb/lancedb` → `@huggingface/transformers@3.0.2` (`^0.33.5`). Deliberately not forcing it via `pnpm.overrides`; waiting on upstream.
- **adm-zip #103 / #120 (high / medium)** — reached via `onnxruntime-node@1.24.3` (`^0.5.16`). #103 is fixed in 0.6.0, which is outside that range, and #120 has no patched version at all (0.6.0 included). Waiting on `onnxruntime-node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)